### PR TITLE
Fixes Using “new tab” display doesn’t open on second attempt

### DIFF
--- a/packages/core/base/src/services/hosted/crossmintModalService.ts
+++ b/packages/core/base/src/services/hosted/crossmintModalService.ts
@@ -198,6 +198,7 @@ export function crossmintModalService({
                 }
                 case "new-tab": {
                     window.open(url, "_blank");
+                    setConnecting(false);
                     return;
                 }
                 case "same-tab":


### PR DESCRIPTION
## Description
When `CrossmintPaymentElement` is configured with `new-tab`  the button keeps the "connecting" state blocking to allow re-clik if the tab is closed


<!-- Human must describe here why are we doing this change, and roughly what it does -->
<!-- Optional screenshot or video -->

## Test plan
Tested locally with this specific config
<!--
  Example:
   * Unit tests which cover functionality X, Y, Z
   * V was tested via UI tests
   * W was tested manually
-->
