### PR TITLE
verification-sdk: Styling and text content props

### DIFF
--- a/packages/client/ui/react-ui/src/components/hosted/CrossmintPayButton.tsx
+++ b/packages/client/ui/react-ui/src/components/hosted/CrossmintPayButton.tsx
@@ -2,10 +2,11 @@ import { CSSProperties, MouseEvent, useMemo } from "react";
 import { useState } from "react";
 
 import {
+    CheckoutProps,
     CrossmintPayButtonProps,
     clientNames,
     crossmintModalService,
-    crossmintPayButtonService, CheckoutProps,
+    crossmintPayButtonService,
 } from "@crossmint/client-sdk-base";
 
 import { LIB_VERSION } from "../../consts/version";
@@ -78,7 +79,7 @@ export function CrossmintPayButton(buttonProps: CrossmintPayButtonReactProps) {
         connecting,
         paymentMethod,
         locale,
-        checkoutProps
+        checkoutProps,
     });
 
     const _handleClick = (event: MouseEvent<HTMLButtonElement>) =>

--- a/packages/client/ui/react-ui/src/components/hosted/CrossmintVerificationButton.tsx
+++ b/packages/client/ui/react-ui/src/components/hosted/CrossmintVerificationButton.tsx
@@ -3,9 +3,13 @@ import { CSSProperties, MouseEvent } from "react";
 import { CrossmintVerificationButtonProps, crossmintVerificationService } from "@crossmint/client-sdk-base";
 import { PopupWindow } from "@crossmint/client-sdk-window";
 
+import { formatProps, useStyles } from "./styles";
+
 export type CrossmintVerificationButtonReactProps = CrossmintVerificationButtonProps & {
     onClick?: (e: MouseEvent<HTMLButtonElement>) => void;
     style?: CSSProperties;
+    children?: React.ReactNode;
+    className?: string;
 };
 
 export function CrossmintVerificationButton(props: CrossmintVerificationButtonReactProps) {
@@ -16,10 +20,25 @@ export function CrossmintVerificationButton(props: CrossmintVerificationButtonRe
         fields: props.fields,
     });
 
+    // TODO: Do we want to support themes?
+    const classes = useStyles(formatProps("dark"));
+
     async function onClick() {
-        PopupWindow.init(getUrl(), { width: 400, height: 650 });
+        PopupWindow.init(getUrl(), { width: 400, height: 666 });
     }
 
-    // TODO: Styling
-    return <button onClick={onClick}>Verify collection</button>;
+    return (
+        <button
+            onClick={onClick}
+            className={`${classes.crossmintButton} ${props.className || ""}`}
+            style={{ ...props.style }}
+        >
+            <img
+                className={classes.crossmintImg}
+                src="https://www.crossmint.io/assets/crossmint/logo.svg"
+                alt="Crossmint logo"
+            />
+            {props.children}
+        </button>
+    );
 }


### PR DESCRIPTION
## Description

<!-- Human must describe here why are we doing this change, and roughly what it does -->
<!-- Optional screenshot or video -->
For consistency, using the same strategy as with the CrossmintPayButton for styling.

Users will be able to pass:
- Classes
- Styles
- Text content

## Test plan

<!--
  Example:
   * Unit tests which cover functionality X, Y, Z
   * V was tested via UI tests
   * W was tested manually
-->
Tested locally in starter. High level customisation.
![Screenshot 2024-03-07 at 19 45 20](https://github.com/Crossmint/crossmint-sdk/assets/20989060/1d08bddd-b7ec-46ca-ae86-10a8abb3bcc0)
