### PR TITLE
Fix: `APIErrorService` not actually throwing the error up the call stack

### DIFF
--- a/packages/client/wallets/smart-wallet/src/api/APIErrorService.ts
+++ b/packages/client/wallets/smart-wallet/src/api/APIErrorService.ts
@@ -64,6 +64,9 @@ export class APIErrorService {
                 throw new CrossmintServiceError(body.message, response.status);
             }
         } catch (e) {
+            if (e instanceof SmartWalletSDKError) {
+                throw e;
+            }
             console.error("Error parsing response", e);
         }
 

--- a/packages/client/wallets/smart-wallet/src/error/index.ts
+++ b/packages/client/wallets/smart-wallet/src/error/index.ts
@@ -14,6 +14,7 @@ export const SmartWalletErrors = {
     ERROR_ADMIN_MISMATCH: "smart-wallet:wallet-config.admin-mismatch",
     ERROR_PASSKEY_MISMATCH: "smart-wallet:wallet-config.passkey-mismatch",
     ERROR_ADMIN_SIGNER_ALREADY_USED: "smart-wallet:wallet-config.admin-signer-already-used",
+    ERROR_PROJECT_NONCUSTODIAL_WALLETS_NOT_ENABLED: "smart-wallet:wallet-config.non-custodial-wallets-not-enabled",
     UNCATEGORIZED: "smart-wallet:uncategorized", // catch-all error code
 } as const;
 export type SmartWalletErrorCode = (typeof SmartWalletErrors)[keyof typeof SmartWalletErrors];
@@ -142,6 +143,7 @@ export class AdminAlreadyUsedError extends ConfigError {
 }
 
 export class NonCustodialWalletsNotEnabledError extends ConfigError {
+    public readonly code = SmartWalletErrors.ERROR_PROJECT_NONCUSTODIAL_WALLETS_NOT_ENABLED;
     constructor() {
         super("Non-custodial wallets are not enabled for this project");
     }


### PR DESCRIPTION
## Description

We had a bug here where the proper error was being selected and logged to the console, but not actually thrown up the call stack. When I was testing this I misread the console output

This PR also includes changes that I accidentally didn't stage for a previous PR, which is to add an SDK code to the error that we throw when a project isn't configured to use non custodial wallets

## Test plan

Tested locally