### PR TITLE
Simplification: Drop Custodian Session Key Pt. 1

### DIFF
--- a/packages/client/wallets/aa/src/CrossmintAASDK.ts
+++ b/packages/client/wallets/aa/src/CrossmintAASDK.ts
@@ -83,15 +83,11 @@ export class CrossmintAASDK extends LoggerWrapper {
                         this.crossmintService,
                         chain,
                         publicClient,
-                        ecdsaValidator,
                         entryPoint
                     );
 
                     const abstractAddress = account.address;
                     const { sessionKeySignerAddress } = await this.crossmintService.createSessionKey(abstractAddress);
-
-                    evmAAWallet.setSessionKeySignerAddress(sessionKeySignerAddress);
-
                     await this.crossmintService.storeAbstractWallet({
                         userIdentifier,
                         type: ZERO_DEV_TYPE,

--- a/packages/client/wallets/aa/src/api/CrossmintWalletService.ts
+++ b/packages/client/wallets/aa/src/api/CrossmintWalletService.ts
@@ -1,4 +1,4 @@
-import { GenerateSignatureDataInput, StoreAbstractWalletInput, UserIdentifier } from "@/types";
+import { StoreAbstractWalletInput } from "@/types";
 
 import { EVMBlockchainIncludingTestnet, UserIdentifierParams } from "@crossmint/common-sdk-base";
 
@@ -38,14 +38,6 @@ export class CrossmintWalletService extends BaseCrossmintService {
             `v1-alpha1/wallets/entry-point-version?${identifier}&chain=${chain}`,
             { method: "GET" },
             `Error getting entry point version. Please contact support`
-        );
-    }
-
-    async generateChainData(input: GenerateSignatureDataInput) {
-        return this.fetchCrossmintAPI(
-            "unstable/wallets/aa/wallets/chaindata",
-            { method: "POST", body: JSON.stringify(input) },
-            "Error setting custodian. Please contact support"
         );
     }
 

--- a/packages/client/wallets/aa/src/blockchain/wallets/EVMAAWallet.ts
+++ b/packages/client/wallets/aa/src/blockchain/wallets/EVMAAWallet.ts
@@ -15,7 +15,7 @@ import { resolveDeferrable } from "@/utils/deferrable";
 import { LoggerWrapper } from "@/utils/log";
 import type { Deferrable } from "@ethersproject/properties";
 import { type TransactionRequest } from "@ethersproject/providers";
-import { createKernelAccountClient, createZeroDevPaymasterClient } from "@zerodev/sdk";
+import { KernelSmartAccount, createKernelAccountClient, createZeroDevPaymasterClient } from "@zerodev/sdk";
 import { BigNumberish } from "ethers";
 import { EntryPoint } from "permissionless/types/entrypoint";
 import type { Hash, HttpTransport, PublicClient, TypedDataDefinition } from "viem";
@@ -47,7 +47,6 @@ export class EVMAAWallet extends LoggerWrapper {
             KernelSmartAccount<EntryPoint, HttpTransport, TChain>
         >
     >;
-    private entryPoint: EntryPoint;
     chain: EVMBlockchainIncludingTestnet;
 
     constructor(
@@ -61,8 +60,6 @@ export class EVMAAWallet extends LoggerWrapper {
         this.chain = chain;
         this.crossmintService = crossmintService;
         this.publicClient = publicClient;
-        this.ecdsaValidator = ecdsaValidator;
-
         this.kernelClient = createKernelAccountClient({
             account,
             chain: getViemNetwork(chain),
@@ -85,7 +82,6 @@ export class EVMAAWallet extends LoggerWrapper {
             }),
         });
         this.account = account;
-        this.entryPoint = entryPoint;
     }
 
     getAddress() {

--- a/packages/client/wallets/aa/src/blockchain/wallets/EVMAAWallet.ts
+++ b/packages/client/wallets/aa/src/blockchain/wallets/EVMAAWallet.ts
@@ -15,13 +15,11 @@ import { resolveDeferrable } from "@/utils/deferrable";
 import { LoggerWrapper } from "@/utils/log";
 import type { Deferrable } from "@ethersproject/properties";
 import { type TransactionRequest } from "@ethersproject/providers";
-import type { KernelValidator } from "@zerodev/ecdsa-validator";
-import type { KernelSmartAccount } from "@zerodev/sdk";
 import { createKernelAccountClient, createZeroDevPaymasterClient } from "@zerodev/sdk";
 import { BigNumberish } from "ethers";
 import { EntryPoint } from "permissionless/types/entrypoint";
 import type { Hash, HttpTransport, PublicClient, TypedDataDefinition } from "viem";
-import { Hex, http, publicActions } from "viem";
+import { http, publicActions } from "viem";
 
 import { EVMBlockchainIncludingTestnet } from "@crossmint/common-sdk-base";
 
@@ -29,7 +27,7 @@ import erc20 from "../../ABI/ERC20.json";
 import erc721 from "../../ABI/ERC721.json";
 import erc1155 from "../../ABI/ERC1155.json";
 import { CrossmintWalletService } from "../../api/CrossmintWalletService";
-import { TChain, entryPoint, getBundlerRPC, getPaymasterRPC, getViemNetwork } from "../BlockchainNetworks";
+import { TChain, getBundlerRPC, getPaymasterRPC, getViemNetwork } from "../BlockchainNetworks";
 import { ERC20TransferType, SFTTransferType, TransferType } from "../token";
 
 type GasFeeTransactionParams = {
@@ -38,10 +36,8 @@ type GasFeeTransactionParams = {
 };
 
 export class EVMAAWallet extends LoggerWrapper {
-    private sessionKeySignerAddress?: Hex;
     private crossmintService: CrossmintWalletService;
     private publicClient: PublicClient;
-    private ecdsaValidator: KernelValidator<entryPoint, "ECDSAValidator">;
     private account: KernelSmartAccount<EntryPoint, HttpTransport, TChain>;
     private kernelClient: ReturnType<
         typeof createKernelAccountClient<
@@ -59,7 +55,6 @@ export class EVMAAWallet extends LoggerWrapper {
         crossmintService: CrossmintWalletService,
         chain: EVMBlockchainIncludingTestnet,
         publicClient: PublicClient,
-        ecdsaValidator: KernelValidator<entryPoint, "ECDSAValidator">,
         entryPoint: EntryPoint
     ) {
         super("EVMAAWallet", { chain, address: account.address });

--- a/packages/client/wallets/aa/src/types/API.ts
+++ b/packages/client/wallets/aa/src/types/API.ts
@@ -1,7 +1,5 @@
 import { EntryPointVersion } from "permissionless/_types/types";
 
-import { BlockchainIncludingTestnet } from "@crossmint/common-sdk-base";
-
 import { UserIdentifier } from "./Config";
 
 export type StoreAbstractWalletInput = {
@@ -14,14 +12,6 @@ export type StoreAbstractWalletInput = {
     baseLayer: string;
     chainId: number;
     entryPointVersion: EntryPointVersion;
-};
-
-export type GenerateSignatureDataInput = {
-    smartContractWalletAddress: `0x${string}`;
-    sessionKeyData?: string;
-    killSwitchData?: string;
-    chain: BlockchainIncludingTestnet | "evm";
-    version: number;
 };
 
 export type TransferInput = {


### PR DESCRIPTION
## Description

`setCustodianForTokens` in `EVMAAWallet` is not ready for use, and we don't  have plans to support this T. There's no sense exposing it or keeping it within the SDK.

## Test plan

TS Compiling and Existing Tests

Created a new wallet and minted an NFT on the `w3a-main` branch locally (w/ a few small changes to accomidate other changes to the sdk)

<img width="317" alt="Screenshot 2024-05-28 at 6 11 54 PM" src="https://github.com/Crossmint/crossmint-sdk/assets/17352012/09b0f3f5-99c0-4968-86a2-3c514275cbfb">

