### PR TITLE
Simplification: Smart Account Client Handling & Types

### DIFF
--- a/packages/client/wallets/aa/src/blockchain/wallets/EVMAAWallet.ts
+++ b/packages/client/wallets/aa/src/blockchain/wallets/EVMAAWallet.ts
@@ -7,15 +7,15 @@ import {
     convertData,
     decorateSendTransactionData,
     errorToJSON,
+    gelatoBundlerProperties,
     getNonce,
-    hasEIP1559Support,
+    usesGelatoBundler,
 } from "@/utils";
 import { resolveDeferrable } from "@/utils/deferrable";
 import { LoggerWrapper } from "@/utils/log";
 import type { Deferrable } from "@ethersproject/properties";
 import { type TransactionRequest } from "@ethersproject/providers";
 import { KernelAccountClient, KernelSmartAccount, createKernelAccountClient } from "@zerodev/sdk";
-import { BigNumberish } from "ethers";
 import { EntryPoint } from "permissionless/types/entrypoint";
 import type { Hash, HttpTransport, PublicClient, TypedDataDefinition } from "viem";
 import { Chain, http, publicActions } from "viem";
@@ -29,11 +29,6 @@ import { CrossmintWalletService } from "../../api/CrossmintWalletService";
 import { getBundlerRPC, getViemNetwork } from "../BlockchainNetworks";
 import { ERC20TransferType, SFTTransferType, TransferType } from "../token";
 import { paymasterMiddleware } from "./paymaster";
-
-type GasFeeTransactionParams = {
-    maxFeePerGas?: BigNumberish;
-    maxPriorityFeePerGas?: BigNumberish;
-};
 
 export class EVMAAWallet extends LoggerWrapper {
     public readonly chain: EVMBlockchainIncludingTestnet;
@@ -58,7 +53,7 @@ export class EVMAAWallet extends LoggerWrapper {
             chain: getViemNetwork(chain),
             entryPoint,
             bundlerTransport: http(getBundlerRPC(chain)),
-            ...(hasEIP1559Support(chain) && paymasterMiddleware({ entryPoint, chain })),
+            ...(!usesGelatoBundler(chain) && paymasterMiddleware({ entryPoint, chain })),
         });
         this.chain = chain;
         this.publicClient = publicClient;
