### PR TITLE
Smart Wallets: Passkey Prompt Error (Resolves WAL-2464)

### DIFF
--- a/crossmint-sdk.code-workspace
+++ b/crossmint-sdk.code-workspace
@@ -29,7 +29,7 @@
             "path": "packages/client/ui/react-ui"
         },
         {
-            "name": "⚛️ @crossmint/client-sdk-smart-wallet-react-starter",
+            "name": "⚛️🔒 @crossmint/client-sdk-smart-wallet-react-starter",
             "path": "apps/wallets/smart-wallet/react"
         },
         {

--- a/packages/client/wallets/smart-wallet/src/blockchain/wallets/passkey.ts
+++ b/packages/client/wallets/smart-wallet/src/blockchain/wallets/passkey.ts
@@ -3,7 +3,7 @@ import { type PasskeySignerData, displayPasskey } from "@/types/API";
 import type { PasskeySigner, UserParams, WalletParams } from "@/types/Config";
 import type { AccountAndSigner, PasskeyValidatorSerializedData, WalletCreationParams } from "@/types/internal";
 import { PasskeyValidatorContractVersion, WebAuthnMode, toPasskeyValidator } from "@zerodev/passkey-validator";
-import { KernelSmartAccount, type KernelValidator, createKernelAccount } from "@zerodev/sdk";
+import { type KernelSmartAccount, type KernelValidator, createKernelAccount } from "@zerodev/sdk";
 import { WebAuthnKey, toWebAuthnKey } from "@zerodev/webauthn-key";
 import type { EntryPoint } from "permissionless/types/entrypoint";
 

--- a/packages/client/wallets/smart-wallet/src/error/index.ts
+++ b/packages/client/wallets/smart-wallet/src/error/index.ts
@@ -13,6 +13,7 @@ export const SmartWalletErrors = {
     ERROR_WALLET_CONFIG: "smart-wallet:wallet-config.error",
     ERROR_ADMIN_MISMATCH: "smart-wallet:wallet-config.admin-mismatch",
     ERROR_PASSKEY_MISMATCH: "smart-wallet:wallet-config.passkey-mismatch",
+    ERROR_PASSKEY_PROMPT: "smart-wallet:passkey.prompt",
     ERROR_ADMIN_SIGNER_ALREADY_USED: "smart-wallet:wallet-config.admin-signer-already-used",
     ERROR_PROJECT_NONCUSTODIAL_WALLETS_NOT_ENABLED: "smart-wallet:wallet-config.non-custodial-wallets-not-enabled",
     UNCATEGORIZED: "smart-wallet:uncategorized", // catch-all error code
@@ -116,6 +117,15 @@ export class UserWalletAlreadyCreatedError extends SmartWalletSDKError {
 
     constructor(userId: string) {
         super(`The user with userId ${userId.toString()} already has a wallet created for this project`);
+    }
+}
+
+export class PasskeyPromptError extends SmartWalletSDKError {
+    public passkeyName: string;
+
+    constructor(passkeyName: string) {
+        super("Passkey prompt was either cancelled or timed out", SmartWalletErrors.ERROR_PASSKEY_PROMPT);
+        this.passkeyName = passkeyName;
     }
 }
 

--- a/packages/client/wallets/smart-wallet/src/error/index.ts
+++ b/packages/client/wallets/smart-wallet/src/error/index.ts
@@ -124,7 +124,10 @@ export class PasskeyPromptError extends SmartWalletSDKError {
     public passkeyName: string;
 
     constructor(passkeyName: string) {
-        super("Passkey prompt was either cancelled or timed out", SmartWalletErrors.ERROR_PASSKEY_PROMPT);
+        super(
+            `Prompt was either cancelled or timed out for passkey ${passkeyName}`,
+            SmartWalletErrors.ERROR_PASSKEY_PROMPT
+        );
         this.passkeyName = passkeyName;
     }
 }

--- a/packages/client/wallets/smart-wallet/src/index.ts
+++ b/packages/client/wallets/smart-wallet/src/index.ts
@@ -27,6 +27,7 @@ export {
     AdminAlreadyUsedError,
     AdminMismatchError,
     PasskeyMismatchError,
+    PasskeyPromptError,
     ConfigError,
     NonCustodialWalletsNotEnabledError,
 } from "./error";


### PR DESCRIPTION
## Description

This PR:
- lays the foundation for catching passkey specific errors
- adds an error for when a passkey prompt is cancelled or times out.

## Test plan

Locally, using the demo site, tested the error both when registering a passkey for a new wallet and signing a user operation.
