### PR TITLE
SCW-309: Added getSigner

### DIFF
--- a/packages/client/wallets/aa/src/blockchain/wallets/EVMAAWallet.ts
+++ b/packages/client/wallets/aa/src/blockchain/wallets/EVMAAWallet.ts
@@ -1,3 +1,7 @@
+import { logError, logInfo } from "@/services/logging";
+import { SignerType } from "@/types";
+import { errorToJSON } from "@/utils";
+import { BaseSmartContractAccount } from "@alchemy/aa-core";
 import { verifyMessage } from "@ambire/signature-validator";
 import {
     ERC165SessionKeyProvider,
@@ -22,8 +26,6 @@ import {
 import { Custodian } from "../plugins";
 import { TokenType } from "../token/Tokens";
 import BaseWallet from "./BaseWallet";
-import { logError, logInfo } from "@/services/logging";
-import { errorToJSON } from "@/utils";
 
 export class EVMAAWallet<B extends EVMBlockchain = EVMBlockchain> extends BaseWallet {
     private sessionKeySignerAddress?: string;
@@ -41,6 +43,20 @@ export class EVMAAWallet<B extends EVMBlockchain = EVMBlockchain> extends BaseWa
             message,
             signature,
         });
+    }
+
+    async getSigner(type: SignerType): Promise<ethers.Signer | BaseSmartContractAccount> {
+        switch (type) {
+            case "ethers":
+                return this.provider.getSigner();
+            case "viem":
+                return this.provider.accountProvider.getAccount();
+            default:
+                logError("[GET_SIGNER] - ERROR", {
+                    error: errorToJSON("Invalid signer type"),
+                });
+                throw new Error("Invalid signer type");
+        }
     }
 
     setSessionKeySignerAddress(sessionKeySignerAddress: string) {

--- a/packages/client/wallets/aa/src/types/Config.ts
+++ b/packages/client/wallets/aa/src/types/Config.ts
@@ -1,4 +1,3 @@
-import { Blockchain } from "@/blockchain";
 import { ethers } from "ethers";
 
 export type CrossmintAASDKInitParams = {
@@ -12,6 +11,7 @@ export type UserIdentifier = {
     phoneNumber?: string;
 };
 
+export type SignerType = "ethers" | "viem";
 /**
  * Used in v2
  */


### PR DESCRIPTION
## Description

This Pull Request introduces a significant enhancement to the interaction with the Reservoir SDK's `buyToken` function. The core objective is to enable clients to obtain a `viem` object or a `walletClient` for direct use in the `buyToken` method.
Both methods ensure seamless integration with the `buyToken` action, facilitating token purchases with progress tracking.

Additionally, the PR defines behavior for the `.getSigner("viem")` and `.getSigner("ethers")` methods on an instance of `EVMAAWallet`, returning the respective `viem "account"` object or an `ethers signer` object.

## Test Plan

- Unit tests cover the functionality of the new `getSigner` method for both `viem` and `ethers` types.
- Manual testing is conducted to ensure the integration and flow with the `buyToken` method works as expected.


## IMPORTANT NOTE: 

We need to decide which is the best approach, this functionality is achieved through two primary approaches:
1. Directly returning a `walletClient` to be used in `buyToken` by leveraging `crossmintSDK.getOrCreateWallet(...)`. The `wallet.getSigner("viem")` method fetches the required `walletClient`.

2. Indirectly, by utilizing a `viem` account to create a `walletClient`. This is done by obtaining an account from `wallet.getSigner("viem")` and then creating a `walletClient` with `createWalletClient({ account, transport: ... })`.

And then update the docs according the decision.