### PR TITLE
Improve `logPerformance` metadata fields

### DIFF
--- a/packages/client/base/src/services/api/BaseCrossmintService.ts
+++ b/packages/client/base/src/services/api/BaseCrossmintService.ts
@@ -36,10 +36,11 @@ export abstract class BaseCrossmintService {
         onServerErrorMessage: string,
         authToken?: string
     ) {
+        const url = `${this.crossmintBaseUrl}api/${endpoint}`;
+        const urlPath = new URL(url).pathname;
         return this.logger.logPerformance(
             "FETCH_CROSSMINT_API",
             async () => {
-                const url = `${this.crossmintBaseUrl}api/${endpoint}`;
                 const { body, method } = options;
 
                 let response: Response;
@@ -67,7 +68,7 @@ export abstract class BaseCrossmintService {
 
                 return await response.json();
             },
-            { endpoint }
+            { endpoint: urlPath }
         );
     }
 

--- a/packages/client/base/src/utils/SDKLogger.ts
+++ b/packages/client/base/src/utils/SDKLogger.ts
@@ -19,8 +19,8 @@ export class SDKLogger {
         const start = new Date().getTime();
         const result = await cb();
         const durationInMs = new Date().getTime() - start;
-        const args = { durationInMs, ...extraInfo };
-        this.log(`[${name} - TIME] - ${this.beautify(args)}`, { args: { ...args, name } });
+        const args = { durationInMs, ...extraInfo, name };
+        this.log(`[${name} - TIME] - ${this.beautify(args)}`, { args });
         return result;
     }
 

--- a/packages/client/base/src/utils/SDKLogger.ts
+++ b/packages/client/base/src/utils/SDKLogger.ts
@@ -20,7 +20,7 @@ export class SDKLogger {
         const result = await cb();
         const durationInMs = new Date().getTime() - start;
         const args = { durationInMs, ...extraInfo };
-        this.log(`[${name} - TIME] - ${this.beautify(args)}`, { args });
+        this.log(`[${name} - TIME] - ${this.beautify(args)}`, { args: { ...args, name } });
         return result;
     }
 


### PR DESCRIPTION
## Description

Two changes:
- Ensure we include the operation name in these logs
- Change the endpoint logged in FETCH_CROSSMINT_API to not include query parameters for better aggregation

## Test plan

Ran though demo locally and ensured the above work