### PR TITLE
SCW-82: Add callbacks for wallet creation given latency

### DIFF
--- a/packages/client/wallets/aa/src/CrossmintAASDK.ts
+++ b/packages/client/wallets/aa/src/CrossmintAASDK.ts
@@ -1,8 +1,15 @@
 import { CrossmintService } from "@/api";
-import { Blockchain, EVMAAWallet, getChainIdByBlockchain, getZeroDevProjectIdByBlockchain, isEVMBlockchain } from "@/blockchain";
-import type { CrossmintAASDKInitParams, UserIdentifier, WalletConfig } from "@/types";
+import {
+    Blockchain,
+    EVMAAWallet,
+    getChainIdByBlockchain,
+    getZeroDevProjectIdByBlockchain,
+    isEVMBlockchain,
+} from "@/blockchain";
+import type { CrossmintAASDKInitParams, UserIdentifier, WalletCallback, WalletConfig } from "@/types";
 import { CURRENT_VERSION, WalletSdkError, ZERO_DEV_TYPE, createOwnerSigner, errorToJSON } from "@/utils";
 import { ZeroDevEthersProvider } from "@zerodev/sdk";
+
 import { logError, logInfo } from "./services/logging";
 
 export class CrossmintAASDK {
@@ -19,7 +26,8 @@ export class CrossmintAASDK {
     async getOrCreateWallet<B extends Blockchain = Blockchain>(
         user: UserIdentifier,
         chain: B,
-        walletConfig: WalletConfig
+        walletConfig: WalletConfig,
+        callback?: WalletCallback
     ) {
         try {
             logInfo("[GET_OR_CREATE_WALLET] - INIT", {
@@ -46,6 +54,9 @@ export class CrossmintAASDK {
             }
 
             const evmAAWallet = new EVMAAWallet(zDevProvider, this.crossmintService, chain);
+            if (callback) {
+                callback(evmAAWallet);
+            }
 
             const abstractAddress = await evmAAWallet.getAddress();
             const { sessionKeySignerAddress } = await this.crossmintService.createSessionKey(abstractAddress);
@@ -75,9 +86,7 @@ export class CrossmintAASDK {
                 chain,
             });
 
-            throw new WalletSdkError(
-                `Error creating the Wallet [${error?.name ?? ""}]`
-            );
+            throw new WalletSdkError(`Error creating the Wallet [${error?.name ?? ""}]`);
         }
     }
 

--- a/packages/client/wallets/aa/src/types/Config.ts
+++ b/packages/client/wallets/aa/src/types/Config.ts
@@ -1,4 +1,4 @@
-import { Blockchain } from "@/blockchain";
+import { EVMAAWallet } from "@/blockchain";
 import { ethers } from "ethers";
 
 export type CrossmintAASDKInitParams = {
@@ -40,3 +40,5 @@ type Signer = FireblocksNCWSigner | ethers.Signer | Web3AuthSigner; // V2 add: E
 export interface WalletConfig {
     signer: Signer;
 }
+
+export type WalletCallback = (wallet: EVMAAWallet) => void;


### PR DESCRIPTION
## Description

Testing if adding a callback method to return the wallet just before instantiate it allow us to give the EVMWallet instance earlier to the user.

## Test plan

Times testing in local environment:
Creating new wallet using FBs: 54s total / 48s to get the EVMWallet on callback.
Login again with the same wallet already created: 12s/10s

![Captura de pantalla 2024-01-03 a las 10 50 51](https://github.com/Crossmint/crossmint-sdk/assets/16114328/f51dc818-4819-4bc1-9543-8d8fb5de417e)
![Captura de pantalla 2024-01-03 a las 10 50 18](https://github.com/Crossmint/crossmint-sdk/assets/16114328/8e131d04-3bd8-47b0-b97f-65673cbcff35)
