### PR TITLE
embed: fix fiat live update params

### DIFF
--- a/.changeset/lemon-grapes-pretend.md
+++ b/.changeset/lemon-grapes-pretend.md
@@ -1,0 +1,6 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+"@crossmint/client-sdk-nextjs-starter": patch
+---
+
+embed: fiat fix live updating params

--- a/apps/payments/nextjs/pages/payment-element/fiat.tsx
+++ b/apps/payments/nextjs/pages/payment-element/fiat.tsx
@@ -35,6 +35,7 @@ export default function PaymentElementPage() {
 }
 
 function Content({ count }: { count: number }) {
+    const [email, setEmail] = useState("");
     const [quoteMessage, setQuoteMessage] = useState<InitialQuotePayload | undefined>();
 
     return (
@@ -43,7 +44,7 @@ function Content({ count }: { count: number }) {
 
             <CrossmintPaymentElement
                 environment="staging"
-                clientId="1bd7b6b4-a390-4716-82f3-f78f9f2aa335"
+                clientId="02dbf2b7-bbaa-4fb3-a962-05b65518fd4d"
                 recipient={{ wallet: "0xdC9bb9929b79b62d630A7C3568c979a2843eFd8b" }}
                 mintConfig={{ totalPrice: `${0.001 * count}`, quantity: count }}
                 paymentMethod="fiat"

--- a/apps/payments/nextjs/pages/payment-element/fiat.tsx
+++ b/apps/payments/nextjs/pages/payment-element/fiat.tsx
@@ -35,7 +35,6 @@ export default function PaymentElementPage() {
 }
 
 function Content({ count }: { count: number }) {
-    const [email, setEmail] = useState("");
     const [quoteMessage, setQuoteMessage] = useState<InitialQuotePayload | undefined>();
 
     return (

--- a/packages/client/ui/react-ui/src/components/embed/fiat/FiatEmbeddedCheckoutIFrame.tsx
+++ b/packages/client/ui/react-ui/src/components/embed/fiat/FiatEmbeddedCheckoutIFrame.tsx
@@ -1,7 +1,22 @@
-import { FiatEmbeddedCheckoutProps } from "@crossmint/client-sdk-base";
+import useDeepEffect from "@/hooks/useDeepEffect";
+
+import {
+    FiatEmbeddedCheckoutProps,
+    crossmintIFrameService,
+    embeddedCheckoutPropsToUpdatableParamsPayload,
+} from "@crossmint/client-sdk-base";
 
 import CrossmintEmbeddedCheckoutIFrame from "../EmbeddedCheckoutIFrame";
 
 export default function FiatEmbeddedCheckoutIFrame(props: FiatEmbeddedCheckoutProps) {
+    const { emitInternalEvent } = crossmintIFrameService(props);
+
+    useDeepEffect(() => {
+        emitInternalEvent({
+            type: "params-update",
+            payload: embeddedCheckoutPropsToUpdatableParamsPayload(props),
+        });
+    }, [props.recipient, props.mintConfig, props.locale, props.currency, props.whPassThroughArgs]);
+
     return <CrossmintEmbeddedCheckoutIFrame {...props} />;
 }


### PR DESCRIPTION
## Description

i have no idea how this was not found earlier, but this was introduced [here](https://github.com/Crossmint/crossmint-sdk/pull/397/files) - the live params update over window messaging was not tested/implemented in fiat at all

## Test plan

BEFORE:
updates not applying

https://github.com/user-attachments/assets/4a7b5f4f-fa88-4bd5-b115-80ae83dd4a5d

AFTER:

https://github.com/user-attachments/assets/632d4fce-04a2-45fb-be87-957206fd1689

