### PR TITLE
Smart Wallets: Admin & Passkey Mismatch Errors (Resolves WAL-2468 and WAL-2578)

### DIFF
--- a/packages/client/wallets/smart-wallet/src/api/CrossmintWalletService.ts
+++ b/packages/client/wallets/smart-wallet/src/api/CrossmintWalletService.ts
@@ -3,7 +3,6 @@ import type { UserParams } from "@/types/Config";
 
 import type { EVMBlockchainIncludingTestnet } from "@crossmint/common-sdk-base";
 
-import { CrossmintServiceError } from "../error";
 import { BaseCrossmintService } from "./BaseCrossmintService";
 
 export { EVMBlockchainIncludingTestnet } from "@crossmint/common-sdk-base";
@@ -21,7 +20,13 @@ export class CrossmintWalletService extends BaseCrossmintService {
     async getSmartWalletConfig(
         user: UserParams,
         chain: EVMBlockchainIncludingTestnet
-    ): Promise<{ kernelVersion: string; entryPointVersion: string; signers: { signerData: SignerData }[] }> {
+    ): Promise<{
+        kernelVersion: string;
+        entryPointVersion: string;
+        userId: string;
+        signers: { signerData: SignerData }[];
+        smartContractWalletAddress?: string;
+    }> {
         return this.fetchCrossmintAPI(
             `sdk/smart-wallet/config?chain=${chain}`,
             { method: "GET" },

--- a/packages/client/wallets/smart-wallet/src/blockchain/wallets/eoa.ts
+++ b/packages/client/wallets/smart-wallet/src/blockchain/wallets/eoa.ts
@@ -24,7 +24,7 @@ export class EOAAccountService {
 
         if (existingSignerConfig != null && !equalsIgnoreCase(eoa.address, existingSignerConfig.eoaAddress)) {
             throw new AdminMismatchError(
-                `User '${user.id}' has an existing wallet with an eoa signer '${existingSignerConfig.eoaAddress}', this does not match input eoa signer '${existingSignerConfig.eoaAddress}'.`,
+                `User '${user.id}' has an existing wallet with an eoa signer '${existingSignerConfig.eoaAddress}', this does not match input eoa signer '${eoa.address}'.`,
                 existingSignerConfig,
                 { type: "eoa", eoaAddress: existingSignerConfig.eoaAddress }
             );

--- a/packages/client/wallets/smart-wallet/src/error/index.ts
+++ b/packages/client/wallets/smart-wallet/src/error/index.ts
@@ -1,3 +1,5 @@
+import { PasskeyDisplay, SignerDisplay } from "@/types/API";
+
 export const SmartWalletErrors = {
     NOT_AUTHORIZED: "smart-wallet:not-authorized",
     TRANSFER: "smart-wallet:transfer.error",
@@ -9,6 +11,8 @@ export const SmartWalletErrors = {
     ERROR_USER_WALLET_ALREADY_CREATED: "smart-wallet:user-wallet-already-created.error",
     ERROR_OUT_OF_CREDITS: "smart-wallet:out-of-credits.error",
     ERROR_WALLET_CONFIG: "smart-wallet:wallet-config.error",
+    ERROR_ADMIN_MISMATCH: "smart-wallet:wallet-config.admin-mismatch",
+    ERROR_PASSKEY_MISMATCH: "smart-wallet:wallet-config.passkey-mismatch",
     ERROR_ADMIN_SIGNER_ALREADY_USED: "smart-wallet:wallet-config.admin-signer-already-used",
     UNCATEGORIZED: "smart-wallet:uncategorized", // catch-all error code
 } as const;
@@ -37,6 +41,28 @@ export class CrossmintServiceError extends SmartWalletSDKError {
     constructor(message: string, status?: number) {
         super(message, undefined, SmartWalletErrors.CROSSMINT_SERVICE);
         this.status = status;
+    }
+}
+
+export class AdminMismatchError extends SmartWalletSDKError {
+    public readonly required: SignerDisplay;
+    public readonly used?: SignerDisplay;
+
+    constructor(message: string, required: SignerDisplay, used?: SignerDisplay) {
+        super(message, SmartWalletErrors.ERROR_ADMIN_MISMATCH);
+        this.required = required;
+        this.used = used;
+    }
+}
+
+export class PasskeyMismatchError extends SmartWalletSDKError {
+    public readonly required: PasskeyDisplay;
+    public readonly used?: PasskeyDisplay;
+
+    constructor(message: string, required: PasskeyDisplay, used?: PasskeyDisplay) {
+        super(message, SmartWalletErrors.ERROR_ADMIN_MISMATCH);
+        this.required = required;
+        this.used = used;
     }
 }
 

--- a/packages/client/wallets/smart-wallet/src/error/index.ts
+++ b/packages/client/wallets/smart-wallet/src/error/index.ts
@@ -60,7 +60,7 @@ export class PasskeyMismatchError extends SmartWalletSDKError {
     public readonly used?: PasskeyDisplay;
 
     constructor(message: string, required: PasskeyDisplay, used?: PasskeyDisplay) {
-        super(message, SmartWalletErrors.ERROR_ADMIN_MISMATCH);
+        super(message, SmartWalletErrors.ERROR_PASSKEY_MISMATCH);
         this.required = required;
         this.used = used;
     }

--- a/packages/client/wallets/smart-wallet/src/index.ts
+++ b/packages/client/wallets/smart-wallet/src/index.ts
@@ -25,6 +25,8 @@ export {
     UserWalletAlreadyCreatedError,
     OutOfCreditsError,
     AdminAlreadyUsedError,
+    AdminMismatchError,
+    PasskeyMismatchError,
     ConfigError,
 } from "./error";
 

--- a/packages/client/wallets/smart-wallet/src/types/API.ts
+++ b/packages/client/wallets/smart-wallet/src/types/API.ts
@@ -24,3 +24,14 @@ export type PasskeySignerData = PasskeyValidatorSerializedData & {
     domain: string;
     type: "passkeys";
 };
+
+export type PasskeyDisplay = Pick<PasskeySignerData, "type" | "passkeyName" | "pubKeyX" | "pubKeyY">;
+export type SignerDisplay = EOASignerData | PasskeyDisplay;
+export function displayPasskey(data: PasskeySignerData): PasskeyDisplay {
+    return {
+        pubKeyX: data.pubKeyX,
+        pubKeyY: data.pubKeyY,
+        passkeyName: data.passkeyName,
+        type: "passkeys",
+    };
+}

--- a/packages/client/wallets/smart-wallet/src/types/internal.ts
+++ b/packages/client/wallets/smart-wallet/src/types/internal.ts
@@ -24,7 +24,7 @@ export function isSupportedEntryPointVersion(version: string): version is Suppor
 }
 
 export interface WalletCreationParams {
-    user: UserParams;
+    user: UserParams & { id: string };
     chain: EVMBlockchainIncludingTestnet;
     publicClient: PublicClient<HttpTransport>;
     walletParams: WalletParams;

--- a/packages/client/wallets/smart-wallet/src/utils/helpers.ts
+++ b/packages/client/wallets/smart-wallet/src/utils/helpers.ts
@@ -9,3 +9,7 @@ export function isLocalhost() {
 export function isEmpty(str: string | undefined | null): str is undefined | null {
     return !str || str.length === 0 || str.trim().length === 0;
 }
+
+export function equalsIgnoreCase(a?: string, b?: string): boolean {
+    return a?.toLowerCase() === b?.toLowerCase();
+}


### PR DESCRIPTION
## Description

This PR defines and uses two new errors:
- AdminMismatchError
- PasskeyMismatchError
As defined in [the errors spec](https://github.com/Paella-Labs/aa-wallet-sdk-docs/pull/6) (with some small improvements)

## Test plan

Locally, using the demo site, I tested each error.
