### PR TITLE
Smart Wallets: Update Chain Export

### DIFF
--- a/apps/wallets/smart-wallet/react/src/app/utils/createAAWallet/createMetamaskWallet.ts
+++ b/apps/wallets/smart-wallet/react/src/app/utils/createAAWallet/createMetamaskWallet.ts
@@ -1,7 +1,6 @@
 import { EIP1193Provider } from "viem";
 
-import { SmartWalletSDK } from "@crossmint/client-sdk-smart-wallet";
-import { SmartWalletChain } from "@crossmint/client-sdk-smart-wallet";
+import { Chain, SmartWalletSDK } from "@crossmint/client-sdk-smart-wallet";
 
 type WindowWithEthereum = Window & {
     ethereum: EIP1193Provider;
@@ -24,13 +23,9 @@ export const createMetamaskAAWallet = async (isProd: boolean) => {
                   clientApiKey: process.env.REACT_APP_CROSSMINT_API_KEY_STG || "",
               });
 
-        return await xm.getOrCreateWallet(
-            userIdentifier,
-            isProd ? SmartWalletChain.POLYGON : SmartWalletChain.POLYGON_AMOY,
-            {
-                signer: window.ethereum as any,
-            }
-        );
+        return await xm.getOrCreateWallet(userIdentifier, isProd ? Chain.POLYGON : Chain.POLYGON_AMOY, {
+            signer: window.ethereum as any,
+        });
     } catch (error) {
         console.error("Error creating MetaMask wallet:", error);
         throw error;

--- a/apps/wallets/smart-wallet/react/src/app/utils/createAAWallet/createPasskeyWallet.ts
+++ b/apps/wallets/smart-wallet/react/src/app/utils/createAAWallet/createPasskeyWallet.ts
@@ -1,5 +1,4 @@
-import { SmartWalletSDK } from "@crossmint/client-sdk-smart-wallet";
-import { SmartWalletChain } from "@crossmint/client-sdk-smart-wallet";
+import { SmartWalletSDK, Chain } from "@crossmint/client-sdk-smart-wallet";
 
 import { checkAuthState, signInWithGoogle } from "../../auth/FirebaseAuthManager";
 
@@ -22,7 +21,7 @@ export async function createPasskeyWallet(isProd: boolean) {
               clientApiKey: process.env.REACT_APP_CROSSMINT_API_KEY_STG || "",
           });
 
-    const chain = isProd ? SmartWalletChain.POLYGON : SmartWalletChain.POLYGON_AMOY;
+    const chain = isProd ? Chain.POLYGON : Chain.POLYGON_AMOY;
 
     const test = await xm.getOrCreateWallet({ jwt }, chain);
 

--- a/apps/wallets/smart-wallet/react/src/app/utils/createAAWallet/createPasskeyWallet.ts
+++ b/apps/wallets/smart-wallet/react/src/app/utils/createAAWallet/createPasskeyWallet.ts
@@ -1,4 +1,4 @@
-import { SmartWalletSDK, Chain } from "@crossmint/client-sdk-smart-wallet";
+import { Chain, SmartWalletSDK } from "@crossmint/client-sdk-smart-wallet";
 
 import { checkAuthState, signInWithGoogle } from "../../auth/FirebaseAuthManager";
 

--- a/apps/wallets/smart-wallet/react/src/app/utils/createAAWallet/createViemWallet.ts
+++ b/apps/wallets/smart-wallet/react/src/app/utils/createAAWallet/createViemWallet.ts
@@ -1,7 +1,6 @@
 import { privateKeyToAccount } from "viem/accounts";
 
-import { SmartWalletSDK, ViemAccount } from "@crossmint/client-sdk-smart-wallet";
-import { SmartWalletChain } from "@crossmint/client-sdk-smart-wallet";
+import { Chain, SmartWalletSDK, ViemAccount } from "@crossmint/client-sdk-smart-wallet";
 
 import { checkAuthState, signInWithGoogle } from "../../auth/FirebaseAuthManager";
 
