### PR TITLE
Simplification: Consolidate Paymaster Pieces

### DIFF
--- a/packages/client/wallets/aa/src/blockchain/BlockchainNetworks.ts
+++ b/packages/client/wallets/aa/src/blockchain/BlockchainNetworks.ts
@@ -1,6 +1,5 @@
 import {
     BUNDLER_RPC,
-    PAYMASTER_RPC,
     PM_BASE_RPC,
     PM_BASE_SEPOLIA_RPC,
     ZD_AMOY_PROJECT_ID,
@@ -22,7 +21,6 @@ import {
 } from "@/utils";
 import { EntryPoint } from "permissionless/types/entrypoint";
 import {
-    Chain,
     arbitrum,
     arbitrumNova,
     arbitrumSepolia,
@@ -289,16 +287,5 @@ export const getBundlerRPC = logInputOutput((chain: EVMBlockchainIncludingTestne
             return BUNDLER_RPC + getZeroDevProjectIdByBlockchain(chain) + "?bundlerProvider=STACKUP";
     }
 }, "getBundlerRPC");
-
-export const getPaymasterRPC = logInputOutput((chain: EVMBlockchainIncludingTestnet) => {
-    switch (chain) {
-        case EVMBlockchainIncludingTestnet.BASE_SEPOLIA:
-            return PM_BASE_SEPOLIA_RPC;
-        case EVMBlockchainIncludingTestnet.BASE:
-            return PM_BASE_RPC;
-        default:
-            return PAYMASTER_RPC + getZeroDevProjectIdByBlockchain(chain) + "?paymasterProvider=STACKUP";
-    }
-}, "getPaymasterRPC");
 
 export type entryPoint = EntryPoint;

--- a/packages/client/wallets/aa/src/blockchain/wallets/EVMAAWallet.ts
+++ b/packages/client/wallets/aa/src/blockchain/wallets/EVMAAWallet.ts
@@ -15,12 +15,7 @@ import { resolveDeferrable } from "@/utils/deferrable";
 import { LoggerWrapper } from "@/utils/log";
 import type { Deferrable } from "@ethersproject/properties";
 import { type TransactionRequest } from "@ethersproject/providers";
-import {
-    KernelAccountClient,
-    KernelSmartAccount,
-    createKernelAccountClient,
-    createZeroDevPaymasterClient,
-} from "@zerodev/sdk";
+import { KernelAccountClient, KernelSmartAccount, createKernelAccountClient } from "@zerodev/sdk";
 import { BigNumberish } from "ethers";
 import { EntryPoint } from "permissionless/types/entrypoint";
 import type { Hash, HttpTransport, PublicClient, TypedDataDefinition } from "viem";
@@ -32,8 +27,9 @@ import erc20 from "../../ABI/ERC20.json";
 import erc721 from "../../ABI/ERC721.json";
 import erc1155 from "../../ABI/ERC1155.json";
 import { CrossmintWalletService } from "../../api/CrossmintWalletService";
-import { getBundlerRPC, getPaymasterRPC, getViemNetwork } from "../BlockchainNetworks";
+import { getBundlerRPC, getViemNetwork } from "../BlockchainNetworks";
 import { ERC20TransferType, SFTTransferType, TransferType } from "../token";
+import { paymasterMiddleware } from "./paymaster";
 
 type GasFeeTransactionParams = {
     maxFeePerGas?: BigNumberish;
@@ -63,21 +59,7 @@ export class EVMAAWallet extends LoggerWrapper {
             chain: getViemNetwork(chain),
             entryPoint,
             bundlerTransport: http(getBundlerRPC(chain)),
-            ...(hasEIP1559Support(chain) && {
-                middleware: {
-                    sponsorUserOperation: async ({ userOperation }) => {
-                        const paymasterClient = createZeroDevPaymasterClient({
-                            chain: getViemNetwork(chain),
-                            transport: http(getPaymasterRPC(chain)),
-                            entryPoint,
-                        });
-                        return paymasterClient.sponsorUserOperation({
-                            userOperation,
-                            entryPoint,
-                        });
-                    },
-                },
-            }),
+            ...(hasEIP1559Support(chain) && paymasterMiddleware({ entryPoint, chain })),
         });
         this.chain = chain;
         this.publicClient = publicClient;

--- a/packages/client/wallets/aa/src/blockchain/wallets/paymaster.ts
+++ b/packages/client/wallets/aa/src/blockchain/wallets/paymaster.ts
@@ -1,0 +1,32 @@
+import { createZeroDevPaymasterClient } from "@zerodev/sdk";
+import { Middleware } from "permissionless/actions/smartAccount";
+import { EntryPoint } from "permissionless/types/entrypoint";
+import { http } from "viem";
+
+import { EVMBlockchainIncludingTestnet } from "@crossmint/common-sdk-base";
+
+import { getPaymasterRPC, getViemNetwork } from "../BlockchainNetworks";
+
+export function paymasterMiddleware({
+    entryPoint,
+    chain,
+}: {
+    entryPoint: EntryPoint;
+    chain: EVMBlockchainIncludingTestnet;
+}): Middleware<EntryPoint> {
+    return {
+        middleware: {
+            sponsorUserOperation: async ({ userOperation }) => {
+                const paymasterClient = createZeroDevPaymasterClient({
+                    chain: getViemNetwork(chain),
+                    transport: http(getPaymasterRPC(chain)),
+                    entryPoint,
+                });
+                return paymasterClient.sponsorUserOperation({
+                    userOperation,
+                    entryPoint,
+                });
+            },
+        },
+    };
+}

--- a/packages/client/wallets/aa/src/blockchain/wallets/paymaster.ts
+++ b/packages/client/wallets/aa/src/blockchain/wallets/paymaster.ts
@@ -1,3 +1,5 @@
+import { PAYMASTER_RPC, PM_BASE_RPC, PM_BASE_SEPOLIA_RPC } from "@/utils";
+import { logInputOutput } from "@/utils/log";
 import { createZeroDevPaymasterClient } from "@zerodev/sdk";
 import { Middleware } from "permissionless/actions/smartAccount";
 import { EntryPoint } from "permissionless/types/entrypoint";
@@ -5,7 +7,18 @@ import { http } from "viem";
 
 import { EVMBlockchainIncludingTestnet } from "@crossmint/common-sdk-base";
 
-import { getPaymasterRPC, getViemNetwork } from "../BlockchainNetworks";
+import { getViemNetwork, getZeroDevProjectIdByBlockchain } from "../BlockchainNetworks";
+
+const getPaymasterRPC = logInputOutput((chain: EVMBlockchainIncludingTestnet) => {
+    switch (chain) {
+        case EVMBlockchainIncludingTestnet.BASE_SEPOLIA:
+            return PM_BASE_SEPOLIA_RPC;
+        case EVMBlockchainIncludingTestnet.BASE:
+            return PM_BASE_RPC;
+        default:
+            return PAYMASTER_RPC + getZeroDevProjectIdByBlockchain(chain) + "?paymasterProvider=STACKUP";
+    }
+}, "getPaymasterRPC");
 
 export function paymasterMiddleware({
     entryPoint,


### PR DESCRIPTION
## Description

This PR:
- moves the paymaster middleware definition outside of the constructor to make `EVMAAWallet` more minimal
- Consolidates paymaster functions into a new `paymaster.ts` file

## Test plan

Locally tested web3auth flow, tx was sponsored as expected.
TS compiling + existing tests