### PR TITLE
Smart Wallet: Make `EVMSmartWallet` Provider Agnostic

### DIFF
--- a/packages/client/wallets/smart-wallet/src/blockchain/wallets/EVMSmartWallet.ts
+++ b/packages/client/wallets/smart-wallet/src/blockchain/wallets/EVMSmartWallet.ts
@@ -1,15 +1,13 @@
 import { logError } from "@/services/logging";
 import { TransferError } from "@/types/Error";
-import type { SmartAccountClient } from "permissionless";
-import type { SmartAccount } from "permissionless/accounts";
-import type { EntryPoint } from "permissionless/types/entrypoint";
 import type { HttpTransport, PublicClient } from "viem";
-import { type Chain, isAddress, publicActions } from "viem";
+import { isAddress, publicActions } from "viem";
 
 import { EVMBlockchainIncludingTestnet } from "@crossmint/common-sdk-base";
 
 import type { CrossmintWalletService } from "../../api/CrossmintWalletService";
 import type { TransferType } from "../../types/Tokens";
+import { SmartWalletClient } from "../../types/internal";
 import { SCW_SERVICE } from "../../utils/constants";
 import { LoggerWrapper, errorToJSON } from "../../utils/log";
 import { transferParams } from "../transfer";
@@ -28,7 +26,7 @@ export class EVMSmartWallet extends LoggerWrapper {
         /**
          * An interface to interact with the smart wallet, execute transactions, sign messages, etc.
          */
-        wallet: SmartAccountClient<EntryPoint, HttpTransport, Chain, SmartAccount<EntryPoint>>;
+        wallet: SmartWalletClient;
 
         /**
          * An interface to read onchain data, fetch transactions, retrieve account balances, etc. Corresponds to public [JSON-RPC API](https://ethereum.org/en/developers/docs/apis/json-rpc/) methods.
@@ -38,7 +36,7 @@ export class EVMSmartWallet extends LoggerWrapper {
 
     constructor(
         private readonly crossmintService: CrossmintWalletService,
-        private readonly accountClient: SmartAccountClient<EntryPoint, HttpTransport, Chain, SmartAccount<EntryPoint>>,
+        private readonly accountClient: SmartWalletClient,
         publicClient: PublicClient<HttpTransport>,
         chain: EVMBlockchainIncludingTestnet
     ) {

--- a/packages/client/wallets/smart-wallet/src/blockchain/wallets/service.ts
+++ b/packages/client/wallets/smart-wallet/src/blockchain/wallets/service.ts
@@ -62,16 +62,17 @@ export class SmartWalletService {
                 kernelVersion,
             });
 
-            const kernelParams = {
+            const kernelAccountClient: SmartWalletClient = createKernelAccountClient({
                 account,
                 chain: getViemNetwork(chain),
                 entryPoint: account.entryPoint,
                 bundlerTransport: http(getBundlerRPC(chain)),
                 ...(usePaymaster(chain) && paymasterMiddleware({ entryPoint: account.entryPoint, chain })),
-            };
-            const smartAccountClient: SmartWalletClient = toCrossmintSmartAccountClient({
+            });
+
+            const smartAccountClient = toCrossmintSmartAccountClient({
                 crossmintChain: chain,
-                smartAccountClient: createKernelAccountClient(kernelParams),
+                smartAccountClient: kernelAccountClient,
             });
 
             return new EVMSmartWallet(this.crossmintWalletService, smartAccountClient, publicClient, chain);

--- a/packages/client/wallets/smart-wallet/src/blockchain/wallets/service.ts
+++ b/packages/client/wallets/smart-wallet/src/blockchain/wallets/service.ts
@@ -1,8 +1,8 @@
 import type { SignerData } from "@/types/API";
-import { type KernelAccountClient, type KernelSmartAccount, createKernelAccountClient } from "@zerodev/sdk";
+import { type KernelSmartAccount, createKernelAccountClient } from "@zerodev/sdk";
 import { ENTRYPOINT_ADDRESS_V06, ENTRYPOINT_ADDRESS_V07 } from "permissionless";
 import type { EntryPoint } from "permissionless/types/entrypoint";
-import { type Chain, type HttpTransport, createPublicClient, http } from "viem";
+import { type HttpTransport, createPublicClient, http } from "viem";
 
 import { blockchainToChainId } from "@crossmint/common-sdk-base";
 
@@ -12,6 +12,7 @@ import { WalletSdkError } from "../../types/Error";
 import {
     SUPPORTED_ENTRYPOINT_VERSIONS,
     SUPPORTED_KERNEL_VERSIONS,
+    SmartWalletClient,
     type SupportedKernelVersion,
     type WalletCreationParams,
     isSupportedEntryPointVersion,
@@ -68,13 +69,7 @@ export class SmartWalletService {
                 bundlerTransport: http(getBundlerRPC(chain)),
                 ...(usePaymaster(chain) && paymasterMiddleware({ entryPoint: account.entryPoint, chain })),
             };
-
-            const smartAccountClient: KernelAccountClient<
-                EntryPoint,
-                HttpTransport,
-                Chain,
-                KernelSmartAccount<EntryPoint, HttpTransport>
-            > = toCrossmintSmartAccountClient({
+            const smartAccountClient: SmartWalletClient = toCrossmintSmartAccountClient({
                 crossmintChain: chain,
                 smartAccountClient: createKernelAccountClient(kernelParams),
             });

--- a/packages/client/wallets/smart-wallet/src/types/internal.ts
+++ b/packages/client/wallets/smart-wallet/src/types/internal.ts
@@ -1,11 +1,13 @@
-import { KernelSmartAccount } from "@zerodev/sdk";
-import { EntryPoint } from "permissionless/types/entrypoint";
-import type { Hex, HttpTransport, PublicClient } from "viem";
+import type { KernelSmartAccount } from "@zerodev/sdk";
+import type { SmartAccountClient } from "permissionless";
+import type { SmartAccount } from "permissionless/accounts";
+import type { EntryPoint } from "permissionless/types/entrypoint";
+import type { Chain, Hex, HttpTransport, PublicClient } from "viem";
 
-import { EVMBlockchainIncludingTestnet } from "@crossmint/common-sdk-base";
+import type { EVMBlockchainIncludingTestnet } from "@crossmint/common-sdk-base";
 
-import { SignerData } from "./API";
-import { EntryPointDetails, UserParams, WalletConfig } from "./Config";
+import type { SignerData } from "./API";
+import type { EntryPointDetails, UserParams, WalletConfig } from "./Config";
 
 export const SUPPORTED_KERNEL_VERSIONS = ["0.3.1", "0.3.0", "0.2.4"] as const;
 export type SupportedKernelVersion = (typeof SUPPORTED_KERNEL_VERSIONS)[number];
@@ -44,3 +46,5 @@ export type PasskeyValidatorSerializedData = {
     pubKeyY: string;
     authenticatorIdHash: Hex;
 };
+
+export type SmartWalletClient = SmartAccountClient<EntryPoint, HttpTransport, Chain, SmartAccount<EntryPoint>>;


### PR DESCRIPTION
## Description

This PR:
- Changes `EVMSmartWallet` to be provider agnostic, and cleans up the constructor, which had too much going on.
- Makes setting up error handling easier.

## Test plan

Went through the demo minting flow.

Existing tests + CI
