### PR TITLE
Smart Wallets: Passkey Registration Error (Resolves WAL-2557)

### DIFF
--- a/packages/client/wallets/smart-wallet/src/blockchain/wallets/passkey.ts
+++ b/packages/client/wallets/smart-wallet/src/blockchain/wallets/passkey.ts
@@ -3,7 +3,7 @@ import { type PasskeySignerData, displayPasskey } from "@/types/API";
 import type { PasskeySigner, UserParams, WalletParams } from "@/types/Config";
 import type { AccountAndSigner, PasskeyValidatorSerializedData, WalletCreationParams } from "@/types/internal";
 import { PasskeyValidatorContractVersion, WebAuthnMode, toPasskeyValidator } from "@zerodev/passkey-validator";
-import { KernelSmartAccount, type KernelValidator, createKernelAccount } from "@zerodev/sdk";
+import { type KernelSmartAccount, type KernelValidator, createKernelAccount } from "@zerodev/sdk";
 import { WebAuthnKey, toWebAuthnKey } from "@zerodev/webauthn-key";
 import type { EntryPoint } from "permissionless/types/entrypoint";
 

--- a/packages/client/wallets/smart-wallet/src/blockchain/wallets/passkey.ts
+++ b/packages/client/wallets/smart-wallet/src/blockchain/wallets/passkey.ts
@@ -7,7 +7,7 @@ import { type KernelSmartAccount, type KernelValidator, createKernelAccount } fr
 import { WebAuthnKey, toWebAuthnKey } from "@zerodev/webauthn-key";
 import type { EntryPoint } from "permissionless/types/entrypoint";
 
-import { PasskeyMismatchError, PasskeyPromptError } from "../../error";
+import { PasskeyMismatchError, PasskeyPromptError, PasskeyRegistrationError } from "../../error";
 
 export interface PasskeyWalletParams extends WalletCreationParams {
     walletParams: WalletParams & { signer: PasskeySigner };
@@ -108,6 +108,10 @@ export class PasskeyAccountService {
     }
 
     private mapError(error: any, passkeyName: string) {
+        if (error.message === "Registration not verified") {
+            return new PasskeyRegistrationError(passkeyName);
+        }
+
         if (error.code === "ERROR_PASSTHROUGH_SEE_CAUSE_PROPERTY" && error.name === "NotAllowedError") {
             return new PasskeyPromptError(passkeyName);
         }

--- a/packages/client/wallets/smart-wallet/src/error/index.ts
+++ b/packages/client/wallets/smart-wallet/src/error/index.ts
@@ -14,6 +14,7 @@ export const SmartWalletErrors = {
     ERROR_ADMIN_MISMATCH: "smart-wallet:wallet-config.admin-mismatch",
     ERROR_PASSKEY_MISMATCH: "smart-wallet:wallet-config.passkey-mismatch",
     ERROR_PASSKEY_PROMPT: "smart-wallet:passkey.prompt",
+    ERROR_PASSKEY_REGISTRATION: "smart-wallet:passkey.registration",
     ERROR_ADMIN_SIGNER_ALREADY_USED: "smart-wallet:wallet-config.admin-signer-already-used",
     ERROR_PROJECT_NONCUSTODIAL_WALLETS_NOT_ENABLED: "smart-wallet:wallet-config.non-custodial-wallets-not-enabled",
     UNCATEGORIZED: "smart-wallet:uncategorized", // catch-all error code
@@ -126,7 +127,21 @@ export class PasskeyPromptError extends SmartWalletSDKError {
     constructor(passkeyName: string) {
         super(
             `Prompt was either cancelled or timed out for passkey ${passkeyName}`,
+            undefined,
             SmartWalletErrors.ERROR_PASSKEY_PROMPT
+        );
+        this.passkeyName = passkeyName;
+    }
+}
+
+export class PasskeyRegistrationError extends SmartWalletSDKError {
+    public passkeyName: string;
+
+    constructor(passkeyName: string) {
+        super(
+            `Registration for passkey ${passkeyName} failed, either the registration took too long, or passkey signature vaildation failed.`,
+            undefined,
+            SmartWalletErrors.ERROR_PASSKEY_REGISTRATION
         );
         this.passkeyName = passkeyName;
     }

--- a/packages/client/wallets/smart-wallet/src/error/index.ts
+++ b/packages/client/wallets/smart-wallet/src/error/index.ts
@@ -13,6 +13,7 @@ export const SmartWalletErrors = {
     ERROR_WALLET_CONFIG: "smart-wallet:wallet-config.error",
     ERROR_ADMIN_MISMATCH: "smart-wallet:wallet-config.admin-mismatch",
     ERROR_PASSKEY_MISMATCH: "smart-wallet:wallet-config.passkey-mismatch",
+    ERROR_PASSKEY_PROMPT: "smart-wallet:passkey.prompt",
     ERROR_ADMIN_SIGNER_ALREADY_USED: "smart-wallet:wallet-config.admin-signer-already-used",
     ERROR_PROJECT_NONCUSTODIAL_WALLETS_NOT_ENABLED: "smart-wallet:wallet-config.non-custodial-wallets-not-enabled",
     UNCATEGORIZED: "smart-wallet:uncategorized", // catch-all error code
@@ -116,6 +117,15 @@ export class UserWalletAlreadyCreatedError extends SmartWalletSDKError {
 
     constructor(userId: string) {
         super(`The user with userId ${userId.toString()} already has a wallet created for this project`);
+    }
+}
+
+export class PasskeyPromptError extends SmartWalletSDKError {
+    public passkeyName: string;
+
+    constructor(passkeyName: string) {
+        super("Passkey prompt was either cancelled or timed out", SmartWalletErrors.ERROR_PASSKEY_PROMPT);
+        this.passkeyName = passkeyName;
     }
 }
 

--- a/packages/client/wallets/smart-wallet/src/error/index.ts
+++ b/packages/client/wallets/smart-wallet/src/error/index.ts
@@ -124,7 +124,10 @@ export class PasskeyPromptError extends SmartWalletSDKError {
     public passkeyName: string;
 
     constructor(passkeyName: string) {
-        super("Passkey prompt was either cancelled or timed out", SmartWalletErrors.ERROR_PASSKEY_PROMPT);
+        super(
+            `Prompt was either cancelled or timed out for passkey ${passkeyName}`,
+            SmartWalletErrors.ERROR_PASSKEY_PROMPT
+        );
         this.passkeyName = passkeyName;
     }
 }

--- a/packages/client/wallets/smart-wallet/src/index.ts
+++ b/packages/client/wallets/smart-wallet/src/index.ts
@@ -27,6 +27,7 @@ export {
     AdminAlreadyUsedError,
     AdminMismatchError,
     PasskeyMismatchError,
+    PasskeyPromptError,
     ConfigError,
     NonCustodialWalletsNotEnabledError,
 } from "./error";

--- a/packages/client/wallets/smart-wallet/src/index.ts
+++ b/packages/client/wallets/smart-wallet/src/index.ts
@@ -28,6 +28,7 @@ export {
     AdminMismatchError,
     PasskeyMismatchError,
     PasskeyPromptError,
+    PasskeyRegistrationError,
     ConfigError,
     NonCustodialWalletsNotEnabledError,
 } from "./error";


### PR DESCRIPTION
## Description

We receive a pretty vague error through the SDK when our passkey server fails to verify a registration, either because it took too long, or the signature was invalid.

This PR adds error handling for this case!

## Test plan

Locally reproduced the error, confirming the new improved error is thrown now.
