### PR TITLE
PayWithL2: Added 'network' parameter to pay with ETH

### DIFF
--- a/packages/client/base/src/types/embed/crypto.ts
+++ b/packages/client/base/src/types/embed/crypto.ts
@@ -3,6 +3,7 @@ import type { Transaction as _SolanaTransaction } from "@solana/web3.js";
 
 import { CommonEmbeddedCheckoutProps } from ".";
 import { CryptoPaymentMethod } from "..";
+import { Blockchain } from "@crossmint/common-sdk-base";
 
 type CryptoEmbeddedCheckoutPropsBase<
     PM extends keyof CryptoPaymentMethodSignerMap = keyof CryptoPaymentMethodSignerMap,
@@ -45,6 +46,7 @@ type SolanaTransaction = _SolanaTransaction;
 // Signers
 export type ETHEmbeddedCheckoutSigner = CommonEmbeddedCheckoutSignerProps & {
     signAndSendTransaction: (transaction: EthersTransaction) => Promise<string>;
+    network?: Blockchain;
 };
 
 export type SOLEmbeddedCheckoutSigner = CommonEmbeddedCheckoutSignerProps & {

--- a/packages/client/base/src/utils/embed/updatableParams.ts
+++ b/packages/client/base/src/utils/embed/updatableParams.ts
@@ -19,7 +19,7 @@ export function embeddedCheckoutPropsToUpdatableParamsPayload(
                 const value = props[key];
 
                 if (key === "signer" && value != null) {
-                    return [key, { address: (value as CryptoEmbeddedCheckoutPropsWithSigner["signer"]).address }];
+                    return [key, { address: (value as CryptoEmbeddedCheckoutPropsWithSigner["signer"]).address, network: (value as any).network }];
                 }
 
                 return [key, value];

--- a/packages/client/base/src/utils/embed/updatableParams.ts
+++ b/packages/client/base/src/utils/embed/updatableParams.ts
@@ -19,7 +19,12 @@ export function embeddedCheckoutPropsToUpdatableParamsPayload(
                 const value = props[key];
 
                 if (key === "signer" && value != null) {
-                    return [key, { address: (value as CryptoEmbeddedCheckoutPropsWithSigner["signer"]).address, network: (value as any).network }];
+                    return [key, 
+                        { 
+                            address: (value as CryptoEmbeddedCheckoutPropsWithSigner["signer"]).address, 
+                            ...("network" in value ? { network: value.network } : {}) 
+                        } 
+                    ];
                 }
 
                 return [key, value];

--- a/packages/client/ui/react-ui/src/components/embed/crypto/CryptoEmbeddedCheckoutIFrame.tsx
+++ b/packages/client/ui/react-ui/src/components/embed/crypto/CryptoEmbeddedCheckoutIFrame.tsx
@@ -82,7 +82,15 @@ export default function CryptoEmbeddedCheckoutIFrame(props: CryptoEmbeddedChecko
             type: "params-update",
             payload: embeddedCheckoutPropsToUpdatableParamsPayload(props),
         });
-    }, [props.signer.address, (props.signer as any).network, props.recipient, props.mintConfig, props.locale, props.currency, props.whPassThroughArgs]);
+    }, [
+        props.signer.address, 
+        props.recipient, 
+        props.mintConfig, 
+        props.locale, 
+        props.currency, 
+        props.whPassThroughArgs,
+        ..."network" in props.signer ? [props.signer.network] : [],
+    ]);
 
     return <CrossmintEmbeddedCheckoutIFrame onInternalEvent={onInternalEvent} {...props} />;
 }

--- a/packages/client/ui/react-ui/src/components/embed/crypto/CryptoEmbeddedCheckoutIFrame.tsx
+++ b/packages/client/ui/react-ui/src/components/embed/crypto/CryptoEmbeddedCheckoutIFrame.tsx
@@ -82,7 +82,7 @@ export default function CryptoEmbeddedCheckoutIFrame(props: CryptoEmbeddedChecko
             type: "params-update",
             payload: embeddedCheckoutPropsToUpdatableParamsPayload(props),
         });
-    }, [props.signer.address, props.recipient, props.mintConfig, props.locale, props.currency, props.whPassThroughArgs]);
+    }, [props.signer.address, (props.signer as any).network, props.recipient, props.mintConfig, props.locale, props.currency, props.whPassThroughArgs]);
 
     return <CrossmintEmbeddedCheckoutIFrame onInternalEvent={onInternalEvent} {...props} />;
 }


### PR DESCRIPTION
## Description
Related with -> https://github.com/Paella-Labs/crossbit-main/pull/11326

Added a new parameter to pay with crypto so it can be used to specify the network the dev wants the user to pay with
<!-- Human must describe here why are we doing this change, and roughly what it does -->
<!-- Optional screenshot or video -->

## Test plan
Example usage:
<img width="926" alt="Screenshot 2024-02-07 at 11 18 14" src="https://github.com/Crossmint/crossmint-sdk/assets/95720482/17fcf619-2251-4423-a612-cf8ffe98655d">

Tested e2e with https://github.com/Paella-Labs/crossbit-main/pull/11326
<!--
  Example:
   * Unit tests which cover functionality X, Y, Z
   * V was tested via UI tests
   * W was tested manually
-->
