### PR TITLE
PayWithL2: Sending whether handleSwitchChain is used

### DIFF
--- a/packages/client/base/src/services/embed/crossmintIFrameService.ts
+++ b/packages/client/base/src/services/embed/crossmintIFrameService.ts
@@ -32,7 +32,7 @@ export function crossmintIFrameService(props: CrossmintEmbeddedCheckoutProps) {
                 continue;
             }
             if (typeof value === "object") {
-                queryParams.append(key, JSON.stringify(value));
+                queryParams.append(key, JSON.stringify(value, (key, val) => (typeof val === 'function') ? 'function' : val));
             } else if (typeof value === "string") {
                 if (value === "undefined") {
                     continue;


### PR DESCRIPTION
## Description
In embedded checkout we need to know whether the function handleSwitchChain is defined or not, and right now this JSON.parse just hides it completely. So the proposed solution is to keep the functions there so we can check for it later on crossmint-main side, as the signer is sent as a JSON string completely
<!-- Human must describe here why are we doing this change, and roughly what it does -->
<!-- Optional screenshot or video -->

## Test plan
Tested e2e that the switch change request is triggered
<!--
  Example:
   * Unit tests which cover functionality X, Y, Z
   * V was tested via UI tests
   * W was tested manually
-->
