### PR TITLE
Smart Wallets: Update User Param Type & Preview

### DIFF
--- a/packages/client/wallets/aa/src/types/Config.ts
+++ b/packages/client/wallets/aa/src/types/Config.ts
@@ -6,7 +6,7 @@ export type SmartWalletSDKInitParams = {
     clientApiKey: string;
 };
 
-type WhitelabelUserParams = {
+export type UserParams = {
     /**
      * A unique identifier for the user. This must match the value of the identifier within the JWT
      * that is specified in the project settings (typically `sub`).
@@ -14,7 +14,6 @@ type WhitelabelUserParams = {
     id: string;
     jwt: string;
 };
-export type UserParams = WhitelabelUserParams;
 
 export type Web3AuthSigner = {
     type: "WEB3_AUTH";


### PR DESCRIPTION
## Description

This PR makes sure that the Type that appears in the preview for `SmartWalletSDK.getOrCreateWallet` for user parameters is `UserParams` instead of `WhitelabelUserParams`.

## Test plan

TS Compiling + Existing Tests
