### PR TITLE
Smart Wallets: Improve Demo Workspace Names

### DIFF
--- a/crossmint-sdk.code-workspace
+++ b/crossmint-sdk.code-workspace
@@ -29,11 +29,11 @@
             "path": "packages/client/ui/react-ui"
         },
         {
-            "name": "⚛️🔒 @crossmint/client-sdk-smart-wallet-react-starter",
+            "name": "⚛️🔒 Smart Wallet SDK Playground",
             "path": "apps/wallets/smart-wallet/react"
         },
         {
-            "name": "⚛️🔒 @crossmint/client-sdk-smart-wallet-next-starter",
+            "name": "⚛️🔒 Smart Wallet + Auth Demo",
             "path": "apps/wallets/smart-wallet/next"
         },
         {


### PR DESCRIPTION
## Description

I keep on mixing these up or wasting brain cycles making sure to choose the right one. This PR improves workspace naming for the demos

Before:

<img width="666" alt="Screenshot 2024-08-20 at 8 23 45 AM" src="https://github.com/user-attachments/assets/0697949c-936d-441c-a57f-200924735345">

After:

<img width="635" alt="Screenshot 2024-08-20 at 8 23 30 AM" src="https://github.com/user-attachments/assets/f34e5666-0d26-43a9-9a28-897c4e44fd40">

## Test plan

N/A
