### PR TITLE
SCW-344: Fix 'wallet is not defined' error

### DIFF
--- a/packages/client/wallets/aa/src/services/logging/index.ts
+++ b/packages/client/wallets/aa/src/services/logging/index.ts
@@ -4,11 +4,16 @@ import { ConsoleProvider } from "./ConsoleProvider";
 import { DatadogProvider } from "./DatadogProvider";
 
 function getBrowserLogger() {
-    if (isLocalhost()) {
+    try {
+        if (isLocalhost()) {
+            return new ConsoleProvider();
+        }
+        return new DatadogProvider();
+    } catch (e) {
+        //Control 'window not defined' error when using Datadog. 
         return new ConsoleProvider();
     }
-
-    return new DatadogProvider();
+    
 }
 
 const { logInfo, logWarn, logError } = getBrowserLogger();


### PR DESCRIPTION
## Description

Catching an error on the logging service file. 
DatadogProvider uses the variable 'window' and it crashes when using the SDK on a frame from Crossbit (Adding passphrase modal on Crossmint Connect to recover the wallet )
Tried to put a condition like  `if (!window)`  or `if (typeof window == "undefined")` but it was throwing the same error. 

## Test plan

Using the SDK to recover the AA Wallet using Crossmint Connect
