### PR TITLE
Simplification: Drop Custodian Session Key Pt. 2

### DIFF
--- a/packages/client/wallets/aa/src/api/CrossmintWalletService.test.ts
+++ b/packages/client/wallets/aa/src/api/CrossmintWalletService.test.ts
@@ -40,19 +40,6 @@ describe("CrossmintService", () => {
         });
     });
 
-    describe("createSessionKey", () => {
-        it("should call fetchCrossmintAPI with correct arguments", async () => {
-            global.fetch = jest.fn().mockResolvedValue({
-                ok: true,
-                json: () => Promise.resolve({}),
-            });
-
-            const address = "test-address";
-            await crossmintService.createSessionKey(address);
-            expect(global.fetch).toHaveBeenCalledWith(expect.any(String), expect.any(Object));
-        });
-    });
-
     afterEach(() => {
         jest.clearAllMocks();
     });

--- a/packages/client/wallets/aa/src/api/CrossmintWalletService.ts
+++ b/packages/client/wallets/aa/src/api/CrossmintWalletService.ts
@@ -7,17 +7,6 @@ import { BaseCrossmintService } from "./BaseCrossmintService";
 export { EVMBlockchainIncludingTestnet } from "@crossmint/common-sdk-base";
 
 export class CrossmintWalletService extends BaseCrossmintService {
-    async createSessionKey(address: string | `0x${string}`) {
-        return this.fetchCrossmintAPI(
-            "unstable/wallets/aa/wallets/sessionkey",
-            {
-                method: "POST",
-                body: JSON.stringify({ address }),
-            },
-            "Error creating the wallet. Please check the configuration parameters"
-        );
-    }
-
     async storeAbstractWallet(input: StoreAbstractWalletInput) {
         return this.fetchCrossmintAPI(
             "unstable/wallets/aa/wallets",

--- a/packages/client/wallets/aa/src/blockchain/wallets/eoa.ts
+++ b/packages/client/wallets/aa/src/blockchain/wallets/eoa.ts
@@ -1,0 +1,60 @@
+import { CrossmintWalletService } from "@/api";
+import { EVMAAWallet } from "@/blockchain";
+import type { UserIdentifier, WalletConfig } from "@/types";
+import { CURRENT_VERSION, ZERO_DEV_TYPE, createOwnerSigner } from "@/utils";
+import { signerToEcdsaValidator } from "@zerodev/ecdsa-validator";
+import { createKernelAccount } from "@zerodev/sdk";
+import { EntryPoint, EntryPointVersion } from "permissionless/types/entrypoint";
+import { HttpTransport, PublicClient } from "viem";
+
+import { EVMBlockchainIncludingTestnet, blockchainToChainId } from "@crossmint/common-sdk-base";
+
+export default class EOAWalletService {
+    constructor(private readonly crossmintService: CrossmintWalletService) {}
+
+    public async getOrCreate({
+        userIdentifier,
+        chain,
+        publicClient,
+        entryPoint,
+        entryPointVersion,
+        walletConfig,
+    }: {
+        userIdentifier: UserIdentifier;
+        chain: EVMBlockchainIncludingTestnet;
+        publicClient: PublicClient<HttpTransport>;
+        entryPoint: EntryPoint;
+        entryPointVersion: EntryPointVersion;
+        walletConfig: WalletConfig;
+    }) {
+        const eoa = await createOwnerSigner({
+            chain,
+            walletConfig,
+        });
+        const ecdsaValidator = await signerToEcdsaValidator(publicClient, {
+            signer: eoa,
+            entryPoint,
+        });
+        const account = await createKernelAccount(publicClient, {
+            plugins: {
+                sudo: ecdsaValidator,
+            },
+            index: BigInt(0),
+            entryPoint,
+        });
+
+        const wallet = new EVMAAWallet(account, this.crossmintService, publicClient, entryPoint, chain);
+        await this.crossmintService.storeAbstractWallet({
+            userIdentifier,
+            type: ZERO_DEV_TYPE,
+            smartContractWalletAddress: account.address,
+            eoaAddress: eoa.address,
+            version: CURRENT_VERSION,
+            baseLayer: "evm",
+            chainId: blockchainToChainId(chain),
+            entryPointVersion,
+        });
+
+        return wallet;
+    }
+}

--- a/packages/client/wallets/aa/src/blockchain/wallets/eoa.ts
+++ b/packages/client/wallets/aa/src/blockchain/wallets/eoa.ts
@@ -48,7 +48,7 @@ export default class EOAWalletService {
             userIdentifier,
             type: ZERO_DEV_TYPE,
             smartContractWalletAddress: account.address,
-            eoaAddress: eoa.address,
+            signerData: { eoaAddress: eoa.address, type: "eoa" },
             version: CURRENT_VERSION,
             baseLayer: "evm",
             chainId: blockchainToChainId(chain),

--- a/packages/client/wallets/aa/src/types/API.ts
+++ b/packages/client/wallets/aa/src/types/API.ts
@@ -6,8 +6,8 @@ export type StoreAbstractWalletInput = {
     userIdentifier: UserIdentifier;
     type: string;
     smartContractWalletAddress: string;
-    eoaAddress: string;
-    sessionKeySignerAddress: string;
+    eoaAddress?: string;
+    sessionKeySignerAddress?: string;
     version: number;
     baseLayer: string;
     chainId: number;

--- a/packages/client/wallets/aa/src/types/API.ts
+++ b/packages/client/wallets/aa/src/types/API.ts
@@ -6,13 +6,18 @@ export type StoreAbstractWalletInput = {
     userIdentifier: UserIdentifier;
     type: string;
     smartContractWalletAddress: string;
-    eoaAddress?: string;
+    signerData: EOASignerData;
     sessionKeySignerAddress?: string;
     version: number;
     baseLayer: string;
     chainId: number;
     entryPointVersion: EntryPointVersion;
 };
+
+export interface EOASignerData {
+    eoaAddress: string;
+    type: "eoa";
+}
 
 export type TransferInput = {
     tokenId: number;

--- a/packages/client/wallets/aa/src/utils/error.ts
+++ b/packages/client/wallets/aa/src/utils/error.ts
@@ -11,31 +11,6 @@ export class NotAuthorizedError extends Error {
     }
 }
 
-export class RateLimitError extends Error {
-    code = "ERROR_RATE_LIMIT";
-    retryAfterMs: number;
-
-    constructor(message: string, retryAfterMs: number) {
-        super(message);
-
-        this.retryAfterMs = retryAfterMs;
-
-        // ES5 workaround
-        Object.setPrototypeOf(this, RateLimitError.prototype);
-    }
-}
-
-export class SignTransactionError extends Error {
-    code = "ERROR_SIGN_TRANSACTION";
-
-    constructor(message: string) {
-        super(message);
-
-        // ES5 workaround
-        Object.setPrototypeOf(this, SignTransactionError.prototype);
-    }
-}
-
 export class TransferError extends Error {
     code = "ERROR_TRANSFER";
 
@@ -66,20 +41,6 @@ export class CrossmintServiceError extends Error {
 
         // ES5 workaround
         Object.setPrototypeOf(this, CrossmintServiceError.prototype);
-    }
-}
-
-/**
- * Generic undefined error
- */
-export class NonCustodialWalletError extends Error {
-    code = "ERROR_UNDEFINED";
-
-    constructor(message: string) {
-        super(message);
-
-        // ES5 workaround
-        Object.setPrototypeOf(this, NonCustodialWalletError.prototype);
     }
 }
 


### PR DESCRIPTION
## Description

This PR:
- Stops session keys from being created with new AA wallets in conjunction with  https://github.com/Paella-Labs/crossbit-main/pull/13254.
    - For these session keys have any effect, the user must sign.
    - We've removed the method to do that from the SDK, since it's not ready yet.
    - When/if we re-enable, we'll include custodial session key (A FB vault on CM Backend) creation within the method, not upon wallet creation.
- In anticipation of passkeys, organizes EOA wallet creation into a `EOAWalletService` class.

## Test plan

TS Compiling + Existing Tests

Will test E2E before merging once the `crossbit-main` PR lands