@@ -108,8 +103,7 @@ export class EVMAAWallet extends LoggerWrapper {
         return this.logPerformance("SEND_TRANSACTION", async () => {
             try {
                 const decoratedTransaction = await decorateSendTransactionData(transaction);
-                const { to, value, gasLimit, nonce, data, maxFeePerGas, maxPriorityFeePerGas } =
-                    await resolveDeferrable(decoratedTransaction);
+                const { to, value, gasLimit, nonce, data } = await resolveDeferrable(decoratedTransaction);
 
                 const txParams = {
                     to: to as `0x${string}`,
@@ -117,14 +111,7 @@ export class EVMAAWallet extends LoggerWrapper {
                     gas: gasLimit ? BigInt(gasLimit.toString()) : undefined,
                     nonce: await getNonce(nonce),
                     data: await convertData(data),
-                    ...this.getLegacyTransactionFeesParamsIfApply({ maxFeePerGas, maxPriorityFeePerGas }),
-                    maxFeePerBlobGas: undefined,
-                    blobs: undefined,
-                    blobVersionedHashes: undefined,
-                    kzg: undefined,
-                    sidecars: undefined,
-                    type: undefined,
-                    chain: null,
+                    ...(usesGelatoBundler(this.chain) && gelatoBundlerProperties),
                 };
 
                 logInfo(`[EVMAAWallet - SEND_TRANSACTION] - tx_params: ${JSON.stringify(txParams)}`);
@@ -152,7 +139,7 @@ export class EVMAAWallet extends LoggerWrapper {
                             abi: erc20,
                             functionName: "transfer",
                             args: [toAddress, (config as ERC20TransferType).amount],
-                            ...this.getLegacyTransactionFeesParamsIfApply(),
+                            ...(usesGelatoBundler(this.chain) && gelatoBundlerProperties),
                         });
                         transaction = await publicClient.writeContract(request);
                         break;
@@ -165,7 +152,7 @@ export class EVMAAWallet extends LoggerWrapper {
                             abi: erc1155,
                             functionName: "safeTransferFrom",
                             args: [this.getAddress(), toAddress, tokenId, (config as SFTTransferType).quantity, "0x00"],
-                            ...this.getLegacyTransactionFeesParamsIfApply(),
+                            ...(usesGelatoBundler(this.chain) && gelatoBundlerProperties),
                         });
                         transaction = await publicClient.writeContract(request);
                         break;
@@ -178,7 +165,7 @@ export class EVMAAWallet extends LoggerWrapper {
                             abi: erc721,
                             functionName: "safeTransferFrom",
                             args: [this.getAddress(), toAddress, tokenId],
-                            ...this.getLegacyTransactionFeesParamsIfApply(),
+                            ...(usesGelatoBundler(this.chain) && gelatoBundlerProperties),
                         });
                         transaction = await publicClient.writeContract(request);
                         break;
@@ -233,29 +220,5 @@ export class EVMAAWallet extends LoggerWrapper {
         return this.logPerformance("GET_NFTS", async () => {
             return this.crossmintService.fetchNFTs(this.account.address, this.chain);
         });
-    }
-
-    private getLegacyTransactionFeesParamsIfApply(gasFeeParams?: GasFeeTransactionParams) {
-        const { maxFeePerGas, maxPriorityFeePerGas } = gasFeeParams ?? {};
-
-        if (hasEIP1559Support(this.chain)) {
-            return {
-                // only include if non-null and non-zero
-                ...(maxFeePerGas && { maxFeePerGas: BigInt(maxFeePerGas.toString()) }),
-                ...(maxPriorityFeePerGas && { maxPriorityFeePerGas: BigInt(maxPriorityFeePerGas.toString()) }),
-            };
-        } else {
-            if (maxFeePerGas || maxPriorityFeePerGas) {
-                console.warn(
-                    "maxFeePerGas and maxPriorityFeePerGas are not supported on this chain as it supports Legacy Transacitons. Ignoring them."
-                );
-            }
-            return {
-                // It's on zerodev doc that we need to ignore ts errros on maxFeePerGas and maxPriorityFeePerGas
-                // https://docs.zerodev.app/sdk/faqs/use-with-gelato#transaction-configuration
-                maxFeePerGas: "0x0" as any,
-                maxPriorityFeePerGas: "0x0" as any,
-            };
-        }
     }
 }

--- a/packages/client/wallets/aa/src/blockchain/wallets/EVMAAWallet.ts
+++ b/packages/client/wallets/aa/src/blockchain/wallets/EVMAAWallet.ts
@@ -19,6 +19,7 @@ import { type TransactionRequest } from "@ethersproject/providers";
 import { KernelAccountClient, KernelSmartAccount, createKernelAccountClient } from "@zerodev/sdk";
 import { BigNumberish } from "ethers";
 import { SmartAccountClient } from "permissionless";
+import { SmartAccount } from "permissionless/accounts";
 import { EntryPoint } from "permissionless/types/entrypoint";
 import type { Hash, HttpTransport, PublicClient, TypedDataDefinition } from "viem";
 import { Chain, http, publicActions } from "viem";
@@ -213,7 +214,7 @@ export class EVMAAWallet extends LoggerWrapper {
 
     public getSigner(type: "viem" = "viem"): {
         publicClient: PublicClient;
-        walletClient: SmartAccountClient<EntryPoint, HttpTransport, Chain>;
+        walletClient: SmartAccountClient<EntryPoint, HttpTransport, Chain, SmartAccount<EntryPoint>>;
     } {
         switch (type) {
             case "viem": {

--- a/packages/client/wallets/aa/src/blockchain/wallets/EVMAAWallet.ts
+++ b/packages/client/wallets/aa/src/blockchain/wallets/EVMAAWallet.ts
@@ -18,6 +18,7 @@ import type { Deferrable } from "@ethersproject/properties";
 import { type TransactionRequest } from "@ethersproject/providers";
 import { KernelAccountClient, KernelSmartAccount, createKernelAccountClient } from "@zerodev/sdk";
 import { BigNumberish } from "ethers";
+import { SmartAccountClient } from "permissionless";
 import { EntryPoint } from "permissionless/types/entrypoint";
 import type { Hash, HttpTransport, PublicClient, TypedDataDefinition } from "viem";
 import { Chain, http, publicActions } from "viem";
@@ -31,11 +32,12 @@ import { CrossmintWalletService } from "../../api/CrossmintWalletService";
 import { getBundlerRPC, getViemNetwork } from "../BlockchainNetworks";
 import { ERC20TransferType, SFTTransferType, TransferType } from "../token";
 import { paymasterMiddleware } from "./paymaster";
+import { toCrossmintSmartAccountClient } from "./smartAccount";
 
 export class EVMAAWallet extends LoggerWrapper {
     public readonly chain: EVMBlockchainIncludingTestnet;
     public readonly publicClient: PublicClient;
-    private readonly kernelClient: KernelAccountClient<
+    private readonly smartAccountClient: KernelAccountClient<
         EntryPoint,
         HttpTransport,
         Chain,
@@ -50,19 +52,30 @@ export class EVMAAWallet extends LoggerWrapper {
         chain: EVMBlockchainIncludingTestnet
     ) {
         super("EVMAAWallet", { chain, address: account.address });
-        this.kernelClient = createKernelAccountClient({
+
+        const kernelClient: KernelAccountClient<
+            EntryPoint,
+            HttpTransport,
+            Chain,
+            KernelSmartAccount<EntryPoint, HttpTransport>
+        > = createKernelAccountClient({
             account,
             chain: getViemNetwork(chain),
             entryPoint,
             bundlerTransport: http(getBundlerRPC(chain)),
             ...(!usesGelatoBundler(chain) && paymasterMiddleware({ entryPoint, chain })),
         });
+
+        this.smartAccountClient = toCrossmintSmartAccountClient({
+            smartAccountClient: kernelClient,
+            crossmintChain: chain,
+        });
         this.chain = chain;
         this.publicClient = publicClient;
     }
 
     public getAddress() {
-        return this.kernelClient.account.address;
+        return this.smartAccountClient.account.address;
     }
 
     public async signMessage(message: string | Uint8Array) {
@@ -76,7 +89,7 @@ export class EVMAAWallet extends LoggerWrapper {
                     messageAsString = message;
                 }
 
-                return await this.kernelClient.signMessage({
+                return await this.smartAccountClient.signMessage({
                     message: messageAsString,
                 });
             } catch (error) {
@@ -87,11 +100,7 @@ export class EVMAAWallet extends LoggerWrapper {
 
     public async signTypedData(params: TypedDataDefinition) {
         return this.logPerformance("SIGN_TYPED_DATA", async () => {
-            try {
-                return await this.kernelClient.signTypedData(params);
-            } catch (error) {
-                throw new Error(`Error signing typed data. If this error persists, please contact support.`);
-            }
+            return await this.smartAccountClient.signTypedData(params);
         });
     }
 
@@ -119,7 +128,7 @@ export class EVMAAWallet extends LoggerWrapper {
 
                 logInfo(`[EVMAAWallet - SEND_TRANSACTION] - tx_params: ${JSON.stringify(txParams)}`);
 
-                return await this.kernelClient.sendTransaction(txParams);
+                return await this.smartAccountClient.sendTransaction(txParams);
             } catch (error) {
                 throw new TransactionError(`Error sending transaction: ${error}`);
             }
@@ -130,7 +139,7 @@ export class EVMAAWallet extends LoggerWrapper {
         return this.logPerformance("TRANSFER", async () => {
             const evmToken = config.token;
             const contractAddress = evmToken.contractAddress as `0x${string}`;
-            const publicClient = this.kernelClient.extend(publicActions);
+            const publicClient = this.smartAccountClient.extend(publicActions);
             let transaction;
             let tokenId;
             try {
@@ -202,12 +211,15 @@ export class EVMAAWallet extends LoggerWrapper {
         });
     }
 
-    public getSigner(type: "viem" = "viem") {
+    public getSigner(type: "viem" = "viem"): {
+        publicClient: PublicClient;
+        walletClient: SmartAccountClient<EntryPoint, HttpTransport, Chain>;
+    } {
         switch (type) {
             case "viem": {
                 return {
                     publicClient: this.publicClient,
-                    walletClient: this.kernelClient,
+                    walletClient: this.smartAccountClient,
                 };
             }
             default:

--- a/packages/client/wallets/aa/src/blockchain/wallets/smartAccount.ts
+++ b/packages/client/wallets/aa/src/blockchain/wallets/smartAccount.ts
@@ -1,0 +1,49 @@
+import { logInfo } from "@/services/logging";
+import { gelatoBundlerProperties, usesGelatoBundler } from "@/utils";
+import { SmartAccountClient } from "permissionless";
+import { EntryPoint } from "permissionless/types/entrypoint";
+
+import { EVMBlockchainIncludingTestnet } from "@crossmint/common-sdk-base";
+
+export function toCrossmintSmartAccountClient<Client extends SmartAccountClient<EntryPoint>>({
+    crossmintChain,
+    smartAccountClient,
+}: {
+    crossmintChain: EVMBlockchainIncludingTestnet;
+    smartAccountClient: Client;
+}): Client {
+    return {
+        ...smartAccountClient,
+        async signMessage(args) {
+            try {
+                return await smartAccountClient.signMessage(args);
+            } catch (error) {
+                throw new Error(`Error signing message. If this error persists, please contact support.`);
+            }
+        },
+        async signTypedData(data) {
+            try {
+                return smartAccountClient.signTypedData(data);
+            } catch (error) {
+                throw new Error(`Error signing typed data. If this error persists, please contact support.`);
+            }
+        },
+        async sendTransaction(txn) {
+            txn = {
+                ...txn,
+                ...(usesGelatoBundler(crossmintChain) && gelatoBundlerProperties),
+            };
+            logInfo(`[CrossmintSmartWallet.sendTransaction] - params: ${JSON.stringify(txn)}`);
+            return smartAccountClient.sendTransaction(txn);
+        },
+        async sendUserOperation({ userOperation, middleware, account }) {
+            userOperation = {
+                ...userOperation,
+                ...(usesGelatoBundler(crossmintChain) && gelatoBundlerProperties),
+            };
+
+            logInfo(`[CrossmintSmartWallet.sendUserOperation] - params: ${{ userOperation, middleware, account }}`);
+            return smartAccountClient.sendUserOperation({ userOperation, middleware, account });
+        },
+    };
+}

--- a/packages/client/wallets/aa/src/utils/blockchain.ts
+++ b/packages/client/wallets/aa/src/utils/blockchain.ts
@@ -78,7 +78,9 @@ export async function verifyMessage({ address, message, signature, chain }: Veri
 function isPolygonCDK(chain: EVMBlockchainIncludingTestnet) {
     const polygonCDKchains: EVMBlockchainIncludingTestnet[] = [
         EVMBlockchainIncludingTestnet.ZKYOTO,
+        EVMBlockchainIncludingTestnet.ZKATANA,
         EVMBlockchainIncludingTestnet.ASTAR_ZKEVM,
+        EVMBlockchainIncludingTestnet.HYPERSONIC_TESTNET,
     ];
     return polygonCDKchains.includes(chain);
 }

--- a/packages/client/wallets/aa/src/utils/blockchain.ts
+++ b/packages/client/wallets/aa/src/utils/blockchain.ts
@@ -83,6 +83,10 @@ function isPolygonCDK(chain: EVMBlockchainIncludingTestnet) {
     return polygonCDKchains.includes(chain);
 }
 
+export function hasEIP1559Support(chain: EVMBlockchainIncludingTestnet) {
+    return !isPolygonCDK(chain);
+}
+
 export function usesGelatoBundler(chain: EVMBlockchainIncludingTestnet) {
     return isPolygonCDK(chain);
 }

--- a/packages/client/wallets/aa/src/utils/blockchain.ts
+++ b/packages/client/wallets/aa/src/utils/blockchain.ts
@@ -75,10 +75,23 @@ export async function verifyMessage({ address, message, signature, chain }: Veri
     });
 }
 
-export function hasEIP1559Support(chain: EVMBlockchainIncludingTestnet) {
-    const chainsNotSupportingEIP1559: EVMBlockchainIncludingTestnet[] = [
+function isPolygonCDK(chain: EVMBlockchainIncludingTestnet) {
+    const polygonCDKchains: EVMBlockchainIncludingTestnet[] = [
         EVMBlockchainIncludingTestnet.ZKYOTO,
         EVMBlockchainIncludingTestnet.ASTAR_ZKEVM,
     ];
-    return !chainsNotSupportingEIP1559.includes(chain);
+    return polygonCDKchains.includes(chain);
 }
+
+export function usesGelatoBundler(chain: EVMBlockchainIncludingTestnet) {
+    return isPolygonCDK(chain);
+}
+
+/*
+ * Chain that ZD uses Gelato as for bundler require special parameters:
+ * https://docs.zerodev.app/sdk/faqs/use-with-gelato#transaction-configuration
+ */
+export const gelatoBundlerProperties = {
+    maxFeePerGas: "0x0" as any,
+    maxPriorityFeePerGas: "0x0" as any,
+};


### PR DESCRIPTION
## Description

Context here is that we're in the process of minimizing our API surface, including removing the redundant methods:
- `EVMAAWallet.sendTransaction`
- `EVMAAWallet.signMessage`
- `EVMAAWallet.signTypedData`
In favor of letting developers using a `walletClient` we expose directly instead.

In order to completely replace these methods, we need to add some error handling & logging to the `walletClient` we expose. This PR:
- Creates a minimal wrapper over `SmartAccountClient` to show how we'll do this
- Updates `getSigner` to return a `SmartAccountClient` rather than a `KernelAccountClient` since our API should aim not to expose provider specific types.

Within the PRs that remove the methods I mention above, we'll replace any functionality within this wrapper.

## Test plan

Local Testing on SCW Demo on branch `main-w3a`:
- Confirmed that the pieces added in `toCrossmintSmartAccountClient` used within `EVMAAWallet` are working as expected by checking additional logs.
- Confirmed that minting still works.

Passkey Release QA.
TS Compiling & Existing Tests.
