### PR TITLE
PayWithL2: Renamed parameters

### DIFF
--- a/packages/client/base/src/types/embed/crypto.ts
+++ b/packages/client/base/src/types/embed/crypto.ts
@@ -46,9 +46,9 @@ type SolanaTransaction = _SolanaTransaction;
 // Signers
 export type ETHEmbeddedCheckoutSigner = CommonEmbeddedCheckoutSignerProps & {
     signAndSendTransaction: (transaction: EthersTransaction) => Promise<string>;
-    network?: Blockchain;
-    supportedNetworks?: Blockchain[];
-    switchNetwork?: (network: Blockchain) => Promise<void>;
+    chain?: Blockchain;
+    supportedChains?: Blockchain[];
+    handleSwitchChain?: (network: Blockchain) => Promise<void>;
 };
 
 export type SOLEmbeddedCheckoutSigner = CommonEmbeddedCheckoutSignerProps & {

--- a/packages/client/base/src/types/events/internal/events.ts
+++ b/packages/client/base/src/types/events/internal/events.ts
@@ -1,7 +1,7 @@
 export const IncomingInternalEvents = {
     UI_HEIGHT_CHANGED: "ui:height.changed",
     CRYPTO_PAYMENT_INCOMING_TRANSACTION: "crypto-payment:incoming-transaction",
-    CRYPTO_SWITCH_NETWORK: "crypto-payment:switch-network",
+    CRYPTO_SWITCH_CHAIN: "crypto-payment:switch-chain",
 } as const;
 export type IncomingInternalEvents = (typeof IncomingInternalEvents)[keyof typeof IncomingInternalEvents];
 

--- a/packages/client/base/src/types/events/internal/payloads.ts
+++ b/packages/client/base/src/types/events/internal/payloads.ts
@@ -7,7 +7,7 @@ import { Blockchain } from "@crossmint/common-sdk-base";
 interface IncomingInternalEventMap {
     [CrossmintInternalEvents.UI_HEIGHT_CHANGED]: { height: number };
     [CrossmintInternalEvents.CRYPTO_PAYMENT_INCOMING_TRANSACTION]: { serializedTransaction: string };
-    [CrossmintInternalEvents.CRYPTO_SWITCH_NETWORK]: { network: Blockchain };
+    [CrossmintInternalEvents.CRYPTO_SWITCH_CHAIN]: { chain: Blockchain };
 }
 
 interface OutgoingInternalEventMap {

--- a/packages/client/base/src/utils/embed/updatableParams.ts
+++ b/packages/client/base/src/utils/embed/updatableParams.ts
@@ -22,7 +22,7 @@ export function embeddedCheckoutPropsToUpdatableParamsPayload(
                     return [key, 
                         { 
                             address: (value as CryptoEmbeddedCheckoutPropsWithSigner["signer"]).address, 
-                            ...("network" in value ? { network: value.network } : {}) 
+                            ...("chain" in value ? { chain: value.chain } : {}) 
                         } 
                     ];
                 }

--- a/packages/client/ui/react-ui/src/components/embed/crypto/CryptoEmbeddedCheckoutIFrame.tsx
+++ b/packages/client/ui/react-ui/src/components/embed/crypto/CryptoEmbeddedCheckoutIFrame.tsx
@@ -28,15 +28,15 @@ export default function CryptoEmbeddedCheckoutIFrame(props: CryptoEmbeddedChecko
             handleIncomingTransaction(serializedTransaction);
         }
 
-        if (type === IncomingInternalEvents.CRYPTO_SWITCH_NETWORK) {
-            const { network } = payload;
-            console.log("[Crossmint] Received change of network", network);
+        if (type === IncomingInternalEvents.CRYPTO_SWITCH_CHAIN) {
+            const { chain } = payload;
+            console.log("[Crossmint] Received change of chain", chain);
 
-            const switchNetwork = (signer as ETHEmbeddedCheckoutSigner).switchNetwork;
-            if(switchNetwork == null) {
+            const handleSwitchChain = (signer as ETHEmbeddedCheckoutSigner).handleSwitchChain;
+            if(handleSwitchChain == null) {
                 throw new Error("switchNetwork function should have been defined")
             }
-            switchNetwork(network);
+            handleSwitchChain(chain);
         }
     }
 
@@ -100,7 +100,7 @@ export default function CryptoEmbeddedCheckoutIFrame(props: CryptoEmbeddedChecko
         props.locale, 
         props.currency, 
         props.whPassThroughArgs,
-        ..."network" in props.signer ? [props.signer.network] : [],
+        ..."chain" in props.signer ? [props.signer.chain] : [],
     ]);
 
     return <CrossmintEmbeddedCheckoutIFrame onInternalEvent={onInternalEvent} {...props} />;


### PR DESCRIPTION
## Description
Context: https://crossmint.slack.com/archives/C06CV64AS6M/p1707460963467259?thread_ts=1707339734.618149&cid=C06CV64AS6M
<!-- Human must describe here why are we doing this change, and roughly what it does -->
<!-- Optional screenshot or video -->

## Test plan
Tested e2e all parameters
<!--
  Example:
   * Unit tests which cover functionality X, Y, Z
   * V was tested via UI tests
   * W was tested manually
-->
