### PR TITLE
Smart Wallets: Throw Nice Error When SDK Used Serverside (Closes WAL-2459, WAL-2460)

### DIFF
--- a/packages/client/wallets/aa/src/SmartWalletSDK.ts
+++ b/packages/client/wallets/aa/src/SmartWalletSDK.ts
@@ -2,7 +2,7 @@ import { CrossmintWalletService } from "@/api";
 import { EVMSmartWallet, getBundlerRPC } from "@/blockchain";
 import type { EntryPointDetails, SmartWalletSDKInitParams, UserParams, WalletConfig } from "@/types";
 import { WalletCreationParams } from "@/types/internal";
-import { WalletSdkError } from "@/utils";
+import { RunningOnServerError, WalletSdkError } from "@/utils";
 import { ENTRYPOINT_ADDRESS_V06, ENTRYPOINT_ADDRESS_V07 } from "permissionless";
 import { createPublicClient, http } from "viem";
 
@@ -29,6 +29,10 @@ export class SmartWalletSDK extends LoggerWrapper {
      * @throws error if the api key is not formatted correctly.
      */
     static init(config: SmartWalletSDKInitParams): SmartWalletSDK {
+        if (typeof window === "undefined") {
+            throw new RunningOnServerError();
+        }
+
         const validationResult = validateAPIKey(config.clientApiKey);
         if (!validationResult.isValid) {
             throw new Error("API key invalid");

--- a/packages/client/wallets/aa/src/utils/error.ts
+++ b/packages/client/wallets/aa/src/utils/error.ts
@@ -5,8 +5,6 @@ export class NotAuthorizedError extends Error {
 
     constructor(message: string) {
         super(message);
-
-        // ES5 workaround
         Object.setPrototypeOf(this, NotAuthorizedError.prototype);
     }
 }
@@ -16,8 +14,6 @@ export class TransferError extends Error {
 
     constructor(message: string) {
         super(message);
-
-        // ES5 workaround
         Object.setPrototypeOf(this, TransferError.prototype);
     }
 }
@@ -27,8 +23,6 @@ export class TransactionError extends Error {
 
     constructor(message: string) {
         super(message);
-
-        // ES5 workaround
         Object.setPrototypeOf(this, TransactionError.prototype);
     }
 }
@@ -40,9 +34,15 @@ export class CrossmintServiceError extends Error {
     constructor(message: string, status?: number) {
         super(message);
         this.status = status;
-
-        // ES5 workaround
         Object.setPrototypeOf(this, CrossmintServiceError.prototype);
+    }
+}
+
+export class RunningOnServerError extends Error {
+    public readonly code = "ERROR_RUNNING_ON_SERVER";
+
+    constructor() {
+        super("Smart Wallet SDK should only be used client side.");
     }
 }
 
@@ -54,8 +54,6 @@ export class WalletSdkError extends Error {
 
     constructor(message: string) {
         super(message);
-
-        // ES5 workaround
         Object.setPrototypeOf(this, WalletSdkError.prototype);
     }
 }

--- a/packages/client/wallets/aa/src/utils/helpers.ts
+++ b/packages/client/wallets/aa/src/utils/helpers.ts
@@ -3,7 +3,7 @@ export function isLocalhost() {
         return false;
     }
 
-    return window.location.origin.includes("localhost");
+    return typeof window !== "undefined" && window.location.origin.includes("localhost");
 }
 
 export function isEmpty(str: string | undefined | null): str is undefined | null {


### PR DESCRIPTION
## Description

From beta testing feedback, this PR fixes two issues related to the SDK running server side.

### Calling `window` in the module

We have the following code in the SDK.

```TS
function getBrowserLogger() {
    if (isLocalhost()) {
        return new ConsoleProvider();
    }

    return new DatadogProvider();
}

const { logInfo, logWarn, logError } = getBrowserLogger();
```

Which will run whenever the module is loaded. When used with Next.js (or maybe the latest versions of react in general, I'm not super familiar aha), this means even if we have code that only runs client side:

![Image 7-2-24 at 8 17 PM](https://github.com/Crossmint/crossmint-sdk/assets/17352012/64097faa-0912-4831-b4ba-fa8f24486e1b)

We get errors that look like this:

![Image 7-2-24 at 8 16 PM](https://github.com/Crossmint/crossmint-sdk/assets/17352012/54ce1a99-3f04-4d31-aef2-5883d051f10c)

The issue is that `isLocalhost` accesses `window`. This PR adds a check before.

### A Nice Error

This PR also adds a nice error in the case that `SmartWalletSDK.init` is run server side, which is nicer than exposing the downstream failures that running on the server cause.

## Test plan

In a `create-next-app` starter, with the SDK installed, made sure that:
- With the code pictured above, there we're no errors
- When running `SmartWalletSDK.init` serverside, we throw the new error as expected.