### PR TITLE
WAL-2455: Remove id from userparams

### DIFF
--- a/packages/client/wallets/aa/src/types/API.ts
+++ b/packages/client/wallets/aa/src/types/API.ts
@@ -20,7 +20,6 @@ export interface EOASignerData {
 }
 
 export type PasskeySignerData = PasskeyValidatorSerializedData & {
-    passkeyName: string;
     domain: string;
     type: "passkeys";
 };

--- a/packages/client/wallets/aa/src/types/Config.ts
+++ b/packages/client/wallets/aa/src/types/Config.ts
@@ -7,11 +7,6 @@ export type SmartWalletSDKInitParams = {
 };
 
 export type UserParams = {
-    /**
-     * A unique identifier for the user. This must match the value of the identifier within the JWT
-     * that is specified in the project settings (typically `sub`).
-     */
-    id: string;
     jwt: string;
 };
 
@@ -30,11 +25,6 @@ export type ViemAccount = {
 
 export type PasskeySigner = {
     type: "PASSKEY";
-
-    /**
-     * Displayed to the user during passkey registration or signing prompts.
-     */
-    passkeyName: string;
 };
 
 export type EOASigner = EIP1193Provider | Web3AuthSigner | ViemAccount;


### PR DESCRIPTION
## Description

Removing id from User Params and inferring the passkeys name from the JWT token. 

## Test plan

Create a user with a passkey.

This is how it looks like
![image](https://github.com/Crossmint/crossmint-sdk/assets/7073959/de97b03c-41cf-4dbc-a609-e4b5fe120c09)