### PR TITLE
WAL-1398: Store user data on localstorage, not only on database

### DIFF
--- a/packages/client/wallets/aa/src/storage/LocalStorageRepository.ts
+++ b/packages/client/wallets/aa/src/storage/LocalStorageRepository.ts
@@ -1,0 +1,28 @@
+export class LocalStorageRepository {
+    private NCW_DEVICE_ID_KEY = "NCW-deviceId";
+    private NCW_WALLET_ID_KEY = "NCW-walletId";
+    private NCW_ADDRESS_KEY = "NCW-address";
+
+    get ncwData() {
+        const deviceId = localStorage.getItem(this.NCW_DEVICE_ID_KEY);
+        const walletId = localStorage.getItem(this.NCW_WALLET_ID_KEY);
+        return deviceId && walletId ? { walletId, deviceId } : null;
+    }
+
+    set ncwData(data: { walletId: string; deviceId: string } | null) {
+        if (!data) {
+            return;
+        }
+        const { walletId, deviceId } = data;
+        localStorage.setItem(this.NCW_DEVICE_ID_KEY, deviceId);
+        localStorage.setItem(this.NCW_WALLET_ID_KEY, walletId);
+    }
+
+    get ncwAddress() {
+        return localStorage.getItem(this.NCW_ADDRESS_KEY);
+    }
+
+    set ncwAddress(address: string | null) {
+        address ? localStorage.setItem(this.NCW_ADDRESS_KEY, address) : localStorage.removeItem(this.NCW_ADDRESS_KEY);
+    }
+}

--- a/packages/client/wallets/aa/src/storage/index.ts
+++ b/packages/client/wallets/aa/src/storage/index.ts
@@ -1,1 +1,2 @@
 export * from "./PasswordEncryptedLocalStorage";
+export * from "./LocalStorageRepository";


### PR DESCRIPTION
## Description

WalletId, DeviceId and Address of the NCW are now stored on the DB. 
In the parts of the code where this data is needed we first check if this already exists in the localstorage to skip a call to Crossmint

The Keys starts with 'NCW-'. The user can delete them using the purge data functionality on log out.

## Test plan

Use the SDK using a Fireblocks Signer and create or retrieve the SCW. Info should have been stored on the localstorage of the browser.