### PR TITLE
fix: lock and sync deps

### DIFF
--- a/packages/client/starters/vue-ui-starter/src/components/PayWithCC.vue
+++ b/packages/client/starters/vue-ui-starter/src/components/PayWithCC.vue
@@ -44,7 +44,6 @@ function onEvent(event: CrossmintEvent) {
         default:
             break;
     }
-    return undefined;
 }
 </script>
 

--- a/packages/client/ui/vanilla-ui/package.json
+++ b/packages/client/ui/vanilla-ui/package.json
@@ -35,7 +35,8 @@
         "url": "https://github.com/Crossmint/crossmint-sdk/issues"
     },
     "dependencies": {
-        "@crossmint/client-sdk-base": "1.1.6",
+        "@crossmint/client-sdk-base": "1.1.7",
+        "@crossmint/common-sdk-base": "0.0.5",
         "lit": "2.8.0"
     }
 }

--- a/packages/client/ui/vanilla-ui/src/components/embed/CrossmintPaymentElement.ts
+++ b/packages/client/ui/vanilla-ui/src/components/embed/CrossmintPaymentElement.ts
@@ -7,10 +7,10 @@ import type {
     Locale,
     MintConfig,
     Recipient,
-    UIConfig,
     FiatEmbeddedCheckoutProps,
     CrossmintEvent,
 } from "@crossmint/client-sdk-base";