@@ -31,6 +30,6 @@ export const createViemAAWallet = async (isProd: boolean, privateKey: `0x${strin
         type: "VIEM_ACCOUNT",
         account: privateKeyToAccount(privateKey) as unknown as ViemAccount["account"],
     };
-    const chain = isProd ? SmartWalletChain.POLYGON : SmartWalletChain.POLYGON_AMOY;
+    const chain = isProd ? Chain.POLYGON : Chain.POLYGON_AMOY;
     return await xm.getOrCreateWallet({ jwt }, chain, { signer });
 };

--- a/apps/wallets/smart-wallet/react/src/app/utils/createAAWallet/createW3AAAWallet.ts
+++ b/apps/wallets/smart-wallet/react/src/app/utils/createAAWallet/createW3AAAWallet.ts
@@ -1,5 +1,5 @@
 import { SmartWalletSDK, WalletParams } from "@crossmint/client-sdk-smart-wallet";
-import { SmartWalletChain } from "@crossmint/client-sdk-smart-wallet";
+import { Chain } from "@crossmint/client-sdk-smart-wallet";
 import { TORUS_NETWORK_TYPE, getWeb3AuthSigner } from "@crossmint/client-sdk-smart-wallet-web3auth-adapter";
 
 import { checkAuthState, signInWithGoogle } from "../../auth/FirebaseAuthManager";
@@ -22,7 +22,7 @@ export const createW3AAAWallet = async (isProd: boolean) => {
         : SmartWalletSDK.init({
               clientApiKey: process.env.REACT_APP_CROSSMINT_API_KEY_STG || "",
           });
-    const chain = isProd ? SmartWalletChain.POLYGON : SmartWalletChain.POLYGON_AMOY;
+    const chain = isProd ? Chain.POLYGON : Chain.POLYGON_AMOY;
 
     const walletConfig = {
         signer: await getWeb3AuthSigner({

--- a/apps/wallets/smart-wallet/react/src/app/utils/getContracts.ts
+++ b/apps/wallets/smart-wallet/react/src/app/utils/getContracts.ts
@@ -1,16 +1,16 @@
-import { SmartWalletChain } from "@crossmint/client-sdk-smart-wallet";
+import { Chain } from "@crossmint/client-sdk-smart-wallet";
 
-type GetContractAddressFunction = (chain: SmartWalletChain) => `0x${string}`;
+type GetContractAddressFunction = (chain: Chain) => `0x${string}`;
 
-export const getNFTContractAddress: GetContractAddressFunction = (chain: SmartWalletChain) => {
+export const getNFTContractAddress: GetContractAddressFunction = (chain: Chain) => {
     switch (chain) {
-        case SmartWalletChain.POLYGON:
+        case Chain.POLYGON:
             return "0x6A1e16403c7de87071703eB21C5FB745ecA0Bf41";
-        case SmartWalletChain.POLYGON_AMOY:
+        case Chain.POLYGON_AMOY:
             return "0xf07D348194eaCAE910051615cea2E90Ec4eCA439";
-        case SmartWalletChain.BASE:
+        case Chain.BASE:
             return "0xc81829d73e136CcFee90c17a49Ea7F9c2c28d3d7";
-        case SmartWalletChain.BASE_SEPOLIA:
+        case Chain.BASE_SEPOLIA:
             return "0x53413402DDc75895e98abEbe6940D7333F9b03D8";
         default:
             throw new Error(`[getNFTontractAddress] Invalid chain ${chain}`);
@@ -19,13 +19,13 @@ export const getNFTContractAddress: GetContractAddressFunction = (chain: SmartWa
 
 export const getERC20ContractAddress: GetContractAddressFunction = (chain) => {
     switch (chain) {
-        case SmartWalletChain.POLYGON:
+        case Chain.POLYGON:
             return "0xBE3E3CEdc9D9a1359415f9b3738F155f7b09c27c";
-        case SmartWalletChain.POLYGON_AMOY:
+        case Chain.POLYGON_AMOY:
             return "0xc81829d73e136CcFee90c17a49Ea7F9c2c28d3d7";
-        case SmartWalletChain.BASE:
+        case Chain.BASE:
             return "0xc93800Eaad38e2C809DdA65AF7e29f473bBf885a";
-        case SmartWalletChain.BASE_SEPOLIA:
+        case Chain.BASE_SEPOLIA:
             return "0xC0a167dc84060e34CC716a013d1f6260a51331f2";
         default:
             throw new Error(`[getERC20ContractAddress] Invalid chain ${chain}`);

--- a/apps/wallets/smart-wallet/react/src/app/utils/mintApi.ts
+++ b/apps/wallets/smart-wallet/react/src/app/utils/mintApi.ts
@@ -1,7 +1,7 @@
 import { ethers } from "ethers";
 import { encodeFunctionData } from "viem";
 
-import { EVMSmartWallet, SmartWalletChain } from "@crossmint/client-sdk-smart-wallet";
+import type { Chain, EVMSmartWallet } from "@crossmint/client-sdk-smart-wallet";
 
 import contractAbi from "./MintBurnABI.json";
 import contractERC20abi from "./erc20tokenSell.json";
@@ -98,7 +98,7 @@ export const walletContent = async (account: EVMSmartWallet, isProd: boolean) =>
     }
 };
 
-export const getTokenBalances = async (address: string, isProd: boolean, chain: SmartWalletChain) => {
+export const getTokenBalances = async (address: string, isProd: boolean, chain: Chain) => {
     const baseURL = isProd ? "https://www.crossmint.com" : "https://staging.crossmint.com";
     const apikey = isProd ? process.env.REACT_APP_CROSSMINT_API_KEY_PROD : process.env.REACT_APP_CROSSMINT_API_KEY_STG;
 

--- a/crossmint-sdk.code-workspace
+++ b/crossmint-sdk.code-workspace
@@ -45,6 +45,10 @@
             "path": "packages/client/verifiable-credentials"
         },
         {
+            "name": "🔒 @crossmint/client-sdk-smart-wallet",
+            "path": "packages/client/wallets/smart-wallet"
+        },
+        {
             "name": "🏁 Apps",
             "path": "apps"
         }

--- a/packages/client/wallets/smart-wallet/src/index.ts
+++ b/packages/client/wallets/smart-wallet/src/index.ts
@@ -1,4 +1,4 @@
-export { blockchainToChainId } from "@crossmint/common-sdk-base";
+export { blockchainToChainId, EVMBlockchainIncludingTestnet as Chain } from "@crossmint/common-sdk-base";
 
 export { EVMSmartWallet } from "./blockchain/wallets/EVMSmartWallet";
 
@@ -12,7 +12,6 @@ export type {
 } from "./types/Config";
 
 export type { TransferType, ERC20TransferType, NFTTransferType, SFTTransferType } from "./types/Tokens";
-export { SmartWalletChain } from "./blockchain/chains";
 
 export {
     TransferError,

--- a/packages/client/wallets/smart-wallet/src/types/Tokens.ts
+++ b/packages/client/wallets/smart-wallet/src/types/Tokens.ts
@@ -1,4 +1,4 @@
-import { SmartWalletChain } from "..";
+import type { SmartWalletChain } from "../blockchain/chains";
 
 export interface EVMToken {
     chain: SmartWalletChain;

--- a/packages/client/wallets/smart-wallet/src/types/internal.ts
+++ b/packages/client/wallets/smart-wallet/src/types/internal.ts
@@ -4,7 +4,7 @@ import type { SmartAccount } from "permissionless/accounts";
 import type { EntryPoint } from "permissionless/types/entrypoint";
 import type { Chain, Hex, HttpTransport, PublicClient } from "viem";
 
-import { SmartWalletChain } from "..";
+import type { SmartWalletChain } from "../blockchain/chains";
 import type { SignerData } from "./API";
 import type { EntryPointDetails, UserParams, WalletParams } from "./Config";
 

--- a/packages/client/wallets/smart-wallet/src/utils/blockchain.ts
+++ b/packages/client/wallets/smart-wallet/src/utils/blockchain.ts
@@ -1,4 +1,4 @@
-import { SmartWalletChain } from "..";
+import { SmartWalletChain } from "../blockchain/chains";
 
 export function usesGelatoBundler(chain: SmartWalletChain) {
     return false;

--- a/packages/client/wallets/smart-wallet/src/utils/signer.ts
+++ b/packages/client/wallets/smart-wallet/src/utils/signer.ts
@@ -2,7 +2,7 @@ import { providerToSmartAccountSigner } from "permissionless";
 import type { SmartAccountSigner } from "permissionless/accounts";
 import { Address, EIP1193Provider } from "viem";
 
-import { SmartWalletChain } from "..";
+import { SmartWalletChain } from "../blockchain/chains";
 import { SmartWalletSDKError } from "../error";
 import { ViemAccount, WalletParams } from "../types/Config";
 import { logInputOutput } from "./log";

--- a/packages/client/wallets/web3auth-adapter/src/index.ts
+++ b/packages/client/wallets/web3auth-adapter/src/index.ts
@@ -18,7 +18,7 @@ import {
 } from "./networks";
 
 export type { TORUS_NETWORK_TYPE } from "@web3auth/single-factor-auth";
-export { EVMBlockchainIncludingTestnet as Blockchain } from "@crossmint/common-sdk-base";
+export { EVMBlockchainIncludingTestnet as Chain } from "@crossmint/common-sdk-base";
 export type Web3AuthSignerParams = {
     clientId: string;
     verifierId: string;


### PR DESCRIPTION
## Description

This PR:
- removes the `SmartWalletChain` export from `@crossmint/client-sdk-smart-wallet`, and replaces it with the chains from the core sdk package, renamed from `EVMChainsIncludingTestnet` to `Chain`.
- renames the chain export from `@crossmint/client-sdk-smart-wallet-web3auth-adapter`, which is already doing what I mention above, from `Blockchain` to `Chain`.

These are breaking changes, but I only want to do a patch version bump, the SDK shipped less than 24 hrs ago and is in EAP mode so I'm comfortable breaking semantic versioning rules.

## Test plan

Updated the Demo to use the new export and TS compiled.
