### PR TITLE
VC: Use vc 2.0

### DIFF
--- a/packages/client/verifiable-credentials/package.json
+++ b/packages/client/verifiable-credentials/package.json
@@ -4,7 +4,6 @@
         "@crossmint/common-sdk-base": "0.0.6",
         "@ethersproject/providers": "5.7.2",
         "@ethersproject/wallet": "5.7.0",
-        "@krebitdao/eip712-vc": "1.0.3",
         "@lit-protocol/lit-node-client": "5.1.0",
         "date-fns": "2.30.0"
     },
@@ -38,5 +37,5 @@
     "sideEffects": false,
     "type": "module",
     "types": "./dist/index.d.ts",
-    "version": "3.1.0"
+    "version": "3.2.0"
 }

--- a/packages/client/verifiable-credentials/src/presentation/getCredential.test.ts
+++ b/packages/client/verifiable-credentials/src/presentation/getCredential.test.ts
@@ -6,11 +6,6 @@ global.fetch = jest.fn(() =>
         json: () => Promise.resolve({}),
     })
 ) as jest.Mock;
-jest.mock("@krebitdao/eip712-vc", () => {
-    return {
-        EIP712VC: jest.fn().mockImplementation(() => {}),
-    };
-});
 
 describe("getCredentialFromId", () => {
     let credentialService: CredentialService;

--- a/packages/client/verifiable-credentials/src/presentation/getNfts.test.ts
+++ b/packages/client/verifiable-credentials/src/presentation/getNfts.test.ts
@@ -8,12 +8,6 @@ global.fetch = jest.fn(() =>
     })
 ) as jest.Mock;
 
