### PR TITLE
WC-AA: Add workaround to support odd values on sendTransaction

### DIFF
--- a/packages/client/wallets/aa/src/blockchain/wallets/BaseWallet.ts
+++ b/packages/client/wallets/aa/src/blockchain/wallets/BaseWallet.ts
@@ -1,5 +1,5 @@
 import { logError } from "@/services/logging";
-import { SCW_SERVICE, TransactionError, TransferError, errorToJSON } from "@/utils";
+import { SCW_SERVICE, TransactionError, TransferError, decorateSendTransactionData, errorToJSON } from "@/utils";
 import type { SignTypedDataParams } from "@alchemy/aa-core";
 import type { Deferrable } from "@ethersproject/properties";
 import { type TransactionRequest, type TransactionResponse } from "@ethersproject/providers";
@@ -120,7 +120,8 @@ class BaseWallet extends ZeroDevAccountSigner<"ECDSA"> {
 
     async sendTransaction(transaction: Deferrable<TransactionRequest>): Promise<TransactionResponse> {
         try {
-            return await super.sendTransaction(transaction);
+            const decoratedTransaction = await decorateSendTransactionData(transaction);
+            return await super.sendTransaction(decoratedTransaction);
         } catch (error) {
             logError("[SEND_TRANSACTION] - ERROR_SENDING_TRANSACTION", {
                 service: SCW_SERVICE,

--- a/packages/client/wallets/aa/src/utils/index.ts
+++ b/packages/client/wallets/aa/src/utils/index.ts
@@ -3,3 +3,4 @@ export * from "./constants";
 export * from "./error";
 export * from "./signer";
 export * from "./helpers";
+export * from "./transactions";

--- a/packages/client/wallets/aa/src/utils/transactions.ts
+++ b/packages/client/wallets/aa/src/utils/transactions.ts
@@ -1,0 +1,34 @@
+import type { Deferrable } from "@ethersproject/properties";
+import { type TransactionRequest } from "@ethersproject/providers";
+import { hexlify } from "ethers/lib/utils";
+
+/**
+ * We need to support odd value and data fields in a tx, as that data comes from WC
+ * ZeroDev implements hexlify, but doesn't support to send an odd string in value or data fields
+ * so we need to make the hexlify fix manually when sending a transaction.
+ * That fix can be found here:
+ * https://github.com/ethers-io/ethers.js/commit/a12030ad29aa13c02aa75d9e0860f4986a0043b4#diff-047e7ebfdbd5c41e762cda03593bd15ed8b3121dece67262729dfcbde7040818R221
+ * And more context on this issue:
+ * https://github.com/ethers-io/ethers.js/issues/614
+ *
+ * Applying to it hexValue is used as a workaround on Crossbit, but doesn't cover all the cases (i.e. 0x71afd498d0000).
+ * This function is the same as hexValue but without hexStripZeros, which is what makes it to not work.
+ */
+export async function decorateSendTransactionData(transaction: Deferrable<TransactionRequest>) {
+    const decoratedTransaction = { ...transaction };
+    if (transaction.value) {
+        const awaitedValue = await transaction.value;
+        if (awaitedValue) {
+            decoratedTransaction.value = hexlify(awaitedValue, { hexPad: "left" });
+        }
+    }
+
+    if (transaction.data) {
+        const awaitedData = await transaction.data;
+        if (awaitedData) {
+            decoratedTransaction.data = hexlify(awaitedData, { hexPad: "left" });
+        }
+    }
+
+    return decoratedTransaction;
+}


### PR DESCRIPTION
## Description

/**
 * We need to support odd value and data fields in a tx, as that data comes from WC
 * ZeroDev implements hexlify, but doesn't support to send an odd string in value or data fields
 * so we need to make the hexlify fix manually when sending a transaction.
 * That fix can be found here:
 * https://github.com/ethers-io/ethers.js/commit/a12030ad29aa13c02aa75d9e0860f4986a0043b4#diff-047e7ebfdbd5c41e762cda03593bd15ed8b3121dece67262729dfcbde7040818R221
 * And more context on this issue:
 * https://github.com/ethers-io/ethers.js/issues/614
 *
 * Applying to it hexValue is used as a workaround on Crossbit, but doesn't cover all the cases (i.e. 0x71afd498d0000).
 * This function is the same as hexValue but without hexStripZeros, which is what makes it to not work.
 */

## Test plan

Described in this PR: https://github.com/Paella-Labs/crossbit-main/pull/11826

- Swap through Uniswap

