### PR TITLE
SCW-344: Revert "SCW-344: Fix 'wallet is not defined' error"

### DIFF
--- a/packages/client/wallets/aa/src/services/logging/index.ts
+++ b/packages/client/wallets/aa/src/services/logging/index.ts
@@ -4,17 +4,13 @@ import { ConsoleProvider } from "./ConsoleProvider";
 import { DatadogProvider } from "./DatadogProvider";
 
 function getBrowserLogger() {
-    try {
-        if (isLocalhost()) {
-            return new ConsoleProvider();
-        }
-        return new DatadogProvider();
-    } catch (e) {
-        //Control 'window not defined' error when using Datadog. 
+    if (isLocalhost()) {
         return new ConsoleProvider();
     }
-    
+
+    return new DatadogProvider();
 }
+
 
 const { logInfo, logWarn, logError } = getBrowserLogger();
 


### PR DESCRIPTION
## Description

Revert SDK modification. SDK, as a front package, should have the DatadogLogger provider. Solution implemented on Crossbit 

## Test plan

Test WC and CC using SDK current version