### PR TITLE
Passkeys Release: Core SDK Updates

### DIFF
--- a/packages/client/wallets/aa/src/CrossmintAASDK.test.ts
+++ b/packages/client/wallets/aa/src/CrossmintAASDK.test.ts
@@ -9,7 +9,8 @@ jest.mock("@/utils");
 describe("CrossmintAASDK", () => {
     let sdk: SmartWalletSDK;
     const mockInitParams: SmartWalletSDKInitParams = {
-        apiKey: "sk_staging_A4vDwAp4t5az6fVQMpQK6qapBnAqgpxrrD35TaFQnyKgxehNbd959uZeaHjNCadWDXrgLRAK1CxeasZjtYEq4TbFkKMBBvbQ9oinAxQf8LbHsSYW2DMzT8fBko3YGLq9t7ZiXZjmgkTioxGVUUjyLtWLeBKwNUDLgpshWjaoR7pKRnSE9SqhwjQbiK62VKiBTdA3KvHsyG9k8mLMcKrDyfXp",
+        clientApiKey:
+            "sk_staging_A4vDwAp4t5az6fVQMpQK6qapBnAqgpxrrD35TaFQnyKgxehNbd959uZeaHjNCadWDXrgLRAK1CxeasZjtYEq4TbFkKMBBvbQ9oinAxQf8LbHsSYW2DMzT8fBko3YGLq9t7ZiXZjmgkTioxGVUUjyLtWLeBKwNUDLgpshWjaoR7pKRnSE9SqhwjQbiK62VKiBTdA3KvHsyG9k8mLMcKrDyfXp",
     };
 
     beforeEach(() => {

--- a/packages/client/wallets/aa/src/SmartWalletSDK.ts
+++ b/packages/client/wallets/aa/src/SmartWalletSDK.ts
@@ -18,17 +18,20 @@ export class SmartWalletSDK extends LoggerWrapper {
 
     private constructor(config: SmartWalletSDKInitParams) {
         super("SmartWalletSDK");
-        const validationResult = validateAPIKey(config.apiKey);
-        if (!validationResult.isValid) {
-            throw new Error("API key invalid");
-        }
-
-        this.crossmintService = new CrossmintWalletService(config.apiKey);
+        this.crossmintService = new CrossmintWalletService(config.clientApiKey);
         this.eaoWalletService = new EOAWalletService(this.crossmintService);
     }
 
-    static init(params: SmartWalletSDKInitParams): SmartWalletSDK {
-        return new SmartWalletSDK(params);
+    /**
+     * Initializes the SDK with the **client side** API key obtained from the Crossmint console.
+     * @throws error if the api key is not formatted correctly.
+     */
+    static init(config: SmartWalletSDKInitParams): SmartWalletSDK {
+        const validationResult = validateAPIKey(config.clientApiKey);
+        if (!validationResult.isValid) {
+            throw new Error("API key invalid");
+        }
+        return new SmartWalletSDK(config);
     }
 
     async getOrCreateWallet(

--- a/packages/client/wallets/aa/src/blockchain/wallets/EVMSmartWallet.ts
+++ b/packages/client/wallets/aa/src/blockchain/wallets/EVMSmartWallet.ts
@@ -49,16 +49,15 @@ export class EVMSmartWallet extends LoggerWrapper {
         private readonly crossmintService: CrossmintWalletService,
         account: KernelSmartAccount<EntryPoint, HttpTransport>,
         publicClient: PublicClient<HttpTransport>,
-        entryPoint: EntryPoint,
         chain: EVMBlockchainIncludingTestnet
     ) {
         super("EVMSmartWallet", { chain, address: account.address });
         const kernelParams = {
             account,
             chain: getViemNetwork(chain),
-            entryPoint,
+            entryPoint: account.entryPoint,
             bundlerTransport: http(getBundlerRPC(chain)),
-            ...(usePaymaster(chain) && paymasterMiddleware({ entryPoint, chain })),
+            ...(usePaymaster(chain) && paymasterMiddleware({ entryPoint: account.entryPoint, chain })),
         };
 
         this.kernel = toCrossmintSmartAccountClient({

--- a/packages/client/wallets/aa/src/blockchain/wallets/EVMSmartWallet.ts
+++ b/packages/client/wallets/aa/src/blockchain/wallets/EVMSmartWallet.ts
@@ -16,6 +16,10 @@ import { TransferType, transferParams } from "../token/transfer";
 import { paymasterMiddleware, usePaymaster } from "./paymaster";
 import { toCrossmintSmartAccountClient } from "./smartAccount";
 
+/**
+ * Smart wallet interface for EVM chains enhanced with Crossmint capabilities.
+ * Core functionality is exposed via [viem](https://viem.sh/) clients within the `client` property of the class.
+ */
 export class EVMSmartWallet extends LoggerWrapper {
     public readonly chain: EVMBlockchainIncludingTestnet;
 
@@ -68,10 +72,16 @@ export class EVMSmartWallet extends LoggerWrapper {
         };
     }
 
+    /**
+     * The address of the smart wallet.
+     */
     public get address() {
         return this.kernel.account.address;
     }
 
+    /**
+     * @returns The transaction hash.
+     */
     public async transfer(toAddress: string, config: TransferType): Promise<string> {
         return this.logPerformance("TRANSFER", async () => {
             if (this.chain !== config.token.chain) {
@@ -115,7 +125,10 @@ export class EVMSmartWallet extends LoggerWrapper {
         });
     }
 
-    public async getNFTs() {
+    /**
+     * @returns A list of NFTs owned by the wallet.
+     */
+    public async nfts() {
         return this.logPerformance("GET_NFTS", async () => {
             return this.crossmintService.fetchNFTs(this.kernel.account.address, this.chain);
         });

--- a/packages/client/wallets/aa/src/blockchain/wallets/eoa.ts
+++ b/packages/client/wallets/aa/src/blockchain/wallets/eoa.ts
@@ -43,7 +43,7 @@ export default class EOAWalletService {
             entryPoint,
         });
 
-        const wallet = new EVMSmartWallet(this.crossmintService, account, publicClient, entryPoint, chain);
+        const wallet = new EVMSmartWallet(this.crossmintService, account, publicClient, chain);
         await this.crossmintService.storeAbstractWallet({
             userIdentifier,
             type: ZERO_DEV_TYPE,

--- a/packages/client/wallets/aa/src/types/Config.ts
+++ b/packages/client/wallets/aa/src/types/Config.ts
@@ -2,7 +2,7 @@ import { TORUS_NETWORK_TYPE } from "@web3auth/single-factor-auth";
 import { EIP1193Provider, LocalAccount } from "viem";
 
 export type SmartWalletSDKInitParams = {
-    apiKey: string;
+    clientApiKey: string;
 };
 
 export type UserIdentifierParams = {


### PR DESCRIPTION
## Description

This PR makes a couple adjustments according to the latest iteration of our SDK design:
- Renames `getNFTs` to `nfts` on the `EVMSmartWallet` class
- Update SDK init parameter type, renaming the property `apiKey` to `clientApiKey`
- Adds a few jsdoc comments

## Test plan

Passkey Release QA
TS Compiling & Existing Tests
