### PR TITLE
feat: useCrossmint + CrossmintProvider

### DIFF
--- a/packages/client/ui/react-ui/src/hooks/index.ts
+++ b/packages/client/ui/react-ui/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from "./useCrossmint";

--- a/packages/client/ui/react-ui/src/hooks/useCrossmint.test.tsx
+++ b/packages/client/ui/react-ui/src/hooks/useCrossmint.test.tsx
@@ -1,0 +1,98 @@
+import { act, render } from "@testing-library/react";
+import { useEffect } from "react";
+
+import { Crossmint } from "@crossmint/common-sdk-base";
+
+import { CrossmintProvider, useCrossmint } from "./useCrossmint";
+
+const MOCK_API_KEY =
+    "sk_development_5ZUNkuhjP8aYZEgUTDfWToqFpo5zakEqte1db4pHZgPAVKZ9JuSvnKeGiqY654DoBuuZEzYz4Eb8gRV2ePqQ1fxTjEP8tTaUQdzbGfyG9RgyeN5YbqViXinqxk8EayEkAGtvSSgjpjEr6iaBptJtUFwPW59DjQzTQP6P8uZdiajenVg7bARGKjzFyByNuVEoz41DpRB4hDZNFdwCTuf5joFv";
+
+jest.mock("@crossmint/common-sdk-base", () => {
+    const actualModule = jest.requireActual("@crossmint/common-sdk-base");
+
+    return {
+        ...actualModule,
+        createCrossmint: jest.fn(() => ({
+            apiKey: MOCK_API_KEY,
+        })),
+    };
+});
+
+class MockSDK {
+    constructor(public crossmint: Crossmint) {}
+    somethingThatUpdatesJWT(newJWT: string) {
+        this.crossmint.jwt = newJWT;
+    }
+}
+
+function renderCrossmintProvider({ children }: { children: JSX.Element }) {
+    return render(<CrossmintProvider apiKey={MOCK_API_KEY}>{children}</CrossmintProvider>);
+}
+
+describe("CrossmintProvider", () => {
+    it("provides initial JWT value", () => {
+        const TestComponent = () => {
+            const { crossmint } = useCrossmint();
+            return <div data-testid="jwt">{crossmint.jwt}</div>;
+        };
+        const { getByTestId } = renderCrossmintProvider({ children: <TestComponent /> });
+        expect(getByTestId("jwt").textContent).toBe("");
+    });
+
+    it("updates JWT using setJwt", () => {
+        const TestComponent = () => {
+            const { crossmint, setJwt } = useCrossmint();
+            return (
+                <div>
+                    <div data-testid="jwt">{crossmint.jwt}</div>
+                    <button onClick={() => setJwt("new_jwt")}>Update JWT</button>
+                </div>
+            );
+        };
+        const { getByTestId, getByText } = renderCrossmintProvider({ children: <TestComponent /> });
+        act(() => {
+            getByText("Update JWT").click();
+        });
+        expect(getByTestId("jwt").textContent).toBe("new_jwt");
+    });
+
+    it("updates JWT using WalletSDK", () => {
+        const TestComponent = () => {
+            const { crossmint } = useCrossmint();
+            useEffect(() => {
+                const wallet = new MockSDK(crossmint);
+                wallet.somethingThatUpdatesJWT("sdk_jwt");
+            }, []);
+            return <div data-testid="jwt">{crossmint.jwt}</div>;
+        };
+        const { getByTestId } = renderCrossmintProvider({ children: <TestComponent /> });
+        expect(getByTestId("jwt").textContent).toBe("sdk_jwt");
+    });
+
+    it("triggers re-render on JWT change", () => {
+        const renderCount = jest.fn();
+        const TestComponent = () => {
+            const { crossmint, setJwt } = useCrossmint();
+            useEffect(() => {
+                renderCount();
+            });
+            return (
+                <div>
+                    <div data-testid="jwt">{crossmint.jwt}</div>
+                    <button onClick={() => setJwt("new_jwt")}>Update JWT</button>
+                </div>
+            );
+        };
+
+        const { getByText } = renderCrossmintProvider({ children: <TestComponent /> });
+
+        expect(renderCount).toHaveBeenCalledTimes(1);
+
+        act(() => {
+            getByText("Update JWT").click();
+        });
+
+        expect(renderCount).toHaveBeenCalledTimes(2);
+    });
+});

--- a/packages/client/ui/react-ui/src/index.ts
+++ b/packages/client/ui/react-ui/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./components";
+export * from "./hooks";
 
 export { CrossmintEvents, useCrossmintEvents } from "@crossmint/client-sdk-base";
 export type { CrossmintEvent, CrossmintEventMap } from "@crossmint/client-sdk-base";


### PR DESCRIPTION
## Description

another attempt...

## Test plan

tested basic reactability without using a class, calling setJwt rerenders and crosmint.jwt has the new state

tested storing a reference to `crossmint` within a class, updating the jwt from within the class, and seeing that react also gets the new update
<img width="624" alt="image" src="https://github.com/user-attachments/assets/d92843d1-bb10-4df0-a5e4-de24655822e3">
<img width="1368" alt="image" src="https://github.com/user-attachments/assets/93ce61bc-c8d8-46e2-ad8a-51e4f0613a62">

