### PR TITLE
Simplification: Drop Unused Token Types

### DIFF
--- a/packages/client/wallets/aa/src/blockchain/token/Tokens.ts
+++ b/packages/client/wallets/aa/src/blockchain/token/Tokens.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from "ethers";
 
-import { EVMBlockchainIncludingTestnet, isEVMBlockchain } from "@crossmint/common-sdk-base";
+import { EVMBlockchainIncludingTestnet } from "@crossmint/common-sdk-base";
 
 export interface EVMToken {
     chain: EVMBlockchainIncludingTestnet;
@@ -21,33 +21,9 @@ export interface ERC2OEVMToken extends EVMToken {
     type: "ft";
 }
 
-export interface SolanaToken {
-    mintHash: string;
-    chain: "solana";
-    type: "nft";
-}
-export interface CardanoToken {
-    chain: "cardano";
-    assetId: string;
-    type: "nft";
-}
-
-export function isEVMToken(value: unknown): value is EVMToken {
-    if (typeof value !== "object" || value === null) {
-        return false;
-    }
-    const possibleEVMToken = value as Partial<EVMToken>;
-    return (
-        typeof possibleEVMToken.chain === "string" &&
-        typeof possibleEVMToken.contractAddress === "string" &&
-        isEVMBlockchain(possibleEVMToken.chain)
-    );
-}
-
-export type Token = EVMToken | SolanaToken | CardanoToken;
 export type TokenType = "nft" | "sft" | "ft";
 
 export type ERC20TransferType = { token: ERC2OEVMToken; amount: BigNumber };
 export type SFTTransferType = { token: SFTEVMToken; quantity: number };
-export type NFTTransferType = { token: NFTEVMToken | SolanaToken | CardanoToken };
+export type NFTTransferType = { token: NFTEVMToken };
 export type TransferType = ERC20TransferType | SFTTransferType | NFTTransferType;

--- a/packages/client/wallets/aa/src/blockchain/wallets/EVMAAWallet.ts
+++ b/packages/client/wallets/aa/src/blockchain/wallets/EVMAAWallet.ts
@@ -198,10 +198,6 @@ export class EVMAAWallet<
     async transfer(toAddress: string, config: TransferType): Promise<string> {
         return this.logPerformance("TRANSFER", async () => {
             const evmToken = config.token;
-            if (!isEVMToken(evmToken)) {
-                throw new WalletSdkError(`Blockchain ${evmToken.chain} is not supported`);
-            }
-
             const contractAddress = evmToken.contractAddress as `0x${string}`;
             const publicClient = this.kernelClient.extend(publicActions);
             let transaction;

--- a/packages/client/wallets/aa/src/blockchain/wallets/EVMAAWallet.ts
+++ b/packages/client/wallets/aa/src/blockchain/wallets/EVMAAWallet.ts
@@ -43,7 +43,7 @@ import {
     getViemNetwork,
 } from "../BlockchainNetworks";
 import { Custodian } from "../plugins";
-import { ERC20TransferType, SFTTransferType, TokenType, TransferType, isEVMToken } from "../token";
+import { ERC20TransferType, SFTTransferType, TokenType, TransferType } from "../token";
 
 type GasFeeTransactionParams = {
     maxFeePerGas?: BigNumberish;


### PR DESCRIPTION
## Description

Given that it's unlikely we'll be supporting Cardano or Solana token transfers from our AA SDK anytime soon, this PR drops them.

## Test plan

TS Compiling & existing tests
