### PR TITLE
Smart Wallets: Export Error Codes

### DIFF
--- a/packages/client/wallets/smart-wallet/src/SmartWalletSDK.ts
+++ b/packages/client/wallets/smart-wallet/src/SmartWalletSDK.ts
@@ -7,7 +7,7 @@ import { SmartWalletChain } from "./blockchain/chains";
 import type { EVMSmartWallet } from "./blockchain/wallets";
 import { ClientDecorator } from "./blockchain/wallets/clientDecorator";
 import { SmartWalletService } from "./blockchain/wallets/service";
-import { SmartWalletSDKError } from "./error";
+import { SmartWalletError } from "./error";
 import { ErrorProcessor } from "./error/processor";
 import { DatadogProvider } from "./services/logging/DatadogProvider";
 import type { SmartWalletSDKInitParams, UserParams, WalletParams } from "./types/Config";
@@ -28,7 +28,7 @@ export class SmartWalletSDK extends LoggerWrapper {
      */
     static init({ clientApiKey }: SmartWalletSDKInitParams): SmartWalletSDK {
         if (!isClient()) {
-            throw new SmartWalletSDKError("Smart Wallet SDK should only be used client side.");
+            throw new SmartWalletError("Smart Wallet SDK should only be used client side.");
         }
 
         const validationResult = validateAPIKey(clientApiKey);
@@ -66,7 +66,7 @@ export class SmartWalletSDK extends LoggerWrapper {
                 } catch (error: any) {
                     throw this.errorProcessor.map(
                         error,
-                        new SmartWalletSDKError(`Wallet creation failed: ${error.message}.`, stringify(error))
+                        new SmartWalletError(`Wallet creation failed: ${error.message}.`, stringify(error))
                     );
                 }
             },

--- a/packages/client/wallets/smart-wallet/src/api/APIErrorService.ts
+++ b/packages/client/wallets/smart-wallet/src/api/APIErrorService.ts
@@ -7,7 +7,7 @@ import {
     JWTInvalidError,
     NonCustodialWalletsNotEnabledError,
     OutOfCreditsError,
-    SmartWalletSDKError,
+    SmartWalletError,
     UserWalletAlreadyCreatedError,
 } from "@/error";
 
@@ -22,7 +22,7 @@ export type CrossmintAPIErrorCodes =
 
 export class APIErrorService {
     constructor(
-        private errors: Partial<Record<CrossmintAPIErrorCodes, (apiResponse: any) => SmartWalletSDKError>> = {
+        private errors: Partial<Record<CrossmintAPIErrorCodes, (apiResponse: any) => SmartWalletError>> = {
             ERROR_JWT_INVALID: () => new JWTInvalidError(),
             ERROR_JWT_DECRYPTION: () => new JWTDecryptionError(),
             ERROR_JWT_EXPIRED: ({ expiredAt }: { expiredAt: string }) => new JWTExpiredError(new Date(expiredAt)),
@@ -64,7 +64,7 @@ export class APIErrorService {
                 throw new CrossmintServiceError(body.message, response.status);
             }
         } catch (e) {
-            if (e instanceof SmartWalletSDKError) {
+            if (e instanceof SmartWalletError) {
                 throw e;
             }
             console.error("Error parsing response", e);

--- a/packages/client/wallets/smart-wallet/src/blockchain/wallets/clientDecorator.ts
+++ b/packages/client/wallets/smart-wallet/src/blockchain/wallets/clientDecorator.ts
@@ -1,4 +1,4 @@
-import { SmartWalletSDKError } from "@/error";
+import { SmartWalletError } from "@/error";
 import { ErrorProcessor } from "@/error/processor";
 import { logInfo } from "@/services/logging";
 import { usesGelatoBundler } from "@/utils/blockchain";
@@ -83,7 +83,7 @@ export class ClientDecorator {
             const description = isTxnMethod(prop) ? "signing" : "sending transaction";
             throw this.errorProcessor.map(
                 error,
-                new SmartWalletSDKError(`Error ${description}: ${error.message}`, stringify(error))
+                new SmartWalletError(`Error ${description}: ${error.message}`, stringify(error))
             );
         }
     }

--- a/packages/client/wallets/smart-wallet/src/blockchain/wallets/service.ts
+++ b/packages/client/wallets/smart-wallet/src/blockchain/wallets/service.ts
@@ -11,7 +11,7 @@ import type { CrossmintWalletService } from "../../api/CrossmintWalletService";
 import {
     AdminMismatchError,
     CrossmintServiceError,
-    SmartWalletSDKError,
+    SmartWalletError,
     UserWalletAlreadyCreatedError,
 } from "../../error";
 import type { EntryPointDetails, UserParams, WalletParams } from "../../types/Config";
@@ -110,7 +110,7 @@ export class SmartWalletService {
             await this.crossmintWalletService.getSmartWalletConfig(user, chain);
 
         if (!isSupportedKernelVersion(kernelVersion)) {
-            throw new SmartWalletSDKError(
+            throw new SmartWalletError(
                 `Unsupported kernel version. Supported versions: ${SUPPORTED_KERNEL_VERSIONS.join(
                     ", "
                 )}. Version used: ${kernelVersion}, Please contact support`
@@ -118,7 +118,7 @@ export class SmartWalletService {
         }
 
         if (!isSupportedEntryPointVersion(entryPointVersion)) {
-            throw new SmartWalletSDKError(
+            throw new SmartWalletError(
                 `Unsupported entry point version. Supported versions: ${SUPPORTED_ENTRYPOINT_VERSIONS.join(
                     ", "
                 )}. Version used: ${entryPointVersion}. Please contact support`
@@ -129,7 +129,7 @@ export class SmartWalletService {
             (entryPointVersion === "v0.7" && kernelVersion.startsWith("0.2")) ||
             (entryPointVersion === "v0.6" && kernelVersion.startsWith("0.3"))
         ) {
-            throw new SmartWalletSDKError(
+            throw new SmartWalletError(
                 `Unsupported combination: entryPoint ${entryPointVersion} and kernel version ${kernelVersion}. Please contact support`
             );
         }

--- a/packages/client/wallets/smart-wallet/src/error/index.ts
+++ b/packages/client/wallets/smart-wallet/src/error/index.ts
@@ -1,83 +1,83 @@
 import { PasskeyDisplay, SignerDisplay } from "@/types/API";
 
-export const SmartWalletErrors = {
-    NOT_AUTHORIZED: "smart-wallet:not-authorized",
-    TRANSFER: "smart-wallet:transfer.error",
-    CROSSMINT_SERVICE: "smart-wallet:crossmint-service.error",
-    ERROR_JWT_EXPIRED: "smart-wallet:not-authorized.jwt-expired",
-    ERROR_JWT_INVALID: "smart-wallet:not-authorized.jwt-invalid",
-    ERROR_JWT_DECRYPTION: "smart-wallet:not-authorized.jwt-decryption",
-    ERROR_JWT_IDENTIFIER: "smart-wallet:not-authorized.jwt-identifier",
-    ERROR_USER_WALLET_ALREADY_CREATED: "smart-wallet:user-wallet-already-created.error",
-    ERROR_OUT_OF_CREDITS: "smart-wallet:out-of-credits.error",
-    ERROR_WALLET_CONFIG: "smart-wallet:wallet-config.error",
-    ERROR_ADMIN_MISMATCH: "smart-wallet:wallet-config.admin-mismatch",
-    ERROR_PASSKEY_MISMATCH: "smart-wallet:wallet-config.passkey-mismatch",
-    ERROR_PASSKEY_PROMPT: "smart-wallet:passkey.prompt",
-    ERROR_PASSKEY_INCOMPATIBLE_AUTHENTICATOR: "smart-wallet.passkey.incompatible-authenticator",
-    ERROR_PASSKEY_REGISTRATION: "smart-wallet:passkey.registration",
-    ERROR_ADMIN_SIGNER_ALREADY_USED: "smart-wallet:wallet-config.admin-signer-already-used",
-    ERROR_PROJECT_NONCUSTODIAL_WALLETS_NOT_ENABLED: "smart-wallet:wallet-config.non-custodial-wallets-not-enabled",
-    UNCATEGORIZED: "smart-wallet:uncategorized", // catch-all error code
+export const SmartWalletErrorCode = {
+    NOT_AUTHORIZED: "not-authorized",
+    CROSSMINT_SERVICE: "crossmint-service",
+    JWT_EXPIRED: "not-authorized.jwt-expired",
+    JWT_INVALID: "not-authorized.jwt-invalid",
+    JWT_DECRYPTION: "not-authorized.jwt-decryption",
+    JWT_IDENTIFIER: "not-authorized.jwt-identifier",
+    OUT_OF_CREDITS: "out-of-credits",
+    TRANSFER: "smart-wallet:transfer",
+    SMART_WALLETS_NOT_ENABLED: "smart-wallet:not-enabled",
+    USER_WALLET_ALREADY_CREATED: "smart-wallet:user-wallet-already-created",
+    WALLET_CONFIG: "smart-wallet:config",
+    ADMIN_MISMATCH: "smart-wallet:config.admin-mismatch",
+    PASSKEY_MISMATCH: "smart-wallet:config.passkey-mismatch",
+    ADMIN_SIGNER_ALREADY_USED: "smart-wallet:config.admin-signer-already-used",
+    PASSKEY_PROMPT: "smart-wallet:passkey.prompt",
+    PASSKEY_INCOMPATIBLE_AUTHENTICATOR: "smart-wallet:passkey.incompatible-authenticator",
+    PASSKEY_REGISTRATION: "smart-wallet:passkey.registration",
+    UNCATEGORIZED: "smart-wallet:uncategorized", // smart wallet specific catch-all error code
 } as const;
-export type SmartWalletErrorCode = (typeof SmartWalletErrors)[keyof typeof SmartWalletErrors];
+export type SmartWalletErrorCode = (typeof SmartWalletErrorCode)[keyof typeof SmartWalletErrorCode];
 
-export class SmartWalletSDKError extends Error {
+export class SmartWalletError extends Error {
     public readonly code: SmartWalletErrorCode;
     public readonly details?: string;
 
-    constructor(message: string, details?: string, code: SmartWalletErrorCode = SmartWalletErrors.UNCATEGORIZED) {
+    constructor(message: string, details?: string, code: SmartWalletErrorCode = SmartWalletErrorCode.UNCATEGORIZED) {
         super(message);
         this.details = details;
         this.code = code;
     }
 }
 
-export class TransferError extends SmartWalletSDKError {
+export class TransferError extends SmartWalletError {
     constructor(message: string) {
-        super(message, undefined, SmartWalletErrors.TRANSFER);
+        super(message, undefined, SmartWalletErrorCode.TRANSFER);
     }
 }
 
-export class CrossmintServiceError extends SmartWalletSDKError {
+export class CrossmintServiceError extends SmartWalletError {
     public status?: number;
 
     constructor(message: string, status?: number) {
-        super(message, undefined, SmartWalletErrors.CROSSMINT_SERVICE);
+        super(message, undefined, SmartWalletErrorCode.CROSSMINT_SERVICE);
         this.status = status;
     }
 }
 
-export class AdminMismatchError extends SmartWalletSDKError {
+export class AdminMismatchError extends SmartWalletError {
     public readonly required: SignerDisplay;
     public readonly used?: SignerDisplay;
 
     constructor(message: string, required: SignerDisplay, used?: SignerDisplay) {
-        super(message, SmartWalletErrors.ERROR_ADMIN_MISMATCH);
+        super(message, SmartWalletErrorCode.ADMIN_MISMATCH);
         this.required = required;
         this.used = used;
     }
 }
 
-export class PasskeyMismatchError extends SmartWalletSDKError {
+export class PasskeyMismatchError extends SmartWalletError {
     public readonly required: PasskeyDisplay;
     public readonly used?: PasskeyDisplay;
 
     constructor(message: string, required: PasskeyDisplay, used?: PasskeyDisplay) {
-        super(message, SmartWalletErrors.ERROR_PASSKEY_MISMATCH);
+        super(message, SmartWalletErrorCode.PASSKEY_MISMATCH);
         this.required = required;
         this.used = used;
     }
 }
 
-export class NotAuthorizedError extends SmartWalletSDKError {
+export class NotAuthorizedError extends SmartWalletError {
     constructor(message: string) {
-        super(message, undefined, SmartWalletErrors.NOT_AUTHORIZED);
+        super(message, undefined, SmartWalletErrorCode.NOT_AUTHORIZED);
     }
 }
 
 export class JWTExpiredError extends NotAuthorizedError {
-    public readonly code = SmartWalletErrors.ERROR_JWT_EXPIRED;
+    public readonly code = SmartWalletErrorCode.JWT_EXPIRED;
 
     /**
      * The expiry time of the JWT as an ISO 8601 timestamp.
@@ -91,21 +91,21 @@ export class JWTExpiredError extends NotAuthorizedError {
 }
 
 export class JWTInvalidError extends NotAuthorizedError {
-    public readonly code = SmartWalletErrors.ERROR_JWT_INVALID;
+    public readonly code = SmartWalletErrorCode.JWT_INVALID;
     constructor() {
         super("Invalid JWT provided");
     }
 }
 
 export class JWTDecryptionError extends NotAuthorizedError {
-    public readonly code = SmartWalletErrors.ERROR_JWT_DECRYPTION;
+    public readonly code = SmartWalletErrorCode.JWT_DECRYPTION;
     constructor() {
         super("Error decrypting JWT");
     }
 }
 
 export class JWTIdentifierError extends NotAuthorizedError {
-    public readonly code = SmartWalletErrors.ERROR_JWT_IDENTIFIER;
+    public readonly code = SmartWalletErrorCode.JWT_IDENTIFIER;
     public readonly identifierKey: string;
 
     constructor(identifierKey: string) {
@@ -114,78 +114,78 @@ export class JWTIdentifierError extends NotAuthorizedError {
     }
 }
 
-export class UserWalletAlreadyCreatedError extends SmartWalletSDKError {
-    public readonly code = SmartWalletErrors.ERROR_USER_WALLET_ALREADY_CREATED;
+export class UserWalletAlreadyCreatedError extends SmartWalletError {
+    public readonly code = SmartWalletErrorCode.USER_WALLET_ALREADY_CREATED;
 
     constructor(userId: string) {
         super(`The user with userId ${userId.toString()} already has a wallet created for this project`);
     }
 }
 
-export class PasskeyPromptError extends SmartWalletSDKError {
+export class PasskeyPromptError extends SmartWalletError {
     public passkeyName: string;
 
     constructor(passkeyName: string) {
         super(
             `Prompt was either cancelled or timed out for passkey ${passkeyName}`,
             undefined,
-            SmartWalletErrors.ERROR_PASSKEY_PROMPT
+            SmartWalletErrorCode.PASSKEY_PROMPT
         );
         this.passkeyName = passkeyName;
     }
 }
 
-export class PasskeyRegistrationError extends SmartWalletSDKError {
+export class PasskeyRegistrationError extends SmartWalletError {
     public passkeyName: string;
 
     constructor(passkeyName: string) {
         super(
             `Registration for passkey ${passkeyName} failed, either the registration took too long, or passkey signature vaildation failed.`,
             undefined,
-            SmartWalletErrors.ERROR_PASSKEY_REGISTRATION
+            SmartWalletErrorCode.PASSKEY_REGISTRATION
         );
         this.passkeyName = passkeyName;
     }
 }
 
-export class PasskeyIncompatibleAuthenticatorError extends SmartWalletSDKError {
+export class PasskeyIncompatibleAuthenticatorError extends SmartWalletError {
     public passkeyName: string;
 
     constructor(passkeyName: string) {
         super(
             `User selected authenticator for passkey ${passkeyName} is not compatible with Crossmint's Smart Wallets.`,
             undefined,
-            SmartWalletErrors.ERROR_PASSKEY_INCOMPATIBLE_AUTHENTICATOR
+            SmartWalletErrorCode.PASSKEY_INCOMPATIBLE_AUTHENTICATOR
         );
         this.passkeyName = passkeyName;
     }
 }
 
-export class OutOfCreditsError extends SmartWalletSDKError {
+export class OutOfCreditsError extends SmartWalletError {
     constructor(message?: string) {
         super(
             "You've run out of Crossmint API credits. Visit https://docs.crossmint.com/docs/errors for more information",
             undefined,
-            SmartWalletErrors.ERROR_OUT_OF_CREDITS
+            SmartWalletErrorCode.OUT_OF_CREDITS
         );
     }
 }
 
-export class ConfigError extends SmartWalletSDKError {
+export class ConfigError extends SmartWalletError {
     constructor(message: string) {
-        super(message, undefined, SmartWalletErrors.ERROR_WALLET_CONFIG);
+        super(message, undefined, SmartWalletErrorCode.WALLET_CONFIG);
     }
 }
 
 export class AdminAlreadyUsedError extends ConfigError {
-    public readonly code = SmartWalletErrors.ERROR_ADMIN_SIGNER_ALREADY_USED;
+    public readonly code = SmartWalletErrorCode.ADMIN_SIGNER_ALREADY_USED;
     constructor() {
         super("This signer was already used to create another wallet. Please use a different signer.");
     }
 }
 
 export class NonCustodialWalletsNotEnabledError extends ConfigError {
-    public readonly code = SmartWalletErrors.ERROR_PROJECT_NONCUSTODIAL_WALLETS_NOT_ENABLED;
+    public readonly code = SmartWalletErrorCode.SMART_WALLETS_NOT_ENABLED;
     constructor() {
         super("Non-custodial wallets are not enabled for this project");
     }

--- a/packages/client/wallets/smart-wallet/src/error/processor.ts
+++ b/packages/client/wallets/smart-wallet/src/error/processor.ts
@@ -3,15 +3,15 @@ import { DatadogProvider } from "@/services/logging/DatadogProvider";
 import { SDK_VERSION } from "@/utils/constants";
 import { BaseError, stringify } from "viem";
 
-import { SmartWalletSDKError } from ".";
+import { SmartWalletError } from ".";
 
 export class ErrorProcessor {
     constructor(private readonly logger: DatadogProvider) {}
 
-    public map(error: unknown, fallback: SmartWalletSDKError): SmartWalletSDKError | BaseError {
+    public map(error: unknown, fallback: SmartWalletError): SmartWalletError | BaseError {
         this.record(error);
 
-        if (error instanceof SmartWalletSDKError) {
+        if (error instanceof SmartWalletError) {
             return error;
         }
 

--- a/packages/client/wallets/smart-wallet/src/index.ts
+++ b/packages/client/wallets/smart-wallet/src/index.ts
@@ -32,6 +32,7 @@ export {
     PasskeyIncompatibleAuthenticatorError,
     ConfigError,
     NonCustodialWalletsNotEnabledError,
+    SmartWalletErrors,
 } from "./error";
 
 export { SmartWalletSDK } from "./SmartWalletSDK";

--- a/packages/client/wallets/smart-wallet/src/index.ts
+++ b/packages/client/wallets/smart-wallet/src/index.ts
@@ -16,7 +16,7 @@ export type { TransferType, ERC20TransferType, NFTTransferType, SFTTransferType 
 export {
     TransferError,
     CrossmintServiceError,
-    SmartWalletSDKError,
+    SmartWalletError,
     JWTDecryptionError,
     JWTExpiredError,
     JWTIdentifierError,
@@ -32,7 +32,7 @@ export {
     PasskeyIncompatibleAuthenticatorError,
     ConfigError,
     NonCustodialWalletsNotEnabledError,
-    SmartWalletErrors,
+    SmartWalletErrorCode,
 } from "./error";
 
 export { SmartWalletSDK } from "./SmartWalletSDK";

--- a/packages/client/wallets/smart-wallet/src/utils/signer.ts
+++ b/packages/client/wallets/smart-wallet/src/utils/signer.ts
@@ -3,7 +3,7 @@ import type { SmartAccountSigner } from "permissionless/accounts";
 import { Address, EIP1193Provider } from "viem";
 
 import { SmartWalletChain } from "../blockchain/chains";
-import { SmartWalletSDKError } from "../error";
+import { SmartWalletError } from "../error";
 import { ViemAccount, WalletParams } from "../types/Config";
 import { logInputOutput } from "./log";
 
@@ -20,7 +20,7 @@ export const createOwnerSigner = logInputOutput(
             return walletParams.signer.account;
         } else {
             const signer = walletParams.signer as any;
-            throw new SmartWalletSDKError(`The signer type ${signer.type} is not supported`);
+            throw new SmartWalletError(`The signer type ${signer.type} is not supported`);
         }
     },
     "createOwnerSigner"


### PR DESCRIPTION
## Description

When interacting with other libs I often wish they exported their error codes. This PR does just that for the smart wallet SDK.

This PR also:
- Renames `SmartWalletSDKError` => `SmartWalletError`
- Makes some refinements to our error codes

## Test plan

Sanity checked export works as expected + existing CI.
