### PR TITLE
WAL-2455: Remove id from userparams

### DIFF
--- a/packages/client/wallets/aa/src/api/CrossmintWalletService.ts
+++ b/packages/client/wallets/aa/src/api/CrossmintWalletService.ts
@@ -62,8 +62,7 @@ export class CrossmintWalletService extends BaseCrossmintService {
         );
     }
 
-    public getPasskeyServerUrl(user: UserParams): string {
-        const userParam = `userId=${user.id}`;
-        return this.crossmintBaseUrl + `/unstable/passkeys/${this.crossmintAPIHeaders["x-api-key"]}/${userParam}`;
+    public getPasskeyServerUrl(): string {
+        return this.crossmintBaseUrl + `/internal/passkeys`;
     }
 }

--- a/packages/client/wallets/aa/src/blockchain/wallets/passkey.ts
+++ b/packages/client/wallets/aa/src/blockchain/wallets/passkey.ts
@@ -44,7 +44,7 @@ export class PasskeyWalletService {
         await this.crossmintService.storeAbstractWallet(user, {
             type: ZERO_DEV_TYPE,
             smartContractWalletAddress: kernelAccount.address,
-            signerData: this.getSignerData(validator, walletConfig.signer.passkeyName),
+            signerData: this.getSignerData(validator, walletConfig.signer.passkeyName ?? ""),
             version: CURRENT_VERSION,
             baseLayer: "evm",
             chainId: blockchainToChainId(chain),
@@ -74,9 +74,9 @@ export class PasskeyWalletService {
         }
 
         return createPasskeyValidator(publicClient, {
-            passkeyServerUrl: this.crossmintService.getPasskeyServerUrl(user),
+            passkeyServerUrl: this.crossmintService.getPasskeyServerUrl(),
             entryPoint: entrypoint.address,
-            passkeyName: signer.passkeyName,
+            passkeyName: signer.passkeyName ?? "",
             credentials: "omit",
         });
     }

--- a/packages/client/wallets/aa/src/types/Config.ts
+++ b/packages/client/wallets/aa/src/types/Config.ts
@@ -7,11 +7,6 @@ export type SmartWalletSDKInitParams = {
 };
 
 export type UserParams = {
-    /**
-     * A unique identifier for the user. This must match the value of the identifier within the JWT
-     * that is specified in the project settings (typically `sub`).
-     */
-    id: string;
     jwt: string;
 };
 
@@ -33,8 +28,9 @@ export type PasskeySigner = {
 
     /**
      * Displayed to the user during passkey registration or signing prompts.
+     * If not provided, a default name will be used.
      */
-    passkeyName: string;
+    passkeyName?: string;
 };
 
 export type EOASigner = EIP1193Provider | Web3AuthSigner | ViemAccount;


### PR DESCRIPTION
## Description

Removing id from User Params and making the passkeyName optional. If not provided, infer from the JWT token (projectUserId).

## Test plan

Create a user with a passkey.