### PR TITLE
wc: mock required namespace methods

### DIFF
--- a/packages/client/wallets/walletconnect/src/hooks/useWalletConnectSessions.tsx
+++ b/packages/client/wallets/walletconnect/src/hooks/useWalletConnectSessions.tsx
@@ -1,3 +1,4 @@
+import { mockRequiredNamespaceMethods } from "@/utils/walletconnect/mockRequiredNamespaceMethods";
 import { SessionTypes } from "@walletconnect/types";
 import { buildApprovedNamespaces, getSdkError } from "@walletconnect/utils";
 import { Web3WalletTypes } from "@walletconnect/web3wallet";
@@ -61,9 +62,15 @@ export function WalletConnectSessionsContextProvider({ children }: { children: R
         }
         console.log("[WalletConnectSessionsContextProvider.approveSession()] approving session proposal", proposal);
         try {
+            const supportedNamespaces = await getSupportedNamespaces();
+            const supportedNamespacesWithMockedMethods = mockRequiredNamespaceMethods(
+                proposal.params.requiredNamespaces,
+                supportedNamespaces
+            ); // We mock the supported methods to improve compatibility. If a mocked method is attempted to be called later, we show an "Unsupported method" modal
+
             const approvedNamespaces = buildApprovedNamespaces({
                 proposal: proposal.params,
-                supportedNamespaces: await getSupportedNamespaces(),
+                supportedNamespaces: supportedNamespacesWithMockedMethods,
             });
             console.log(
                 "[WalletConnectSessionsContextProvider.approveSession()] approvedNamespaces",

--- a/packages/client/wallets/walletconnect/src/utils/walletconnect/mockRequiredNamespaceMethods.ts
+++ b/packages/client/wallets/walletconnect/src/utils/walletconnect/mockRequiredNamespaceMethods.ts
@@ -1,0 +1,29 @@
+import { ProposalTypes } from "@walletconnect/types";
+import { BuildApprovedNamespacesParams } from "@walletconnect/utils";
+
+export function mockRequiredNamespaceMethods(
+    requiredNamespaces: ProposalTypes.RequiredNamespaces,
+    supportedNamespaces: BuildApprovedNamespacesParams["supportedNamespaces"]
+) {
+    const mockedNamespaces = { ...supportedNamespaces };
+
+    Object.entries(requiredNamespaces).forEach(([caipKey, requiredNamespace]) => {
+        if (!mockedNamespaces[caipKey]) {
+            return;
+        }
+
+        const unsupportedRequiredMethods = requiredNamespace.methods.filter(
+            (method) => !mockedNamespaces[caipKey].methods?.includes(method)
+        );
+        console.warn(
+            "[mockRequiredNamespaceMethods] Mocking unsupported required methods:",
+            unsupportedRequiredMethods
+        );
+
+        mockedNamespaces[caipKey].methods = Array.from(
+            new Set([...(mockedNamespaces[caipKey].methods || []), ...requiredNamespace.methods])
+        );
+    });
+
+    return mockedNamespaces;
+}

--- a/packages/client/wallets/walletconnect/src/utils/walletconnect/mockRequiredNamespaceMethods.ts
+++ b/packages/client/wallets/walletconnect/src/utils/walletconnect/mockRequiredNamespaceMethods.ts
@@ -17,7 +17,8 @@ export function mockRequiredNamespaceMethods(
         );
         console.warn(
             "[mockRequiredNamespaceMethods] Mocking unsupported required methods:",
-            unsupportedRequiredMethods
+            unsupportedRequiredMethods,
+            "Calling these methods will result in a no-op."
         );
 
         mockedNamespaces[caipKey].methods = Array.from(


### PR DESCRIPTION
## Description

mock the required namespace methods, if the wallet doesnt support them

this improves compatibility, because we can "get in the door" (aka connect, maybe sign a message) with any website - and later if the site tries to use an unsupported method, we will show an "Unsupported method requested" modal

not implemented, modal coming later
![image](https://github.com/Crossmint/crossmint-sdk/assets/93682696/03386db3-7226-48fa-82bb-9a250ee7e6ea)

## Test plan

mocks required methods correctly
![image](https://github.com/Crossmint/crossmint-sdk/assets/93682696/b5c3a673-fc9e-47f1-8d86-8c7db75ed1b8)





