### PR TITLE
NCW: Fix bug identifying a testnet chain

### DIFF
--- a/packages/client/wallets/aa/src/CrossmintAASDK.ts
+++ b/packages/client/wallets/aa/src/CrossmintAASDK.ts
@@ -1,5 +1,5 @@
 import { CrossmintService } from "@/api";
-import { Blockchain, EVMAAWallet, EVMBlockchain } from "@/blockchain";
+import { Blockchain, EVMAAWallet, EVMBlockchain, EVMBlockchainWithTestnet } from "@/blockchain";
 import type { CrossmintAASDKInitParams, UserIdentifier, WalletConfig } from "@/types";
 import { CURRENT_VERSION, WalletSdkError, ZERO_DEV_TYPE, ZERO_PROJECT_ID, createOwnerSigner } from "@/utils";
 import { ZeroDevEthersProvider } from "@zerodev/sdk";
@@ -15,12 +15,13 @@ export class CrossmintAASDK {
         return new CrossmintAASDK(params);
     }
 
-    async getOrCreateWallet<B extends Blockchain = Blockchain>(
+    async getOrCreateWallet<B extends EVMBlockchainWithTestnet = EVMBlockchainWithTestnet>(
         user: UserIdentifier,
         chain: B,
         walletConfig: WalletConfig
     ) {
         try {
+            this.crossmintService.setCrossmintUrl(chain);
             const owner = await createOwnerSigner(user, chain, walletConfig, this.crossmintService);
 
             const address = await owner.getAddress();
@@ -35,8 +36,7 @@ export class CrossmintAASDK {
                 },
             });
 
-            this.crossmintService.setCrossmintUrl(chain);
-            const evmAAWallet = new EVMAAWallet(zDevProvider, this.crossmintService, chain as EVMBlockchain);
+            const evmAAWallet = new EVMAAWallet(zDevProvider, this.crossmintService, chain);
 
             const abstractAddress = await evmAAWallet.getAddress();
             const { sessionKeySignerAddress } = await this.crossmintService.createSessionKey(abstractAddress);

--- a/packages/client/wallets/aa/src/blockchain/BlockchainNetworks.ts
+++ b/packages/client/wallets/aa/src/blockchain/BlockchainNetworks.ts
@@ -25,6 +25,13 @@ export const BlockchainTestNet = {
 } as const; //testnet as a placeholder for non-EVM chains
 export type BlockchainTestNet = (typeof BlockchainTestNet)[keyof typeof BlockchainTestNet];
 
+export const EVMBlockchainWithTestnet = {
+    ...EVMBlockchain,
+    ...BlockchainTestNet,
+} as const;
+
+export type EVMBlockchainWithTestnet = (typeof EVMBlockchainWithTestnet)[keyof typeof EVMBlockchainWithTestnet];
+
 export const Blockchain = {
     ...EVMBlockchain,
     ...NonEVMBlockchain,
@@ -171,7 +178,10 @@ export function getTickerNameByBlockchain(chain: Blockchain) {
 }
 
 export function getApiUrlByBlockchainType(chain: Blockchain): string {
-    return isTestnet(chain) ? CROSSMINT_STG_URL : CROSSMINT_PROD_URL;
+    console.log("getApiUrlByBlockchainType", chain);
+    const result = isTestnet(chain) ? CROSSMINT_STG_URL : CROSSMINT_PROD_URL;
+    console.log("getApiUrlByBlockchainType RESULT", result);
+    return result;
 }
 
 export function getWeb3AuthBlockchain(chain: Blockchain): TORUS_LEGACY_NETWORK_TYPE {
@@ -183,7 +193,7 @@ export function isTestnet(chain: Blockchain): boolean {
         Object.keys(BlockchainTestNet) as Array<keyof typeof BlockchainTestNet>
     );
 
-    if (testnetKeys.has(chain as keyof typeof BlockchainTestNet)) {
+    if (testnetKeys.has(chain.toUpperCase() as keyof typeof BlockchainTestNet)) {
         return true;
     } else {
         return false;

--- a/packages/client/wallets/aa/src/blockchain/BlockchainNetworks.ts
+++ b/packages/client/wallets/aa/src/blockchain/BlockchainNetworks.ts
@@ -178,9 +178,7 @@ export function getTickerNameByBlockchain(chain: Blockchain) {
 }
 
 export function getApiUrlByBlockchainType(chain: Blockchain): string {
-    console.log("getApiUrlByBlockchainType", chain);
     const result = isTestnet(chain) ? CROSSMINT_STG_URL : CROSSMINT_PROD_URL;
-    console.log("getApiUrlByBlockchainType RESULT", result);
     return result;
 }
 

--- a/packages/client/wallets/aa/src/blockchain/wallets/EVMAAWallet.ts
+++ b/packages/client/wallets/aa/src/blockchain/wallets/EVMAAWallet.ts
@@ -14,12 +14,12 @@ import { getFunctionSelector } from "viem";
 import { CrossmintService } from "../../api/CrossmintService";
 import { GenerateSignatureDataInput } from "../../types/API";
 import { ZERO_PROJECT_ID } from "../../utils/constants";
-import { EVMBlockchain, getBlockchainByChainId, getUrlProviderByBlockchain } from "../BlockchainNetworks";
+import { EVMBlockchainWithTestnet, getBlockchainByChainId, getUrlProviderByBlockchain } from "../BlockchainNetworks";
 import { Custodian } from "../plugins";
 import { TokenType } from "../token/Tokens";
 import BaseWallet from "./BaseWallet";
 
-export class EVMAAWallet<B extends EVMBlockchain = EVMBlockchain> extends BaseWallet {
+export class EVMAAWallet<B extends EVMBlockchainWithTestnet = EVMBlockchainWithTestnet> extends BaseWallet {
     private sessionKeySignerAddress?: string;
     chain: B;
 


### PR DESCRIPTION
## Description

There was a bug in the `isTesting` function to identify the correct environment.

Also, there was a bug defining the crossmintUrl, because when using the constructor we hard-coded the stg one, and later in the flow we were checking the network and setting it again. 

The right behavior should be to set it in the very first one executed by the `getOrCreate`. 

## Test plan

Tested it locally using Wallet connect ( Loom in [this PR](https://github.com/Paella-Labs/crossbit-main/pull/10409) )

<!--
  Example:
   * Unit tests which cover functionality X, Y, Z
   * V was tested via UI tests
   * W was tested manually
-->
