### PR TITLE
SCW-326: Fixed yarn build

### DIFF
--- a/packages/client/ui/react-ui/package.json
+++ b/packages/client/ui/react-ui/package.json
@@ -1,7 +1,8 @@
 {
     "author": "Paella Labs Inc",
     "dependencies": {
-        "@crossmint/client-sdk-base": "1.1.3",
+        "@crossmint/client-sdk-base": "1.1.4",
+        "@crossmint/common-sdk-base": "0.0.3",
         "@ethersproject/transactions": "5.7.0",
         "@solana/web3.js": "1.78.5",
         "bs58": "5.0.0",

--- a/packages/client/verifiable-credentials/package.json
+++ b/packages/client/verifiable-credentials/package.json
@@ -6,10 +6,11 @@
         "@krebitdao/eip712-vc": "1.0.3",
         "@lit-protocol/lit-node-client": "3.0.24",
         "date-fns": "2.30.0",
-        "ethers": "5.7.2"
+        "ethers": "5.7.2",
+        "@crossmint/common-sdk-base": "0.0.3"
     },
     "devDependencies": {
-        "@crossmint/client-sdk-base": "1.1.3"
+        "@crossmint/client-sdk-base": "1.1.4"
     },
     "exports": {
         "import": "./dist/index.js",

--- a/packages/client/verifiable-credentials/src/verification/services/nftStatus.ts
+++ b/packages/client/verifiable-credentials/src/verification/services/nftStatus.ts
@@ -1,7 +1,7 @@
 import { Contract } from "ethers";
 import { constants } from "ethers";
 
-import { EVMNFT } from "@crossmint/client-sdk-base";
+import { EVMNFT } from "@crossmint/common-sdk-base";
 
 import { abi_ERC_721 } from "../../ABI/ERC721";
 import { getProvider } from "../../services/provider";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1596,6 +1596,14 @@
   resolved "https://registry.yarnpkg.com/@cosmjs/utils/-/utils-0.30.1.tgz#6d92582341be3c2ec8d82090253cfa4b7f959edb"
   integrity sha512-KvvX58MGMWh7xA+N+deCfunkA/ZNDvFLw4YbOmX3f/XBIkqrVY7qlotfy2aNb1kgp6h4B6Yc8YawJPDTfvWX7g==
 
+"@crossmint/client-sdk-base@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@crossmint/client-sdk-base/-/client-sdk-base-1.1.3.tgz#b65c618cbe4a3188cd341f560a3f6cec2a013e42"
+  integrity sha512-J+VsgW0g2XJ56neT9pEvIAglWvq5ClxWUT2lcx1m7bYeXLFVBy9aBG70tDbqDOyqaTj6Mr0dtH9c1/0aNC/GIA==
+  dependencies:
+    exponential-backoff "3.1.1"
+    uuid "9.0.1"
+
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
@@ -5692,6 +5700,14 @@
   dependencies:
     "@types/node" "*"
 
+"@types/bs58@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@types/bs58/-/bs58-4.0.4.tgz#49fbcb0c7db5f7cea26f0e0f61dc4a41a2445aab"
+  integrity sha512-0IEpMFXXQi2zXaXl9GJ3sRwQo0uEkD+yFOv+FnAU5lkPtcu6h61xb7jc2CFPEZ5BUOaiP13ThuGc9HD4R8lR5g==
+  dependencies:
+    "@types/node" "*"
+    base-x "^3.0.6"
+
 "@types/chai-subset@^1.3.3":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@types/chai-subset/-/chai-subset-1.3.3.tgz#97893814e92abd2c534de422cb377e0e0bdaac94"
@@ -8132,7 +8148,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base-x@^3.0.2:
+base-x@^3.0.2, base-x@^3.0.6:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.9.tgz#6349aaabb58526332de9f60995e548a53fe21320"
   integrity sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==


### PR DESCRIPTION
## Description

This PR addresses a build failure due to an improper import statement. The issue arises from the use of import { EVMNFT } from "@crossmint/client-sdk-base"; which is incorrect. The correct import should come from the @crossmint/common-sdk-base package.

By updating the import statement, we aim to resolve the TypeScript error TS2345 that was preventing the build process from completing successfully. This change is integral to ensuring that the codebase remains stable and that the build processes run without errors.

Also we modified the imports to the latest versions of the client-sdk.

## Test plan

Run `yarn build`
