### PR TITLE
verification-sdk: add to bundle

### DIFF
--- a/packages/client/ui/react-ui/src/components/hosted/index.ts
+++ b/packages/client/ui/react-ui/src/components/hosted/index.ts
@@ -1,3 +1,2 @@
 export * from "./CrossmintPayButton";
-// TODO: Lets enable this once the button is ready to be used
-// export * from "./CrossmintVerificationButton";
+export * from "./CrossmintVerificationButton";

--- a/packages/client/window/package.json
+++ b/packages/client/window/package.json
@@ -24,7 +24,6 @@
         "dev": "yarn clean && tsup src/index.ts --format esm,cjs --outDir ./dist --dts --sourcemap --watch"
     },
     "dependencies": {
-        "nanoid": "5.0.4",
         "zod": "3.22.4"
     }
 }

--- a/packages/client/window/src/EventEmitter.ts
+++ b/packages/client/window/src/EventEmitter.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { generateRandomString } from "./utils/generateRandomString";
+
 export type EventMap = Record<string, z.ZodTypeAny>;
 
 export interface EventEmitterOptions<
@@ -82,7 +84,7 @@ export class EventEmitter<IncomingEvents extends EventMap, OutgoingEvents extend
             }
         };
 
-        const id = (Math.random() + 1).toString(36).substring(7);
+        const id = generateRandomString();
         this.listeners.set(id, listener);
         window.addEventListener("message", listener);
         return id;

--- a/packages/client/window/src/EventEmitter.ts
+++ b/packages/client/window/src/EventEmitter.ts
@@ -1,11 +1,10 @@
-import { nanoid } from "nanoid";
 import { z } from "zod";
 
 export type EventMap = Record<string, z.ZodTypeAny>;
 
 export interface EventEmitterOptions<
     IncomingEvents extends EventMap = EventMap,
-    OutgoingEvents extends EventMap = EventMap,
+    OutgoingEvents extends EventMap = EventMap
 > {
     incomingEvents?: IncomingEvents;
     outgoingEvents?: OutgoingEvents;
@@ -20,7 +19,7 @@ export type SendActionArgs<
     IncomingEvents extends EventMap,
     OutgoingEvents extends EventMap,
     K extends keyof OutgoingEvents,
-    R extends keyof IncomingEvents,
+    R extends keyof IncomingEvents
 > = {
     event: K;
     data: z.infer<OutgoingEvents[K]>;
@@ -36,7 +35,7 @@ export type OnActionArgs<
     IncomingEvents extends EventMap,
     OutgoingEvents extends EventMap,
     K extends keyof IncomingEvents,
-    R extends keyof OutgoingEvents,
+    R extends keyof OutgoingEvents
 > =
     | {
           event: K;
@@ -83,7 +82,7 @@ export class EventEmitter<IncomingEvents extends EventMap, OutgoingEvents extend
             }
         };
 
-        const id = nanoid();
+        const id = (Math.random() + 1).toString(36).substring(7);
         this.listeners.set(id, listener);
         window.addEventListener("message", listener);
         return id;

--- a/packages/client/window/src/handshake/Parent.ts
+++ b/packages/client/window/src/handshake/Parent.ts
@@ -1,4 +1,3 @@
-import { nanoid } from "nanoid";
 import { z } from "zod";
 
 import {
@@ -43,7 +42,7 @@ export class HandshakeParent<IncomingEvents extends EventMap, OutgoingEvents ext
             console.log("[server] Already connected to child");
             return;
         }
-        const requestVerificationId = nanoid();
+        const requestVerificationId = (Math.random() + 1).toString(36).substring(7);
 
         await this._sendAction({
             event: "handshakeRequest",

--- a/packages/client/window/src/handshake/Parent.ts
+++ b/packages/client/window/src/handshake/Parent.ts
@@ -9,6 +9,7 @@ import {
     HandshakeParentEvents,
 } from ".";
 import { EventEmitter, EventMap, SendActionArgs, SendActionOptions } from "../EventEmitter";
+import { generateRandomString } from "@/utils/generateRandomString";
 
 export class HandshakeParent<IncomingEvents extends EventMap, OutgoingEvents extends EventMap> extends EventEmitter<
     IncomingEvents,
@@ -42,7 +43,7 @@ export class HandshakeParent<IncomingEvents extends EventMap, OutgoingEvents ext
             console.log("[server] Already connected to child");
             return;
         }
-        const requestVerificationId = (Math.random() + 1).toString(36).substring(7);
+        const requestVerificationId = generateRandomString();
 
         await this._sendAction({
             event: "handshakeRequest",

--- a/packages/client/window/src/utils/generateRandomString.ts
+++ b/packages/client/window/src/utils/generateRandomString.ts
@@ -1,0 +1,1 @@
+export const generateRandomString = () => Math.random().toString(36).substring(2, 15);

--- a/yarn.lock
+++ b/yarn.lock
@@ -16958,11 +16958,6 @@ nanoid@3.3.4:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
   integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
 
-nanoid@5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.0.4.tgz#d2b608d8169d7da669279127615535705aa52edf"
-  integrity sha512-vAjmBf13gsmhXSgBrtIclinISzFFy22WwCYoyilZlsrRXNIHSwgFQ1bEdjRwMT3aoadeIF6HMuDRlOxzfXV8ig==
-
 nanoid@^3.0.2, nanoid@^3.1.20, nanoid@^3.1.23, nanoid@^3.3.7:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.7.tgz#d0c301a691bc8d54efa0a2226ccf3fe2fd656bd8"


### PR DESCRIPTION
## Description

<!-- Human must describe here why are we doing this change, and roughly what it does -->
<!-- Optional screenshot or video -->
Add the verification SDK into the bundle. Also, removes the `nanoid` dependency. It was introducing the `crypto` package that was conflicting with the react starter. This was the error:

```
 Module not found: Error: Can't resolve 'crypto' in '/Users/pablogarciaegido/Desktop/code/paella/crossmint-client-sdk/packages/client/ui/react-ui/dist'
       BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
       This is no longer the case. Verify if you need this module and configure a polyfill for it.
       
       If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "crypto": require.resolve("crypto-browserify") }'
        - install 'crypto-browserify'
       If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "crypto": false }
```

Since I don't think we need unpredictability and total randomness in the string generation (for what I can see, its only used to differentiate different listeners), I think this should be fine.

## Test plan

<!--
  Example:
   * Unit tests which cover functionality X, Y, Z
   * V was tested via UI tests
   * W was tested manually
-->
The bundle building.