### PR TITLE
fix WC issue

### DIFF
--- a/packages/client/wallets/aa/package.json
+++ b/packages/client/wallets/aa/package.json
@@ -49,6 +49,8 @@
         "build": "yarn clean && tsup src/index.ts --format esm,cjs --outDir ./dist --minify --dts --sourcemap",
         "clean": "shx rm -rf dist/*",
         "dev": "yarn clean && tsup src/index.ts --format esm,cjs --outDir ./dist --dts --sourcemap --watch",
+        "link:common-sdk-base": "yalc add @crossmint/common-sdk-base && yalc link @crossmint/common-sdk-base && yarn && yarn build && yalc push",
+        "unlink:common-sdk-base": "yalc remove @crossmint/common-sdk-base && yarn",
         "test": "cross-env NODE_ENV=test jest",
         "test-coverage": "cross-env NODE_ENV=test jest --coverage"
     },

--- a/packages/client/wallets/aa/src/blockchain/wallets/EVMAAWallet.ts
+++ b/packages/client/wallets/aa/src/blockchain/wallets/EVMAAWallet.ts
@@ -24,6 +24,8 @@ import { TokenType } from "../token/Tokens";
 import BaseWallet from "./BaseWallet";
 import { ZeroDevEip1193Bridge } from "./ZeroDevEip1193Bridge";
 
+export { EVMBlockchainIncludingTestnet, chainIdToBlockchain } from "@crossmint/common-sdk-base";
+
 type SignerMap = {
     ethers: ethers.Signer;
     viem: WalletClient;


### PR DESCRIPTION
## Description

In the[ WC build](https://github.com/Crossmint/crossmint-sdk/actions/runs/8329424732/job/22791687611?pr=437), we're having this error:

`Error: src/wallets/WalletConnectEVMAAWallet.ts(9,5): error TS2742: The inferred type of 'getSupportedChains' cannot be named without a reference to '@crossmint/client-sdk-aa/node_modules/@crossmint/common-sdk-base'. This is likely not portable. A type annotation is necessary.`

It looks like a [bug from Typescript](https://github.com/microsoft/TypeScript/issues/42873#issuecomment-1990995016) (that comment is from last week). 
How it applies to our situation:

// Base

`export { BlockchainIncludingTestnet }`

// AA

```
import { BlockchainIncludingTestnet }
...
export { EVMAAWallet } from  'Base'
```

// WC SDK

``` 
import { EVMAAWallet } from 'AA' // => uses BlockchainIncludingTestnet from Base
..
import { BlockchainIncludingTestnet } from 'Base'
```

This final situation on `WC SDK` is the cause of the error


## Test plan

We need to deploy and release a new version, and then check if when importing that new version this gets fixed.