### PR TITLE
Smart Wallets: Turn Off DD Error Forwarding (Resolves WAL-2521)

### DIFF
--- a/packages/client/wallets/smart-wallet/src/services/logging/DatadogProvider.ts
+++ b/packages/client/wallets/smart-wallet/src/services/logging/DatadogProvider.ts
@@ -33,7 +33,7 @@ function init() {
     datadogLogs.init({
         clientToken: DATADOG_CLIENT_TOKEN,
         site: "datadoghq.com",
-        forwardErrorsToLogs: true,
+        forwardErrorsToLogs: false,
         sampleRate: 100,
     });
 }


### PR DESCRIPTION
## Description

This PR stops us from forwarding `console.error` logs to our DD.

## Test plan

Reproduce the issue via ngrok. Toggle the setting, and confirm that error logs no longer show up.
