### PR TITLE
Simplification: Drop `SignTypedMessage`

### DIFF
--- a/packages/client/wallets/aa/src/adapters/reservoir.ts
+++ b/packages/client/wallets/aa/src/adapters/reservoir.ts
@@ -16,7 +16,7 @@ export function reservoirAdapter(wallet: EVMAAWallet): ReservoirWallet {
                     signature = await wallet.signMessage(signData.message);
                 } else if (signData.signatureKind === "eip712") {
                     console.log("Execute Steps: Signing with eip712");
-                    signature = await wallet.signTypedData({
+                    signature = await wallet.getSigner("viem").walletClient.signTypedData({
                         domain: signData.domain as any,
                         types: signData.types as any,
                         primaryType: signData.primaryType,

--- a/packages/client/wallets/aa/src/blockchain/wallets/EVMAAWallet.ts
+++ b/packages/client/wallets/aa/src/blockchain/wallets/EVMAAWallet.ts
@@ -23,7 +23,7 @@ import {
 } from "@zerodev/sdk";
 import { BigNumberish } from "ethers";
 import { EntryPoint } from "permissionless/types/entrypoint";
-import type { Hash, HttpTransport, PublicClient, TypedDataDefinition } from "viem";
+import type { Hash, HttpTransport, PublicClient } from "viem";
 import { Chain, http, publicActions } from "viem";
 
 import { EVMBlockchainIncludingTestnet } from "@crossmint/common-sdk-base";
@@ -103,16 +103,6 @@ export class EVMAAWallet extends LoggerWrapper {
                 });
             } catch (error) {
                 throw new Error(`Error signing message. If this error persists, please contact support.`);
-            }
-        });
-    }
-
-    public async signTypedData(params: TypedDataDefinition) {
-        return this.logPerformance("SIGN_TYPED_DATA", async () => {
-            try {
-                return await this.kernelClient.signTypedData(params);
-            } catch (error) {
-                throw new Error(`Error signing typed data. If this error persists, please contact support.`);
             }
         });
     }


### PR DESCRIPTION
## Description

This PR drops `SignTypedMessage`. Rational being:
- Our other high level methods add value in some way, either by having a clearer interface or converting types, etc. `EVMAAWallet.SignTypedMessage` does not, it's just a wrapper over `kernelClient`.
- `SignTypedMessage` should fall under advanced usage that an be done via `getSigner`

## Test plan

TS Compiling & Existing Tests
