### PR TITLE
Bug fix for Safari: new tab cannot be opened

### DIFF
--- a/packages/core/base/src/services/crossmintModalService.ts
+++ b/packages/core/base/src/services/crossmintModalService.ts
@@ -193,6 +193,7 @@ export function crossmintModalService({
         setConnecting(false);
         const newTab = window.open(url, "_blank");
         if (!newTab) {
+            window.location.assign(url);
             console.error("Failed to open popup window and new tab");
         }
     };


### PR DESCRIPTION
Open link in current tab if new tab failed