### PR TITLE
Simplification: SDK Surface Audit 1

### DIFF
--- a/packages/client/wallets/aa/src/api/BaseCrossmintService.ts
+++ b/packages/client/wallets/aa/src/api/BaseCrossmintService.ts
@@ -1,8 +1,7 @@
-import { CrossmintServiceError } from "@/utils/error";
-
 import { validateAPIKey } from "@crossmint/common-sdk-base";
 
-import { CROSSMINT_DEV_URL, CROSSMINT_PROD_URL, CROSSMINT_STG_URL } from "../utils";
+import { CROSSMINT_DEV_URL, CROSSMINT_PROD_URL, CROSSMINT_STG_URL } from "../utils/constants";
+import { CrossmintServiceError } from "../utils/error";
 import { LoggerWrapper, logPerformance } from "../utils/log";
 
 export abstract class BaseCrossmintService extends LoggerWrapper {

--- a/packages/client/wallets/aa/src/api/CrossmintWalletService.test.ts
+++ b/packages/client/wallets/aa/src/api/CrossmintWalletService.test.ts
@@ -1,4 +1,4 @@
-import { CROSSMINT_STG_URL } from "../utils";
+import { CROSSMINT_STG_URL } from "../utils/constants";
 import { CrossmintWalletService } from "./CrossmintWalletService";
 
 jest.mock("../services/logging", () => ({

--- a/packages/client/wallets/aa/src/blockchain/BlockchainNetworks.ts
+++ b/packages/client/wallets/aa/src/blockchain/BlockchainNetworks.ts
@@ -18,7 +18,7 @@ import {
     ZD_SEPOLIA_PROJECT_ID,
     ZD_ZKATANA_PROJECT_ID,
     ZD_ZKYOTO_PROJECT_ID,
-} from "@/utils";
+} from "@/utils/constants";
 import {
     arbitrum,
     arbitrumNova,

--- a/packages/client/wallets/aa/src/blockchain/wallets/EVMSmartWallet.ts
+++ b/packages/client/wallets/aa/src/blockchain/wallets/EVMSmartWallet.ts
@@ -1,5 +1,6 @@
 import { logError } from "@/services/logging";
-import { SCW_SERVICE, TransferError, errorToJSON } from "@/utils";
+import { TransferError, errorToJSON } from "@/utils";
+import { SCW_SERVICE } from "@/utils/constants";
 import { LoggerWrapper } from "@/utils/log";
 import { KernelAccountClient, KernelSmartAccount, createKernelAccountClient } from "@zerodev/sdk";
 import { SmartAccountClient } from "permissionless";

--- a/packages/client/wallets/aa/src/blockchain/wallets/eoa.ts
+++ b/packages/client/wallets/aa/src/blockchain/wallets/eoa.ts
@@ -2,7 +2,8 @@ import { CrossmintWalletService } from "@/api";
 import { EVMSmartWallet } from "@/blockchain";
 import type { EOASigner, WalletConfig } from "@/types";
 import { WalletCreationParams } from "@/types/internal";
-import { CURRENT_VERSION, ZERO_DEV_TYPE, createOwnerSigner } from "@/utils";
+import { createOwnerSigner } from "@/utils";
+import { CURRENT_VERSION, ZERO_DEV_TYPE } from "@/utils/constants";
 import { signerToEcdsaValidator } from "@zerodev/ecdsa-validator";
 import { createKernelAccount } from "@zerodev/sdk";
 

--- a/packages/client/wallets/aa/src/blockchain/wallets/passkey.ts
+++ b/packages/client/wallets/aa/src/blockchain/wallets/passkey.ts
@@ -1,5 +1,4 @@
 import {
-    CURRENT_VERSION,
     CrossmintWalletService,
     EVMSmartWallet,
     EntryPointDetails,
@@ -7,10 +6,10 @@ import {
     PasskeySignerData,
     UserParams,
     WalletConfig,
-    ZERO_DEV_TYPE,
     blockchainToChainId,
 } from "@/index";
 import { WalletCreationParams } from "@/types/internal";
+import { CURRENT_VERSION, ZERO_DEV_TYPE } from "@/utils/constants";
 import { createPasskeyValidator, deserializePasskeyValidator } from "@zerodev/passkey-validator";
 import { deserializePasskeyValidatorData, serializePasskeyValidatorData } from "@zerodev/passkey-validator/utils";
 import { KernelValidator, createKernelAccount } from "@zerodev/sdk";

--- a/packages/client/wallets/aa/src/blockchain/wallets/paymaster.ts
+++ b/packages/client/wallets/aa/src/blockchain/wallets/paymaster.ts
@@ -1,4 +1,5 @@
-import { PAYMASTER_RPC, PM_BASE_RPC, PM_BASE_SEPOLIA_RPC, usesGelatoBundler } from "@/utils";
+import { usesGelatoBundler } from "@/utils";
+import { PAYMASTER_RPC, PM_BASE_RPC, PM_BASE_SEPOLIA_RPC } from "@/utils/constants";
 import { logInputOutput } from "@/utils/log";
 import { createZeroDevPaymasterClient } from "@zerodev/sdk";
 import { Middleware } from "permissionless/actions/smartAccount";

--- a/packages/client/wallets/aa/src/utils/blockchain.ts
+++ b/packages/client/wallets/aa/src/utils/blockchain.ts
@@ -1,26 +1,4 @@
-import { getBundlerRPC } from "@/blockchain";
-import { createPublicClient, http } from "viem";
-
 import { EVMBlockchainIncludingTestnet } from "@crossmint/common-sdk-base";
-
-export type VerifyMessageParams = {
-    address: `0x${string}`;
-    message: string;
-    signature: `0x${string}` | Uint8Array;
-    chain: EVMBlockchainIncludingTestnet;
-};
-
-export async function verifyMessage({ address, message, signature, chain }: VerifyMessageParams) {
-    const publicClient = createPublicClient({
-        transport: http(getBundlerRPC(chain)),
-    });
-
-    return publicClient.verifyMessage({
-        address,
-        message,
-        signature,
-    });
-}
 
 function isPolygonCDK(chain: EVMBlockchainIncludingTestnet) {
     const polygonCDKchains: EVMBlockchainIncludingTestnet[] = [

--- a/packages/client/wallets/aa/src/utils/index.ts
+++ b/packages/client/wallets/aa/src/utils/index.ts
@@ -1,5 +1,4 @@
 export * from "./auth";
-export * from "./constants";
 export * from "./error";
 export * from "./signer";
 export * from "./helpers";


### PR DESCRIPTION
## Description

When using the SDK I've noticed we (unintentionally?) surface many unnecessary parts. This makes the surface of the SDK huge and easy to break.

This PR:
- Removes all our constants (`ZD_AMOY_PROJECT_ID`, etc) from the package export
- Drops an unused function.

## Test plan

Build passing & existing tests + passkey release QA
