### PR TITLE
Prod keys: no more sandbox

### DIFF
--- a/packages/client/wallets/aa/src/blockchain/wallets/FireblocksNCWallet.ts
+++ b/packages/client/wallets/aa/src/blockchain/wallets/FireblocksNCWallet.ts
@@ -74,6 +74,7 @@ export const FireblocksNCWallet = async (
     });
 
     const fireblocksNCW = await FireblocksNCW.initialize({
+        env: "production",
         deviceId: _deviceId,
         messagesHandler,
         eventsHandler,


### PR DESCRIPTION
## Description

We no longer use sandbox anywhere. It's always a "production" env, even if it's one of our demo workspaces that only allows testnet

## Test plan

Test locally hooked up SCW demo to this version of SDK 