### PR TITLE
jp: fix translations

### DIFF
--- a/packages/client/base/src/utils/i18n/dictionaries/jaJp.ts
+++ b/packages/client/base/src/utils/i18n/dictionaries/jaJp.ts
@@ -1,10 +1,11 @@
 const jaJp = {
-    CONNECTING: "接続中...",
+    crossmintPayButtonService: {
+        CONNECTING: "接続中...",
         BUY: "Crossmintで購入",
         BUY_WITH_ETH: "ETHで購入",
         BUY_WITH_SOL: "SOLで購入",
         BUY_WITH_CREDIT_CARD: "クレジットカードで購入",
-}
-
+    },
+};
 
 export default jaJp;


### PR DESCRIPTION
## Description

<!-- Human must describe here why are we doing this change, and roughly what it does -->
<!-- Optional screenshot or video -->
The translations file was misformatted. This caused an issue in Storefront in staging. https://app.datadoghq.com/dashboard/4zb-6wt-t6r/console-dashboard?query=%22ERROR_BOUNDARY_STOREFRONT_FRONTEND%22&event=AgAAAY4bzUUeUDuOGgAAAAAAAAAYAAAAAEFZNGJ6YmJ2QUFDcE52djExcHF6ZVFBQQAAACQAAAAAMDE4ZTFjMzctYzExZi00YWFmLWIyYTItNjY0MTgxODMxOWZk&fromUser=false&index=%2A&panelFrom=1709863200000&panelTo=1709865000000&panelType=logs&refresh_mode=sliding&view=spans&from_ts=1709712085712&to_ts=1709884885712&live=true

## Test plan

<!--
  Example:
   * Unit tests which cover functionality X, Y, Z
   * V was tested via UI tests
   * W was tested manually
-->
Tested in starter: 
![Screenshot 2024-03-08 at 09 23 15](https://github.com/Crossmint/crossmint-sdk/assets/20989060/5658002a-5c41-4ef1-b97a-13e9e19022a2)


