### PR TITLE
Simplification: Drop `web3` Dependency.

### DIFF
--- a/packages/client/wallets/aa/package.json
+++ b/packages/client/wallets/aa/package.json
@@ -12,8 +12,7 @@
         "email-validator": "2.0.4",
         "libphonenumber-js": "1.10.44",
         "permissionless": "0.1.29",
-        "viem": "2.13.1",
-        "web3": "4.5.0"
+        "viem": "2.13.1"
     },
     "devDependencies": {
         "@playwright/test": "^1.41.2",

--- a/packages/client/wallets/aa/src/utils/signer.ts
+++ b/packages/client/wallets/aa/src/utils/signer.ts
@@ -63,13 +63,9 @@ export const createOwnerSigner = logInputOutput(
                 throw new WalletSdkError("Web3auth returned a null signer");
             }
 
-            const web3 = new Web3(provider);
-            const [address] = await web3.eth.getAccounts();
-            return await providerToSmartAccountSigner(provider as EIP1193Provider, { signerAddress: address as Hex });
+            return await providerToSmartAccountSigner(provider as EIP1193Provider);
         } else if (isEIP1193Provider(walletConfig.signer)) {
-            const web3 = new Web3(walletConfig.signer);
-            const [address] = await web3.eth.getAccounts();
-            return await providerToSmartAccountSigner(walletConfig.signer, { signerAddress: address as Hex });
+            return await providerToSmartAccountSigner(walletConfig.signer);
         } else if (isAccount(walletConfig.signer)) {
             return walletConfig.signer.account;
         } else {


### PR DESCRIPTION
## Description

We're importing a huge package to wrap the `IProvider` that `web3auth` gives us, but it's not needed! This PR:
- Fixes that
- Drops `web3` from our deps

## Test plan

Manually, within the SCW_DEMO repo, on a fork of the `main-w3a` branch that accommodates the latest SDK changes, I:
- Signed in and minted an NFT.
- Confirmed the address of the signer.