### PR TITLE
Smart Wallets: Target ES2020

### DIFF
--- a/apps/wallets/smart-wallet/next/tsconfig.json
+++ b/apps/wallets/smart-wallet/next/tsconfig.json
@@ -11,6 +11,7 @@
         "resolveJsonModule": true,
         "isolatedModules": true,
         "jsx": "preserve",
+        "target": "ES2020",
         "incremental": true,
         "plugins": [
             {

--- a/apps/wallets/smart-wallet/react/tsconfig.json
+++ b/apps/wallets/smart-wallet/react/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "extends": "../../../../tsconfig.base.json",
     "compilerOptions": {
-        "target": "ES6",
+        "target": "ES2020",
         "lib": ["dom", "dom.iterable", "esnext"],
         "allowJs": true,
         "skipLibCheck": true,

--- a/packages/client/wallets/smart-wallet/src/blockchain/wallets/account/eoa.ts
+++ b/packages/client/wallets/smart-wallet/src/blockchain/wallets/account/eoa.ts
@@ -40,7 +40,7 @@ export class EOACreationStrategy implements AccountCreationStrategy {
             plugins: {
                 sudo: ecdsaValidator,
             },
-            index: BigInt(0),
+            index: 0n,
             entryPoint: entryPoint.address,
             kernelVersion,
         });

--- a/packages/client/wallets/smart-wallet/tsconfig.json
+++ b/packages/client/wallets/smart-wallet/tsconfig.json
@@ -5,7 +5,8 @@
         "baseUrl": ".",
         "paths": {
             "@/*": ["src/*"]
-        }
+        },
+        "target": "ES2020"
     },
     "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Description

Sometimes, we run into issues importing packages that use bigints with modern syntax (ie. `5n`). This PR changes the target in all smart wallet related packages:
- To unify the build target
- To enable use of native bigint syntax
- Even though TS should handle dealing w/ different build targets, I have a hunch this'll help.

## Test plan

I don't see bigint related errors when running the ts compiler anymore

Existing CI should be good here