+import type { UIConfig } from "@crossmint/common-sdk-base";
 
 const propertyDefaults: FiatEmbeddedCheckoutProps = {
     collectionId: "",

--- a/packages/client/ui/vue-ui/package.json
+++ b/packages/client/ui/vue-ui/package.json
@@ -29,7 +29,7 @@
         "format": "prettier --write src/"
     },
     "dependencies": {
-        "@crossmint/client-sdk-base": "1.1.6",
+        "@crossmint/client-sdk-base": "1.1.7",
         "vue": "3.3.4"
     },
     "devDependencies": {

--- a/packages/client/verifiable-credentials/package.json
+++ b/packages/client/verifiable-credentials/package.json
@@ -7,10 +7,10 @@
         "@lit-protocol/lit-node-client": "3.1.2",
         "date-fns": "2.30.0",
         "ethers": "5.7.2",
-        "@crossmint/common-sdk-base": "0.0.4"
+        "@crossmint/common-sdk-base": "0.0.5"
     },
     "devDependencies": {
-        "@crossmint/client-sdk-base": "1.1.6"
+        "@crossmint/client-sdk-base": "1.1.7"
     },
     "exports": {
         "import": "./dist/index.js",
@@ -32,8 +32,8 @@
     "scripts": {
         "build": "yarn clean && tsup src/index.ts --format esm,cjs --outDir ./dist --minify --dts --sourcemap",
         "clean": "shx rm -rf dist/*",
-        "test": "NODE_ENV=test jest --silent",
-        "test-coverage": "NODE_ENV=test jest --coverage --silent",
+        "test": "cross-env NODE_ENV=test jest --silent",
+        "test-coverage": "cross-env NODE_ENV=test jest --coverage --silent",
         "dev": "yarn clean && tsup src/index.ts --format esm,cjs --outDir ./dist --dts --sourcemap --watch"
     },
     "sideEffects": false,

--- a/packages/client/wallets/aa/front/package.json
+++ b/packages/client/wallets/aa/front/package.json
@@ -1,25 +1,25 @@
 {
-  "name": "front",
-  "version": "0.1.0",
-  "private": true,
-  "scripts": {
-    "dev": "next dev -p 3001",
-    "build": "next build",
-    "start": "next start",
-    "lint": "next lint"
-  },
-  "dependencies": {
-    "ethers": "5.7.2",
-    "next": "13.5.6",
-    "react": "^18",
-    "react-dom": "^18",
-    "@crossmint/client-sdk-aa": "file: ../../../",
-    "@crossmint/common-sdk-base": "file: ../../../../../../common/base"
-  },
-  "devDependencies": {
-    "@types/node": "^20",
-    "@types/react": "^18",
-    "@types/react-dom": "^18",
-    "typescript": "^5"
-  }
+    "name": "@crossmint/client-sdk-aa-demo",
+    "version": "0.1.0",
+    "private": true,
+    "scripts": {
+        "dev": "next dev -p 3001",
+        "build": "next build",
+        "start": "next start",
+        "lint": "next lint"
+    },
+    "dependencies": {
+        "ethers": "5.7.2",
+        "next": "13.5.6",
+        "react": "^18",
+        "react-dom": "^18",
+        "@crossmint/client-sdk-aa": "0.2.0",
+        "@crossmint/common-sdk-base": "0.0.5"
+    },
+    "devDependencies": {
+        "@types/node": "^20",
+        "@types/react": "^18",
+        "@types/react-dom": "^18",
+        "typescript": "^5"
+    }
 }

--- a/packages/client/wallets/walletconnect/package.json
+++ b/packages/client/wallets/walletconnect/package.json
@@ -1,7 +1,7 @@
 {
     "author": "Paella Inc",
     "dependencies": {
-        "@crossmint/common-sdk-base": "0.0.4",
+        "@crossmint/common-sdk-base": "0.0.5",
         "@headlessui/react": "1.7.18",
         "@heroicons/react": "2.1.1",
         "@walletconnect/core": "2.11.1",
@@ -12,7 +12,7 @@
         "react-hot-toast": "2.4.1"
     },
     "devDependencies": {
-        "@crossmint/client-sdk-aa": "0.1.2",
+        "@crossmint/client-sdk-aa": "0.2.0",
         "@ethersproject/abstract-provider": "5.7.0",
         "@ethersproject/providers": "5.7.2",
         "@solana/web3.js": "1.90.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1598,38 +1598,6 @@
   resolved "https://registry.yarnpkg.com/@cosmjs/utils/-/utils-0.30.1.tgz#6d92582341be3c2ec8d82090253cfa4b7f959edb"
   integrity sha512-KvvX58MGMWh7xA+N+deCfunkA/ZNDvFLw4YbOmX3f/XBIkqrVY7qlotfy2aNb1kgp6h4B6Yc8YawJPDTfvWX7g==
 
-"@crossmint/client-sdk-aa@file:packages/client/wallets/aa":
-  version "0.1.2"
-  dependencies:
-    "@ambire/signature-validator" "1.3.1"
-    "@crossmint/common-sdk-base" "0.0.4"
-    "@datadog/browser-logs" "4.42.2"
-    "@fireblocks/ncw-js-sdk" "11.0.2"
-    "@lit-protocol/auth-helpers" "3.1.2"
-    "@lit-protocol/constants" "3.1.2"
-    "@lit-protocol/contracts-sdk" "3.1.2"
-    "@lit-protocol/lit-auth-client" "3.1.2"
-    "@lit-protocol/lit-node-client" "3.1.2"
-    "@lit-protocol/pkp-ethers" "3.1.2"
-    "@lit-protocol/types" "3.1.2"
-    "@types/node-forge" "1.3.1"
-    "@web3auth/base" "7.3.2"
-    "@web3auth/ethereum-provider" "7.3.2"
-    "@web3auth/single-factor-auth" "7.3.0"
-    "@zerodev/sdk" "4.5.2"
-    email-validator "2.0.4"
-    ethers "5.7.2"
-    libphonenumber-js "1.10.44"
-    node-forge "1.3.1"
-    siwe "2.1.4"
-    viem "^2.5.0"
-
-"@crossmint/common-sdk-base@file:packages/common/base":
-  version "0.0.4"
-  dependencies:
-    bs58 "5.0.0"
-    tweetnacl "1.0.3"
-
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"


### PR DESCRIPTION
## Description

no reason to not sync these deps with the latest versions, due to syncing yarn.lock doesnt update much - if didnt sync, would be a couple hundred lines

## Test plan

ci passes, `yarn install` doesnt update lock file
