### PR TITLE
Simplification: Gelato Bundler Special Case

### DIFF
--- a/packages/client/wallets/aa/src/blockchain/wallets/EVMAAWallet.ts
+++ b/packages/client/wallets/aa/src/blockchain/wallets/EVMAAWallet.ts
@@ -7,15 +7,15 @@ import {
     convertData,
     decorateSendTransactionData,
     errorToJSON,
+    gelatoBundlerProperties,
     getNonce,
-    hasEIP1559Support,
+    usesGelatoBundler,
 } from "@/utils";
 import { resolveDeferrable } from "@/utils/deferrable";
 import { LoggerWrapper } from "@/utils/log";
 import type { Deferrable } from "@ethersproject/properties";
 import { type TransactionRequest } from "@ethersproject/providers";
 import { KernelAccountClient, KernelSmartAccount, createKernelAccountClient } from "@zerodev/sdk";
-import { BigNumberish } from "ethers";
 import { EntryPoint } from "permissionless/types/entrypoint";
 import type { Hash, HttpTransport, PublicClient, TypedDataDefinition } from "viem";
 import { Chain, http, publicActions } from "viem";
@@ -29,11 +29,6 @@ import { CrossmintWalletService } from "../../api/CrossmintWalletService";
 import { getBundlerRPC, getViemNetwork } from "../BlockchainNetworks";
 import { ERC20TransferType, SFTTransferType, TransferType } from "../token";
 import { paymasterMiddleware } from "./paymaster";
-
-type GasFeeTransactionParams = {
-    maxFeePerGas?: BigNumberish;
-    maxPriorityFeePerGas?: BigNumberish;
-};
 
 export class EVMAAWallet extends LoggerWrapper {
     public readonly chain: EVMBlockchainIncludingTestnet;
@@ -58,7 +53,7 @@ export class EVMAAWallet extends LoggerWrapper {
             chain: getViemNetwork(chain),
             entryPoint,
             bundlerTransport: http(getBundlerRPC(chain)),
-            ...(hasEIP1559Support(chain) && paymasterMiddleware({ entryPoint, chain })),
+            ...(!usesGelatoBundler(chain) && paymasterMiddleware({ entryPoint, chain })),
         });
         this.chain = chain;
         this.publicClient = publicClient;
