### PR TITLE
Simplification: Signer Type

### DIFF
--- a/packages/client/wallets/aa/src/blockchain/wallets/EVMAAWallet.ts
+++ b/packages/client/wallets/aa/src/blockchain/wallets/EVMAAWallet.ts
@@ -1,5 +1,4 @@
 import { logError, logInfo } from "@/services/logging";
-import { SignerMap, SignerType } from "@/types";
 import {
     SCW_SERVICE,
     TransactionError,
@@ -213,7 +212,7 @@ export class EVMAAWallet extends LoggerWrapper {
         });
     }
 
-    public getSigner<Type extends SignerType>(type: Type): SignerMap[Type] {
+    public getSigner(type: "viem" = "viem") {
         switch (type) {
             case "viem": {
                 return {

--- a/packages/client/wallets/aa/src/types/Config.ts
+++ b/packages/client/wallets/aa/src/types/Config.ts
@@ -1,7 +1,5 @@
 import { TORUS_NETWORK_TYPE } from "@web3auth/single-factor-auth";
-import { KernelAccountClient, KernelSmartAccount } from "@zerodev/sdk";
-import { EntryPoint } from "permissionless/_types/types";
-import { Chain, EIP1193Provider, HttpTransport, LocalAccount, PublicClient } from "viem";
+import { EIP1193Provider, LocalAccount } from "viem";
 
 export type CrossmintAASDKInitParams = {
     apiKey: string;
@@ -17,12 +15,6 @@ export type UserIdentifier =
     | { type: "whiteLabel"; userId: string }
     | { type: "email"; email: string }
     | { type: "phoneNumber"; phoneNumber: string };
-
-export type SignerMap = {
-    viem: Client;
-};
-
-export type SignerType = keyof SignerMap;
 
 export type Web3AuthSigner = {
     type: "WEB3_AUTH";
@@ -42,8 +34,3 @@ type Signer = EIP1193Provider | Web3AuthSigner | ViemAccount;
 export interface WalletConfig {
     signer: Signer;
 }
-
-export type Client = {
-    publicClient: PublicClient;
-    walletClient: KernelAccountClient<EntryPoint, HttpTransport, Chain, KernelSmartAccount<EntryPoint, HttpTransport>>;
-};


### PR DESCRIPTION
## Description

To simplify `AAEVMWallet`, given that we only support one signer type atm, this PR:
- Adds a default param, so that SDK consumers can call `getSigner()` and get the `viem` signer by default.
- Removes some types that are overkill for now, but can be added back later w/o breaking the API.

## Test plan

Passkeys QA
TS Compiling & Existing Tests
