### PR TITLE
Add error for projects without non-custodial wallets enabled

### DIFF
--- a/packages/client/wallets/smart-wallet/src/api/APIErrorService.ts
+++ b/packages/client/wallets/smart-wallet/src/api/APIErrorService.ts
@@ -5,6 +5,7 @@ import {
     JWTExpiredError,
     JWTIdentifierError,
     JWTInvalidError,
+    NonCustodialWalletsNotEnabledError,
     OutOfCreditsError,
     SmartWalletSDKError,
     UserWalletAlreadyCreatedError,
@@ -16,7 +17,8 @@ export type CrossmintAPIErrorCodes =
     | "ERROR_JWT_IDENTIFIER"
     | "ERROR_JWT_EXPIRED"
     | "ERROR_USER_WALLET_ALREADY_CREATED"
-    | "ERROR_ADMIN_SIGNER_ALREADY_USED";
+    | "ERROR_ADMIN_SIGNER_ALREADY_USED"
+    | "ERROR_PROJECT_NONCUSTODIAL_WALLETS_NOT_ENABLED";
 
 export class APIErrorService {
     constructor(
@@ -29,6 +31,7 @@ export class APIErrorService {
             ERROR_USER_WALLET_ALREADY_CREATED: ({ userId }: { userId: string }) =>
                 new UserWalletAlreadyCreatedError(userId),
             ERROR_ADMIN_SIGNER_ALREADY_USED: () => new AdminAlreadyUsedError(),
+            ERROR_PROJECT_NONCUSTODIAL_WALLETS_NOT_ENABLED: () => new NonCustodialWalletsNotEnabledError(),
         }
     ) {}
 

--- a/packages/client/wallets/smart-wallet/src/error/index.ts
+++ b/packages/client/wallets/smart-wallet/src/error/index.ts
@@ -114,3 +114,9 @@ export class AdminAlreadyUsedError extends ConfigError {
         super("This signer was already used to create another wallet. Please use a different signer.");
     }
 }
+
+export class NonCustodialWalletsNotEnabledError extends ConfigError {
+    constructor() {
+        super("Non-custodial wallets are not enabled for this project");
+    }
+}

--- a/packages/client/wallets/smart-wallet/src/index.ts
+++ b/packages/client/wallets/smart-wallet/src/index.ts
@@ -26,6 +26,7 @@ export {
     OutOfCreditsError,
     AdminAlreadyUsedError,
     ConfigError,
+    NonCustodialWalletsNotEnabledError,
 } from "./error";
 
 export { SmartWalletSDK } from "./SmartWalletSDK";


### PR DESCRIPTION
## Description

This PR contains:
- A resolution for [WAL-2452](https://linear.app/crossmint/issue/WAL-2452/throw-good-error-when-project-is-configured-with-custodial-wallets)
- A proposal for how we should organize errors, namely that:
  - All errors should be associated with a string code
  - This code can be thrown from our server and processed and re-thrown by our SDK (both of these are similar to how Payments works)
  - We should rely on the string error code instead of error subtypes, mostly for the sake of simplicity and DRY

Needs https://github.com/Paella-Labs/crossbit-main/pull/13973 to be landed to throw our new error and resolve the linked issue

## Test plan

TBA