### PR TITLE
AA: Add Optimism/Arbitrum mainnet and testnet

### DIFF
--- a/packages/client/wallets/smart-wallet/src/blockchain/chains.ts
+++ b/packages/client/wallets/smart-wallet/src/blockchain/chains.ts
@@ -1,5 +1,15 @@
 import { BUNDLER_RPC } from "@/utils/constants";
-import { Chain, base, baseSepolia, polygon, polygonAmoy, optimism, optimismSepolia, } from "viem/chains";
+import {
+    Chain,
+    arbitrum,
+    arbitrumSepolia,
+    base,
+    baseSepolia,
+    optimism,
+    optimismSepolia,
+    polygon,
+    polygonAmoy,
+} from "viem/chains";
 
 import { BlockchainIncludingTestnet as Blockchain, ObjectValues, objectValues } from "@crossmint/common-sdk-base";
 
@@ -7,6 +17,7 @@ export const SmartWalletTestnet = {
     BASE_SEPOLIA: Blockchain.BASE_SEPOLIA,
     POLYGON_AMOY: Blockchain.POLYGON_AMOY,
     OPTIMISM_SEPOLIA: Blockchain.OPTIMISM_SEPOLIA,
+    ARBITRUM_SEPOLIA: Blockchain.ARBITRUM_SEPOLIA,
 } as const;
 export type SmartWalletTestnet = ObjectValues<typeof SmartWalletTestnet>;
 export const SMART_WALLET_TESTNETS = objectValues(SmartWalletTestnet);
@@ -15,6 +26,7 @@ export const SmartWalletMainnet = {
     BASE: Blockchain.BASE,
     POLYGON: Blockchain.POLYGON,
     OPTIMISM: Blockchain.OPTIMISM,
+    ARBITRUM: Blockchain.ARBITRUM,
 } as const;
 export type SmartWalletMainnet = ObjectValues<typeof SmartWalletMainnet>;
 export const SMART_WALLET_MAINNETS = objectValues(SmartWalletMainnet);
@@ -33,6 +45,8 @@ export const zerodevProjects: Record<SmartWalletChain, string> = {
     base: "e8b3020f-4dde-4176-8a7d-be8102527a5c",
     "optimism-sepolia": "f8dd488e-eaed-467d-a5de-0184c160f3b1",
     optimism: "505950ab-ee07-4a9c-bd16-320ac71a9350",
+    arbitrum: "a965100f-fedf-4e6b-a207-20f5687fcc4f",
+    "arbitrum-sepolia": "76c860ca-af77-4fb1-8eac-07825952f6f4",
 };
 
 export const viemNetworks: Record<SmartWalletChain, Chain> = {
@@ -42,6 +56,8 @@ export const viemNetworks: Record<SmartWalletChain, Chain> = {
     "base-sepolia": baseSepolia,
     optimism: optimism,
     "optimism-sepolia": optimismSepolia,
+    arbitrum: arbitrum,
+    "arbitrum-sepolia": arbitrumSepolia,
 };
 
 export const getBundlerRPC = (chain: SmartWalletChain) => {

--- a/packages/client/wallets/smart-wallet/src/blockchain/chains.ts
+++ b/packages/client/wallets/smart-wallet/src/blockchain/chains.ts
@@ -1,11 +1,12 @@
 import { BUNDLER_RPC } from "@/utils/constants";
-import { Chain, base, baseSepolia, polygon, polygonAmoy } from "viem/chains";
+import { Chain, base, baseSepolia, polygon, polygonAmoy, optimism, optimismSepolia, } from "viem/chains";
 
 import { BlockchainIncludingTestnet as Blockchain, ObjectValues, objectValues } from "@crossmint/common-sdk-base";
 
 export const SmartWalletTestnet = {
     BASE_SEPOLIA: Blockchain.BASE_SEPOLIA,
     POLYGON_AMOY: Blockchain.POLYGON_AMOY,
+    OPTIMISM_SEPOLIA: Blockchain.OPTIMISM_SEPOLIA,
 } as const;
 export type SmartWalletTestnet = ObjectValues<typeof SmartWalletTestnet>;
 export const SMART_WALLET_TESTNETS = objectValues(SmartWalletTestnet);
@@ -13,6 +14,7 @@ export const SMART_WALLET_TESTNETS = objectValues(SmartWalletTestnet);
 export const SmartWalletMainnet = {
     BASE: Blockchain.BASE,
     POLYGON: Blockchain.POLYGON,
+    OPTIMISM: Blockchain.OPTIMISM,
 } as const;
 export type SmartWalletMainnet = ObjectValues<typeof SmartWalletMainnet>;
 export const SMART_WALLET_MAINNETS = objectValues(SmartWalletMainnet);
@@ -29,6 +31,8 @@ export const zerodevProjects: Record<SmartWalletChain, string> = {
     "polygon-amoy": "3deef404-ca06-4a5d-9a58-907c99e7ef00",
     "base-sepolia": "5a127978-6473-4784-9dfb-f74395b220a6",
     base: "e8b3020f-4dde-4176-8a7d-be8102527a5c",
+    "optimism-sepolia": "f8dd488e-eaed-467d-a5de-0184c160f3b1",
+    optimism: "505950ab-ee07-4a9c-bd16-320ac71a9350",
 };
 
 export const viemNetworks: Record<SmartWalletChain, Chain> = {
@@ -36,6 +40,8 @@ export const viemNetworks: Record<SmartWalletChain, Chain> = {
     "polygon-amoy": polygonAmoy,
     base: base,
     "base-sepolia": baseSepolia,
+    optimism: optimism,
+    "optimism-sepolia": optimismSepolia,
 };
 
 export const getBundlerRPC = (chain: SmartWalletChain) => {


### PR DESCRIPTION
## Description

Adding two different chains with low gas fees and EIP-7212 support

Some highlights:
- Set the webhook policy to the same as for other SFK projects. That is, 
`https://crossmint-main-staging.azurewebsites.net/api/unstable/wallets/aa/webhookPolicy`
`https://crossmint-main.azurewebsites.net/api/unstable/wallets/aa/webhookPolicy`
- Set the gas sponsoring policy to 500 gwei max on mainnets and 1000 gwei on testnets

Decided not to integrate Ethereum as neither gas is cheap nor has secp256r1 support.

Both chains support the latest v0.7 Entrypoint and v3.1 Kernel

## Test plan

### Minting test

AA mint on Optimism using passkeys https://sepolia-optimism.etherscan.io/tx/0x2e4cf72c81b0936f5dd06cf5a35f0637ade9e49dd9b87acd299b8d83b766b7f0 

And another AA mint on Arbitrum Sepolia https://sepolia.arbiscan.io/tx/0xe1ba6cf7bafff96d9a9977db1a90d549cb3f860ff2352971467de6008fc57646 

### Signature test

Using this code

```typescript
    const signedData = await account.client.wallet.signMessage({
        message: `Mysignedmessage`,
    })
    const verificationResult = await account.client.public.verifyMessage(
        {
            address: account.address,
            message: `Mysignedmessage`,
            signature: signedData,
        }
    )
    console.log("Verification result", verificationResult);
```

It properly verifies the message in
- Arbitrum Sepolia ✅ 
- Optimism Sepolia ✅ 

## Follow up

Adapt demo to also use these chains