@@ -108,8 +103,7 @@ export class EVMAAWallet extends LoggerWrapper {
         return this.logPerformance("SEND_TRANSACTION", async () => {
             try {
                 const decoratedTransaction = await decorateSendTransactionData(transaction);
-                const { to, value, gasLimit, nonce, data, maxFeePerGas, maxPriorityFeePerGas } =
-                    await resolveDeferrable(decoratedTransaction);
+                const { to, value, gasLimit, nonce, data } = await resolveDeferrable(decoratedTransaction);
 
                 const txParams = {
                     to: to as `0x${string}`,
@@ -117,14 +111,7 @@ export class EVMAAWallet extends LoggerWrapper {
                     gas: gasLimit ? BigInt(gasLimit.toString()) : undefined,
                     nonce: await getNonce(nonce),
                     data: await convertData(data),
-                    ...this.getLegacyTransactionFeesParamsIfApply({ maxFeePerGas, maxPriorityFeePerGas }),
-                    maxFeePerBlobGas: undefined,
-                    blobs: undefined,
-                    blobVersionedHashes: undefined,
-                    kzg: undefined,
-                    sidecars: undefined,
-                    type: undefined,
-                    chain: null,
+                    ...(usesGelatoBundler(this.chain) && gelatoBundlerProperties),
                 };
 
                 logInfo(`[EVMAAWallet - SEND_TRANSACTION] - tx_params: ${JSON.stringify(txParams)}`);
@@ -152,7 +139,7 @@ export class EVMAAWallet extends LoggerWrapper {
                             abi: erc20,
                             functionName: "transfer",
                             args: [toAddress, (config as ERC20TransferType).amount],
-                            ...this.getLegacyTransactionFeesParamsIfApply(),
+                            ...(usesGelatoBundler(this.chain) && gelatoBundlerProperties),
                         });
                         transaction = await publicClient.writeContract(request);
                         break;
@@ -165,7 +152,7 @@ export class EVMAAWallet extends LoggerWrapper {
                             abi: erc1155,
                             functionName: "safeTransferFrom",
                             args: [this.getAddress(), toAddress, tokenId, (config as SFTTransferType).quantity, "0x00"],
-                            ...this.getLegacyTransactionFeesParamsIfApply(),
+                            ...(usesGelatoBundler(this.chain) && gelatoBundlerProperties),
                         });
                         transaction = await publicClient.writeContract(request);
                         break;
@@ -178,7 +165,7 @@ export class EVMAAWallet extends LoggerWrapper {
                             abi: erc721,
                             functionName: "safeTransferFrom",
                             args: [this.getAddress(), toAddress, tokenId],
-                            ...this.getLegacyTransactionFeesParamsIfApply(),
+                            ...(usesGelatoBundler(this.chain) && gelatoBundlerProperties),
                         });
                         transaction = await publicClient.writeContract(request);
                         break;
@@ -233,29 +220,5 @@ export class EVMAAWallet extends LoggerWrapper {
         return this.logPerformance("GET_NFTS", async () => {
             return this.crossmintService.fetchNFTs(this.account.address, this.chain);
         });
-    }
-
-    private getLegacyTransactionFeesParamsIfApply(gasFeeParams?: GasFeeTransactionParams) {
-        const { maxFeePerGas, maxPriorityFeePerGas } = gasFeeParams ?? {};
-
-        if (hasEIP1559Support(this.chain)) {
-            return {
-                // only include if non-null and non-zero
-                ...(maxFeePerGas && { maxFeePerGas: BigInt(maxFeePerGas.toString()) }),
-                ...(maxPriorityFeePerGas && { maxPriorityFeePerGas: BigInt(maxPriorityFeePerGas.toString()) }),
-            };
-        } else {
-            if (maxFeePerGas || maxPriorityFeePerGas) {
-                console.warn(
-                    "maxFeePerGas and maxPriorityFeePerGas are not supported on this chain as it supports Legacy Transacitons. Ignoring them."
-                );
-            }
-            return {
-                // It's on zerodev doc that we need to ignore ts errros on maxFeePerGas and maxPriorityFeePerGas
-                // https://docs.zerodev.app/sdk/faqs/use-with-gelato#transaction-configuration
-                maxFeePerGas: "0x0" as any,
-                maxPriorityFeePerGas: "0x0" as any,
-            };
-        }
     }
 }

--- a/packages/client/wallets/aa/src/utils/blockchain.ts
+++ b/packages/client/wallets/aa/src/utils/blockchain.ts
@@ -78,7 +78,9 @@ export async function verifyMessage({ address, message, signature, chain }: Veri
 function isPolygonCDK(chain: EVMBlockchainIncludingTestnet) {
     const polygonCDKchains: EVMBlockchainIncludingTestnet[] = [
         EVMBlockchainIncludingTestnet.ZKYOTO,
+        EVMBlockchainIncludingTestnet.ZKATANA,
         EVMBlockchainIncludingTestnet.ASTAR_ZKEVM,
+        EVMBlockchainIncludingTestnet.HYPERSONIC_TESTNET,
     ];
     return polygonCDKchains.includes(chain);
 }

--- a/packages/client/wallets/aa/src/utils/blockchain.ts
+++ b/packages/client/wallets/aa/src/utils/blockchain.ts
@@ -83,6 +83,10 @@ function isPolygonCDK(chain: EVMBlockchainIncludingTestnet) {
     return polygonCDKchains.includes(chain);
 }
 
+export function hasEIP1559Support(chain: EVMBlockchainIncludingTestnet) {
+    return !isPolygonCDK(chain);
+}
+
 export function usesGelatoBundler(chain: EVMBlockchainIncludingTestnet) {
     return isPolygonCDK(chain);
 }

--- a/packages/client/wallets/aa/src/utils/blockchain.ts
+++ b/packages/client/wallets/aa/src/utils/blockchain.ts
@@ -75,10 +75,23 @@ export async function verifyMessage({ address, message, signature, chain }: Veri
     });
 }
 
-export function hasEIP1559Support(chain: EVMBlockchainIncludingTestnet) {
-    const chainsNotSupportingEIP1559: EVMBlockchainIncludingTestnet[] = [
+function isPolygonCDK(chain: EVMBlockchainIncludingTestnet) {
+    const polygonCDKchains: EVMBlockchainIncludingTestnet[] = [
         EVMBlockchainIncludingTestnet.ZKYOTO,
         EVMBlockchainIncludingTestnet.ASTAR_ZKEVM,
     ];
-    return !chainsNotSupportingEIP1559.includes(chain);
+    return polygonCDKchains.includes(chain);
 }
+
+export function usesGelatoBundler(chain: EVMBlockchainIncludingTestnet) {
+    return isPolygonCDK(chain);
+}
+
+/*
+ * Chain that ZD uses Gelato as for bundler require special parameters:
+ * https://docs.zerodev.app/sdk/faqs/use-with-gelato#transaction-configuration
+ */
+export const gelatoBundlerProperties = {
+    maxFeePerGas: "0x0" as any,
+    maxPriorityFeePerGas: "0x0" as any,
+};


### PR DESCRIPTION
## Description

For certain chains, Zerodev uses Gelato to send transactions. If that's the case, we need to provide:

```TypeScript
...{
    maxFeePerGas: "0x0"
    maxPriorityFeePerGas: "0x0"
}
```

Within transaction and userOp parameters. [source](https://docs.zerodev.app/sdk/faqs/use-with-gelato#transaction-configuration)

Somewhere along the way EIP1559 may have been conflated w/ the Gelato situation, coincidentally, this has worked fine so far because polygon CDK chains, which ZD uses Gelato for, don't support 1559. This PR clarifies this logic, which is useful for other things I'm working on.

## Test plan

Locally, I confirmed that the package still works on the demo repo on branch `main-w3a` by signing in and minting

Passkey Release QA, which will include testing polygon CDK chains.
TS Compiling & Existing Tests.
