### PR TITLE
Simplification: Drop Unused (and unnecessarily exposed) Paymaster Method

### DIFF
--- a/packages/client/wallets/aa/src/blockchain/wallets/EVMAAWallet.ts
+++ b/packages/client/wallets/aa/src/blockchain/wallets/EVMAAWallet.ts
@@ -108,21 +108,6 @@ export class EVMAAWallet<
         this.entryPoint = entryPoint;
     }
 
-    getPaymasterClient() {
-        return this.chain === EVMBlockchainIncludingTestnet.BASE ||
-            this.chain === EVMBlockchainIncludingTestnet.BASE_SEPOLIA
-            ? createPimlicoPaymasterClient({
-                  chain: getViemNetwork(this.chain),
-                  transport: http(getPaymasterRPC(this.chain)),
-                  entryPoint: this.entryPoint,
-              })
-            : createZeroDevPaymasterClient({
-                  chain: getViemNetwork(this.chain),
-                  transport: http(getPaymasterRPC(this.chain)),
-                  entryPoint: this.entryPoint,
-              });
-    }
-
     getAddress() {
         return this.kernelClient.account.address;
     }


### PR DESCRIPTION
## Description

This PR drops the `getPaymasterMethod` from `EVMAAWallet`. You can see [here](https://github.com/Crossmint/crossmint-sdk/pull/456) that it was added:
- For use internally
- Wasn't intentionally exposed.

I'd normally make it private, but since it's no longer used just deleting it instead.

## Test plan

TS Compiles & Existing Tests
