### PR TITLE
AA: Fix Base RPC

### DIFF
--- a/packages/client/wallets/aa/src/blockchain/BlockchainNetworks.ts
+++ b/packages/client/wallets/aa/src/blockchain/BlockchainNetworks.ts
@@ -98,7 +98,7 @@ export function getUrlProviderByBlockchain(chain: EVMBlockchainIncludingTestnet)
         ["optimism-sepolia", "https://sepolia.optimism.io"],
         ["zora-goerli", null],
         ["zora-sepolia", null],
-        ["base", "https://base.llamarpc.com"],
+        ["base", "https://mainnet.base.org"],
         ["zora", null],
         ["arbitrumnova", "https://arbitrum-nova-rpc.publicnode.com"],
         ["astar-zkevm", "https://rpc.startale.com/astar-zkevm"],


### PR DESCRIPTION
## Description

Llama RPC caused a `net_version` error. Changing the url resolves it

## Test plan

Created AA locally