-jest.mock("@krebitdao/eip712-vc", () => {
-    return {
-        EIP712VC: jest.fn().mockImplementation(() => {}),
-    };
-});
-
 describe("getNfts", () => {
     beforeEach(() => {
         crossmintAPI.init("test", { environment: "test" });

--- a/packages/client/verifiable-credentials/src/services/lit.test.ts
+++ b/packages/client/verifiable-credentials/src/services/lit.test.ts
@@ -4,11 +4,6 @@ import { crossmintAPI } from "../crossmintAPI";
 import { Lit } from "./lit";
 
 jest.mock("@lit-protocol/lit-node-client");
-jest.mock("@krebitdao/eip712-vc", () => {
-    return {
-        EIP712VC: jest.fn().mockImplementation(() => {}),
-    };
-});
 
 describe("Lit", () => {
     let lit: Lit;

--- a/packages/client/verifiable-credentials/src/verifiableCredentialsSKD/types/verifiableCredential.ts
+++ b/packages/client/verifiable-credentials/src/verifiableCredentialsSKD/types/verifiableCredential.ts
@@ -3,11 +3,13 @@ import { Nft } from "./nft";
 export interface VerifiableCredential {
     id: string;
     credentialSubject: any;
-    expirationDate?: string;
+    validUntil?: string;
+    name?: string;
+    description?: string;
     nft: Nft;
     issuer: { id: string };
     type: string[];
-    issuanceDate: string;
+    validFrom: string;
     "@context": string[];
     proof?: { proofValue: string; [key: string]: any };
 }

--- a/packages/client/verifiable-credentials/src/verifiableCredentialsSKD/verification/signature.test.ts
+++ b/packages/client/verifiable-credentials/src/verifiableCredentialsSKD/verification/signature.test.ts
@@ -3,60 +3,33 @@ import { verifyTypedData } from "@ethersproject/wallet";
 import { VerifiableCredential } from "../types/verifiableCredential";
 import { VerifiableCredentialSignatureService } from "./signature";
 
-jest.mock("@krebitdao/eip712-vc", () => {
-    return {
-        EIP712VC: jest.fn().mockImplementation(() => {}),
-    };
-});
-jest.mock("@ethersproject/wallet");
-
-class MockSigner {
-    verifyW3CCredential = jest.fn().mockImplementation((issuerId, cred: any, a, b, c) => cred.id == "valid");
-    getDomainTypedData = jest.fn();
-}
+// jest.mock("@ethersproject/wallet");
 
 describe("VerifiableCredentialSignatureService", () => {
     let service: VerifiableCredentialSignatureService;
 
     beforeEach(() => {
-        service = new VerifiableCredentialSignatureService(MockSigner as any);
+        service = new VerifiableCredentialSignatureService();
         jest.resetAllMocks();
     });
 
     it("should verify a valid credential", async () => {
-        const mockCredential: VerifiableCredential = {
-            id: "valid",
-            issuer: { id: "did:chain:address" },
-            proof: {
-                eip712: {
-                    domain: {},
-                    types: {},
-                },
-                proofValue: "proofValue",
-            },
-            // other fields...
-        } as any;
-
-        const result = await service.verify(mockCredential);
+        const result = await service.verify(credential);
 
         expect(result).toBe(true);
     });
 
     it("should fail a invalid credential", async () => {
-        const mockCredential: VerifiableCredential = {
-            id: "nonValid",
-            issuer: { id: "did:chain:address" },
+        const invalidCredential: VerifiableCredential = {
+            ...credential,
             proof: {
-                eip712: {
-                    domain: {},
-                    types: {},
-                },
-                proofValue: "proofValue",
+                ...credential.proof,
+                proofValue:
+                    "0x5b88ebef582fa631bca407e9b6454190a0346de45285add0ffe19a4f374acc6463f1f418c60bc76fb6168884a763fb4e28297f3f8a1c381debedf4e2deb293fe1c",
             },
-            // other fields...
-        } as any;
+        };
 
-        const result = await service.verify(mockCredential);
+        const result = await service.verify(invalidCredential);
 
         expect(result).toBe(false);
     });
@@ -79,3 +52,101 @@ describe("VerifiableCredentialSignatureService", () => {
         await expect(service.verify(mockCredential)).rejects.toThrow("No proof associated with credential");
     });
 });
+
+const credential: VerifiableCredential = {
+    id: "urn:uuid:84a101bf-ded2-442d-b766-4e599d35fe89",
+    credentialSubject: {
+        name: "s",
+        id: "did:polygon-amoy:0x1B887669437644aA348c518844660ef8d63bd643",
+    },
+    nft: {
+        tokenId: "13",
+        chain: "polygon-amoy",
+        contractAddress: "0x2245D3fdFF160503897020A1165b796cEaC00B68",
+    },
+    issuer: {
+        id: "did:polygon-amoy:0xd9d8BA9D5956f78E02F4506940f42ac2dAB9DABd",
+    },
+    type: ["VerifiableCredential", "userName"],
+    validFrom: "2024-07-02T22:56:30.187Z",
+    "@context": ["https://www.w3.org/2018/credentials/v1"],
+    proof: {
+        verificationMethod: "did:polygon-amoy:0xd9d8BA9D5956f78E02F4506940f42ac2dAB9DABd#evmAddress",
+        created: "2024-07-02T22:56:30.187Z",
+        proofPurpose: "assertionMethod",
+        type: "EthereumEip712Signature2021",
+        proofValue:
+            "0x5b88ebef582fd631bca407e9b6454190a0346de45285add0ffe19a4f374acc6463f1f418c60bc76fb6168884a763fb4e28297f3f8a1c381debedf4e2deb293fe1c",
+        eip712: {
+            domain: {
+                name: "Crossmint",
+                version: "0.1",
+                chainId: 4,
+                verifyingContract: "0xD8393a735e8b7B6E199db9A537cf27C61Aa74954",
+            },
+            types: {
+                VerifiableCredential: [
+                    {
+                        name: "@context",
+                        type: "string[]",
+                    },
+                    {
+                        name: "type",
+                        type: "string[]",
+                    },
+                    {
+                        name: "id",
+                        type: "string",
+                    },
+                    {
+                        name: "issuer",
+                        type: "Issuer",
+                    },
+                    {
+                        name: "credentialSubject",
+                        type: "CredentialSubject",
+                    },
+                    {
+                        name: "validFrom",
+                        type: "string",
+                    },
+                    {
+                        name: "nft",
+                        type: "Nft",
+                    },
+                ],
+                CredentialSubject: [
+                    {
+                        name: "id",
+                        type: "string",
+                    },
+                    {
+                        name: "name",
+                        type: "string",
+                    },
+                ],
+                Issuer: [
+                    {
+                        name: "id",
+                        type: "string",
+                    },
+                ],
+                Nft: [
+                    {
+                        name: "tokenId",
+                        type: "string",
+                    },
+                    {
+                        name: "contractAddress",
+                        type: "string",
+                    },
+                    {
+                        name: "chain",
+                        type: "string",
+                    },
+                ],
+            },
+            primaryType: "VerifiableCredential",
+        },
+    },
+};

--- a/packages/client/verifiable-credentials/src/verifiableCredentialsSKD/verification/signature.ts
+++ b/packages/client/verifiable-credentials/src/verifiableCredentialsSKD/verification/signature.ts
@@ -1,35 +1,24 @@
+import { getAddress } from "@ethersproject/address";
 import { verifyTypedData } from "@ethersproject/wallet";
-import { EIP712VC } from "@krebitdao/eip712-vc";
 
 import { VerifiableCredential } from "../types/verifiableCredential";
 
 export class VerifiableCredentialSignatureService {
-    vcSigner;
-    constructor(signer = EIP712VC) {
-        this.vcSigner = signer;
-    }
-
     async verify(vc: VerifiableCredential) {
-        let issuerId = vc.issuer.id;
+        const issuerId = vc.issuer.id;
         const issuerDidParts = issuerId.split(":");
         if (issuerDidParts.length < 2) {
             throw new Error("Issuer DID should be in the format did:{chain}:{address}");
         }
-        issuerId = issuerDidParts[2];
+        const issuerAddress = issuerDidParts[2];
 
         if (vc.proof == undefined) {
             throw new Error("No proof associated with credential");
         }
-        const vcDomain = new this.vcSigner(vc.proof.eip712.domain);
-        const types = vc.proof.eip712.types;
+        const { domain, types } = vc.proof.eip712;
         const proofValue = vc.proof.proofValue;
-        delete vc.proof;
 
-        return await vcDomain.verifyW3CCredential(issuerId, vc, types, proofValue, async (data, proofValue: string) => {
-            const messageTypes = data.types as any;
-            delete messageTypes.EIP712Domain; // data.types contains EIP712Domain, which is not part of the message
-            delete messageTypes.CredentialSchema; // not using credentialSchema
-            return verifyTypedData(vcDomain.getDomainTypedData(), messageTypes, data.message, proofValue);
-        });
+        const recoveredAddress = verifyTypedData(domain, types, vc, proofValue);
+        return getAddress(issuerAddress) === getAddress(recoveredAddress);
     }
 }

--- a/packages/client/verifiable-credentials/src/verifiableCredentialsSKD/verification/verify.test.ts
+++ b/packages/client/verifiable-credentials/src/verifiableCredentialsSKD/verification/verify.test.ts
@@ -5,11 +5,7 @@ import { verifyCredential } from "./verify";
 
 jest.mock("./signature");
 jest.mock("../onchainServices/nft");
-jest.mock("@krebitdao/eip712-vc", () => {
-    return {
-        EIP712VC: jest.fn().mockImplementation(() => {}),
-    };
-});
+
 describe("verifyCredential", () => {
     beforeEach(() => {
         jest.resetAllMocks();
@@ -17,7 +13,17 @@ describe("verifyCredential", () => {
 
     it("should verify a valid credential", async () => {
         const mockCredential: VerifiableCredential = {
-            expirationDate: new Date(Date.now() + 86400000).toISOString(),
+            validUntil: new Date(Date.now() + 86400000).toISOString(),
+            nft: {} as any,
+        } as any;
+        (VerifiableCredentialSignatureService.prototype.verify as jest.Mock).mockResolvedValue(true);
+        (NFTService.prototype.isBurnt as jest.Mock).mockResolvedValue(false);
+        const result = await verifyCredential(mockCredential);
+        expect(result).toEqual({ validVC: true, error: undefined });
+    });
+
+    it("should verify a valid credential without expiration date", async () => {
+        const mockCredential: VerifiableCredential = {
             nft: {} as any,
         } as any;
         (VerifiableCredentialSignatureService.prototype.verify as jest.Mock).mockResolvedValue(true);
@@ -28,7 +34,7 @@ describe("verifyCredential", () => {
 
     it("should fail if revoked credential", async () => {
         const mockCredential: VerifiableCredential = {
-            expirationDate: new Date(Date.now() + 86400000).toISOString(),
+            validUntil: new Date(Date.now() + 86400000).toISOString(),
             nft: {} as any,
         } as any;
         (VerifiableCredentialSignatureService.prototype.verify as jest.Mock).mockResolvedValue(true);
@@ -39,7 +45,7 @@ describe("verifyCredential", () => {
 
     it("should fail if invalid proof credential", async () => {
         const mockCredential: VerifiableCredential = {
-            expirationDate: new Date(Date.now() + 86400000).toISOString(),
+            validUntil: new Date(Date.now() + 86400000).toISOString(),
             nft: {} as any,
         } as any;
         (VerifiableCredentialSignatureService.prototype.verify as jest.Mock).mockResolvedValue(false);
@@ -50,7 +56,7 @@ describe("verifyCredential", () => {
 
     it("should fail if expirationDate is not a valid ISO string", async () => {
         const mockCredential: VerifiableCredential = {
-            expirationDate: "not a valid ISO string",
+            validUntil: "not a valid ISO string",
             nft: {} as any,
         } as any;
         await expect(verifyCredential(mockCredential)).rejects.toThrow(
@@ -59,7 +65,7 @@ describe("verifyCredential", () => {
     });
     it("should fail if expirationDate is not a string", async () => {
         const mockCredential: VerifiableCredential = {
-            expirationDate: 1,
+            validUntil: 1,
             nft: {} as any,
         } as any;
         await expect(verifyCredential(mockCredential)).rejects.toThrow("expirationDate must be a ISO string");
@@ -67,10 +73,10 @@ describe("verifyCredential", () => {
 
     it("should fail if expirationDate is in the past", async () => {
         const mockCredential: VerifiableCredential = {
-            expirationDate: new Date(Date.now() - 86400000).toISOString(), // 1 day in the past
+            validUntil: new Date(Date.now() - 86400000).toISOString(), // 1 day in the past
             nft: {} as any,
         } as any;
         const result = await verifyCredential(mockCredential);
-        expect(result).toEqual({ validVC: false, error: `Credential expired at ${mockCredential.expirationDate}` });
+        expect(result).toEqual({ validVC: false, error: `Credential expired at ${mockCredential.validUntil}` });
     });
 });

--- a/packages/client/verifiable-credentials/src/verifiableCredentialsSKD/verification/verify.ts
+++ b/packages/client/verifiable-credentials/src/verifiableCredentialsSKD/verification/verify.ts
@@ -8,19 +8,19 @@ export async function verifyCredential(
     credential: VerifiableCredential
 ): Promise<{ validVC: boolean; error: string | undefined }> {
     let error;
-    if (credential.expirationDate != null) {
-        if (typeof credential.expirationDate !== "string") {
+    if (credential.validUntil != null) {
+        if (typeof credential.validUntil !== "string") {
             throw new Error("expirationDate must be a ISO string");
         }
 
-        const parsedExpirationDate = parseISO(credential.expirationDate);
+        const parsedExpirationDate = parseISO(credential.validUntil);
         if (!isValid(parsedExpirationDate)) {
-            throw new Error(`Invalid expiration date: ${credential.expirationDate}`);
+            throw new Error(`Invalid expiration date: ${credential.validUntil}`);
         }
 
         const todayDate = new Date();
         if (parsedExpirationDate < todayDate) {
-            error = "Credential expired at " + credential.expirationDate;
+            error = "Credential expired at " + credential.validUntil;
             return { validVC: false, error };
         }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3549,13 +3549,6 @@
     axios "^0.27.2"
     long "^4.0.0"
 
-"@krebitdao/eip712-vc@1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@krebitdao/eip712-vc/-/eip712-vc-1.0.3.tgz#7e70e9d680ef4286a314de8fa1f87a369798b619"
-  integrity sha512-+2J+eM3jyEA++KEQd6QqEycK+sZrSx1o14lY3r4s6rqgkrJ2CaQ6yTTYmBb1cE8ESFz1ai2tU2fbg72U6Vjt6g==
-  dependencies:
-    ethers "^5.5.1"
-
 "@leichtgewicht/ip-codec@^2.0.1":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
@@ -12701,7 +12694,7 @@ ethereumjs-util@^7.1.5:
     ethereum-cryptography "^0.1.3"
     rlp "^2.2.4"
 
-ethers@5.7.2, ethers@^5.5.1, ethers@^5.6.5, ethers@^5.7.1:
+ethers@5.7.2, ethers@^5.6.5, ethers@^5.7.1:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.7.2.tgz#3a7deeabbb8c030d4126b24f84e525466145872e"
   integrity sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==


### PR DESCRIPTION
## Description

Update VCs to W3C 2.0 standard:

Add name and description optional fields
dates are now :"validFrom" and "validUntil"
"validUntil" is optional
removed outdated Krebitdao lib

## Test plan
Unit tests
