### PR TITLE
NCW: remove Fireblocks internal logs

### DIFF
--- a/packages/client/wallets/aa/src/CrossmintAASDK.ts
+++ b/packages/client/wallets/aa/src/CrossmintAASDK.ts
@@ -58,9 +58,9 @@ export class CrossmintAASDK {
             });
 
             return evmAAWallet;
-        } catch (e) {
+        } catch (error: any) {
             throw new WalletSdkError(
-                `Error creating the Wallet [${e instanceof Error ? `${e.name}. ${e.message}` : e}]`
+                `Error creating the Wallet [${error?.name ?? ""}]`
             );
         }
     }

--- a/packages/client/wallets/aa/src/api/CrossmintService.ts
+++ b/packages/client/wallets/aa/src/api/CrossmintService.ts
@@ -168,8 +168,8 @@ export class CrossmintService {
                 throw new CrossmintServiceError(await response.text());
             }
             return await response.json();
-        } catch (error: any) {
-            throw new CrossmintServiceError(`Error fetching Crossmint API`);
+        } catch (error) {
+            throw new CrossmintServiceError(`Error fetching Crossmint API: ${error}`);
         }
     }
 }

--- a/packages/client/wallets/aa/src/api/CrossmintService.ts
+++ b/packages/client/wallets/aa/src/api/CrossmintService.ts
@@ -168,8 +168,8 @@ export class CrossmintService {
                 throw new CrossmintServiceError(await response.text());
             }
             return await response.json();
-        } catch (error) {
-            throw new CrossmintServiceError(`Error fetching Crossmint API: ${error}`);
+        } catch (error: any) {
+            throw new CrossmintServiceError(`Error fetching Crossmint API`);
         }
     }
 }

--- a/packages/client/wallets/aa/src/blockchain/wallets/BaseWallet.ts
+++ b/packages/client/wallets/aa/src/blockchain/wallets/BaseWallet.ts
@@ -70,8 +70,7 @@ class BaseWallet extends ZeroDevAccountSigner<"ECDSA"> {
             console.log("Transaction receipt:", receipt);
 
             return transaction!.hash;
-        } catch (error) {
-            console.error("Error transferring token:", error);
+        } catch (error: any) {
             throw new TransferError(`Error transferring token ${evmToken.tokenId}`);
         }
     }

--- a/packages/client/wallets/aa/src/blockchain/wallets/FireblocksNCWallet.ts
+++ b/packages/client/wallets/aa/src/blockchain/wallets/FireblocksNCWallet.ts
@@ -79,7 +79,6 @@ export const FireblocksNCWallet = async (
         messagesHandler,
         eventsHandler,
         secureStorageProvider,
-        logger: new ConsoleLogger(),
     });
 
     if (isNew) {

--- a/packages/client/wallets/aa/src/blockchain/wallets/FireblocksNCWallet.ts
+++ b/packages/client/wallets/aa/src/blockchain/wallets/FireblocksNCWallet.ts
@@ -86,15 +86,15 @@ export const FireblocksNCWallet = async (
         try {
             await fireblocksNCW.generateMPCKeys(getDefaultAlgorithems());
             await fireblocksNCW.backupKeys(passphrase);
-        } catch (e) {
+        } catch (error: any) {
             await crossmintService.unassignWallet(userEmail);
-            throw new KeysGenerationError(`Error generating keys. ${e instanceof Error ? e.message : e}`);
+            throw new KeysGenerationError(`Error generating keys. ${error?.title ?? ""}}`);
         }
     } else {
         try {
             await fireblocksNCW.recoverKeys(passphrase);
-        } catch (e) {
-            throw new KeysGenerationError(`Error recovering keys. ${e instanceof Error ? e.message : e}`);
+        } catch (error: any) {
+            throw new KeysGenerationError(`Error recovering keys. ${error?.title ?? ""}`);
         }
     }
 
@@ -136,8 +136,8 @@ const signMessage = async (
         const result: ITransactionSignature = await fireblocksNCW.signTransaction(tx);
         console.log(`txId: ${result.txId}`, `status: ${result.transactionSignatureStatus}`);
         handleSignTransactionStatus(result);
-    } catch (e) {
-        throw new SignTransactionError(`Error signing transaction. ${e instanceof Error ? e.message : e}`);
+    } catch (error: any) {
+        throw new SignTransactionError(`Error signing transaction. ${error?.title ?? ""}`);
     }
     return (await crossmintService.getSignature(tx)) as `0x${string}`;
 };
@@ -154,8 +154,8 @@ const signTypedData = async (
         const result: ITransactionSignature = await fireblocksNCW.signTransaction(tx);
         console.log(`txId: ${result.txId}`, `status: ${result.transactionSignatureStatus}`);
         handleSignTransactionStatus(result);
-    } catch (e) {
-        throw new SignTransactionError(`Error signing transaction. ${e instanceof Error ? e.message : e}`);
+    } catch (error: any) {
+        throw new SignTransactionError(`Error signing transaction. ${error?.title ?? ""}`);
     }
     return (await crossmintService.getSignature(tx)) as `0x${string}`;
 };

--- a/packages/client/wallets/aa/src/utils/auth.ts
+++ b/packages/client/wallets/aa/src/utils/auth.ts
@@ -4,7 +4,7 @@ export const parseToken = (token: any) => {
         const base64 = base64Url.replace("-", "+").replace("_", "/");
         return JSON.parse(window.atob(base64 || ""));
     } catch (err) {
-        console.error(err);
+        console.error('Error while parsing token');
         throw err;
     }
 };


### PR DESCRIPTION
## Description

We were logging internal Fireblocks keys due to the `logger` param in the `FireblocksSDK` initialization. This PR removes that, and some other logs that 

## Test plan

Successful Creation

![Screenshot 2023-12-18 at 11 58 12 AM](https://github.com/Crossmint/crossmint-sdk/assets/132915515/dff506c7-c82f-4873-bcd4-3a1a67f6e134)

Failed Creation

![Screenshot 2023-12-18 at 12 00 28 PM](https://github.com/Crossmint/crossmint-sdk/assets/132915515/d5e83100-0ffc-4fa7-aded-bf56dcaf23c1)

