### PR TITLE
WC SDK: Fix library imported from base

### DIFF
--- a/packages/client/wallets/walletconnect/package.json
+++ b/packages/client/wallets/walletconnect/package.json
@@ -1,7 +1,7 @@
 {
     "author": "Paella Inc",
     "dependencies": {
-        "@crossmint/common-sdk-base": "0.0.6",
+        "@crossmint/common-sdk-base": "0.0.7",
         "@headlessui/react": "1.7.18",
         "@heroicons/react": "2.1.1",
         "@walletconnect/core": "2.11.1",
@@ -37,7 +37,8 @@
     "files": [
         "dist",
         "src",
-        "LICENSE"
+        "LICENSE",
+        ".yalc"
     ],
     "license": "Apache-2.0",
     "main": "./dist/index.cjs",
@@ -54,8 +55,12 @@
     "repository": "https://github.com/Crossmint/crossmint-sdk",
     "scripts": {
         "build": "yarn clean && tsup src/index.ts --external react,react-dom --format esm,cjs --outDir ./dist --minify --dts --sourcemap",
-        "dev": "yarn build --watch",
-        "clean": "shx rm -rf dist/*"
+        "dev": "yarn clean && tsup src/index.ts --external react,react-dom --format esm,cjs --outDir ./dist --dts --sourcemap --watch",
+        "clean": "shx rm -rf dist/*",
+        "link:common-sdk-base": "yalc add @crossmint/common-sdk-base && yalc link @crossmint/common-sdk-base && yarn",
+        "unlink:common-sdk-base": "yalc remove @crossmint/common-sdk-base && yalc link @crossmint/common-sdk-base && yarn",
+        "link:client-sdk-aa": "yalc add @crossmint/client-sdk-aa && yalc link @crossmint/client-sdk-aa && yarn ",
+        "unlink:client-sdk-aa": "yalc remove @crossmint/client-sdk-aa && yarn"
     },
     "sideEffects": false,
     "style": "./dist/index.css",

--- a/packages/client/wallets/walletconnect/package.json
+++ b/packages/client/wallets/walletconnect/package.json
@@ -12,7 +12,7 @@
         "react-hot-toast": "2.4.1"
     },
     "devDependencies": {
-        "@crossmint/client-sdk-aa": "0.2.1",
+        "@crossmint/client-sdk-aa": "0.2.6",
         "@ethersproject/abstract-provider": "5.7.0",
         "@ethersproject/providers": "5.7.2",
         "@solana/web3.js": "1.90.0",

--- a/packages/client/wallets/walletconnect/src/utils/walletconnect/prettifyWalletConnectChain.ts
+++ b/packages/client/wallets/walletconnect/src/utils/walletconnect/prettifyWalletConnectChain.ts
@@ -3,7 +3,7 @@ import {
     WALLETCONNECT_SOLANA_MAINNET_CHAIN_IDENTIFIER,
 } from "@/consts/walletconnect";
 
-import { blockchainToCopyName, chainIdToBlockchain } from "@crossmint/common-sdk-base";
+import { blockchainToDisplayName, chainIdToBlockchain } from "@crossmint/common-sdk-base";
 
 export function prettifyWalletConnectChain(chain: string) {
     if (chain.startsWith("eip155:")) {
@@ -12,7 +12,7 @@ export function prettifyWalletConnectChain(chain: string) {
         if (!blockchain) {
             return chain;
         }
-        return blockchainToCopyName(blockchain);
+        return blockchainToDisplayName(blockchain);
     }
     if (chain === WALLETCONNECT_SOLANA_DEVNET_CHAIN_IDENTIFIER) {
         return "Solana Devnet";


### PR DESCRIPTION
## Description

We were importing `blockchainToCopyName`, when the actual function was `blockchainToDisplayName`.

Also, started adding `yalc` commands to make our life easier when connecting packages locally. This only Impacts locally when running the app 

## Test plan

Make a successful connection using WC SDK.![Screenshot 2024-03-18 at 12 40 06 PM](https://github.com/Crossmint/crossmint-sdk/assets/132915515/9db0244e-2f8e-4511-af75-dd9356dac15b)