### PR TITLE
Smart Wallets: Reduce Bundler Latency (Resolves WAL-2749)

### DIFF
--- a/packages/client/wallets/smart-wallet/src/blockchain/chains.ts
+++ b/packages/client/wallets/smart-wallet/src/blockchain/chains.ts
@@ -12,8 +12,6 @@ import {
 
 import { BlockchainIncludingTestnet as Blockchain, ObjectValues, objectValues } from "@crossmint/common-sdk-base";
 
-import { BUNDLER_RPC } from "../utils/constants";
-
 export const SmartWalletTestnet = {
     BASE_SEPOLIA: Blockchain.BASE_SEPOLIA,
     POLYGON_AMOY: Blockchain.POLYGON_AMOY,
@@ -39,17 +37,6 @@ export const SmartWalletChain = {
 export type SmartWalletChain = ObjectValues<typeof SmartWalletChain>;
 export const SMART_WALLET_CHAINS = objectValues(SmartWalletChain);
 
-export const zerodevProjects: Record<SmartWalletChain, string> = {
-    polygon: "5c9f4865-ca8e-44bb-9b9e-3810b2b46f9f",
-    "polygon-amoy": "3deef404-ca06-4a5d-9a58-907c99e7ef00",
-    "base-sepolia": "5a127978-6473-4784-9dfb-f74395b220a6",
-    base: "e8b3020f-4dde-4176-8a7d-be8102527a5c",
-    "optimism-sepolia": "f8dd488e-eaed-467d-a5de-0184c160f3b1",
-    optimism: "505950ab-ee07-4a9c-bd16-320ac71a9350",
-    arbitrum: "a965100f-fedf-4e6b-a207-20f5687fcc4f",
-    "arbitrum-sepolia": "76c860ca-af77-4fb1-8eac-07825952f6f4",
-};
-
 export const viemNetworks: Record<SmartWalletChain, Chain> = {
     polygon: polygon,
     "polygon-amoy": polygonAmoy,
@@ -60,7 +47,3 @@ export const viemNetworks: Record<SmartWalletChain, Chain> = {
     arbitrum: arbitrum,
     "arbitrum-sepolia": arbitrumSepolia,
 };
-
-export function getBundlerRPC(chain: SmartWalletChain) {
-    return BUNDLER_RPC + zerodevProjects[chain];
-}

--- a/packages/client/wallets/smart-wallet/src/blockchain/rpc.ts
+++ b/packages/client/wallets/smart-wallet/src/blockchain/rpc.ts
@@ -1,6 +1,9 @@
+import { blockchainToChainId } from "@crossmint/common-sdk-base";
+
 import { SmartWalletChain } from "./chains";
 
 const ALCHEMY_API_KEY = "-7M6vRDBDknwvMxnqah_jbcieWg0qad9";
+const PIMLICO_API_KEY = "pim_9dKmQPxiTCvtbUNF7XFBbA";
 
 export const ALCHEMY_RPC_SUBDOMAIN: Record<SmartWalletChain, string> = {
     polygon: "polygon-mainnet",
@@ -15,4 +18,8 @@ export const ALCHEMY_RPC_SUBDOMAIN: Record<SmartWalletChain, string> = {
 
 export function getAlchemyRPC(chain: SmartWalletChain): string {
     return `https://${ALCHEMY_RPC_SUBDOMAIN[chain]}.g.alchemy.com/v2/${ALCHEMY_API_KEY}`;
+}
+
+export function getPimlicoBundlerRPC(chain: SmartWalletChain): string {
+    return `https://api.pimlico.io/v2/${blockchainToChainId(chain)}/rpc?apikey=${PIMLICO_API_KEY}`;
 }

--- a/packages/client/wallets/smart-wallet/src/blockchain/wallets/paymaster.ts
+++ b/packages/client/wallets/smart-wallet/src/blockchain/wallets/paymaster.ts
@@ -1,5 +1,6 @@
 import { CrossmintWalletService } from "@/api/CrossmintWalletService";
 import { Middleware } from "permissionless/actions/smartAccount";
+import { PimlicoBundlerClient } from "permissionless/clients/pimlico";
 import { EntryPoint } from "permissionless/types/entrypoint";
 
 import { UserParams } from "../../types/params";
@@ -11,11 +12,13 @@ export function usePaymaster(chain: SmartWalletChain) {
 }
 
 export function paymasterMiddleware({
+    bundlerClient,
     entryPoint,
     chain,
     walletService,
     user,
 }: {
+    bundlerClient: PimlicoBundlerClient<EntryPoint>;
     entryPoint: EntryPoint;
     chain: SmartWalletChain;
     walletService: CrossmintWalletService;
@@ -23,6 +26,7 @@ export function paymasterMiddleware({
 }): Middleware<EntryPoint> {
     return {
         middleware: {
+            gasPrice: async () => (await bundlerClient.getUserOperationGasPrice()).fast,
             sponsorUserOperation: async ({ userOperation }) => {
                 const { sponsorUserOpParams } = await walletService.sponsorUserOperation(
                     user,

--- a/packages/client/wallets/smart-wallet/src/utils/constants.ts
+++ b/packages/client/wallets/smart-wallet/src/utils/constants.ts
@@ -3,7 +3,5 @@ export const CURRENT_VERSION = 0;
 export const SCW_SERVICE = "SCW_SDK";
 export const SDK_VERSION = "0.1.0";
 export const API_VERSION = "2024-06-09";
-export const BUNDLER_RPC = "https://rpc.zerodev.app/api/v2/bundler/";
-export const PAYMASTER_RPC = "https://rpc.zerodev.app/api/v2/paymaster/";
 export const SUPPORTED_KERNEL_VERSIONS = ["0.3.1", "0.3.0", "0.2.4"] as const;
 export const SUPPORTED_ENTRYPOINT_VERSIONS = ["v0.6", "v0.7"] as const;


### PR DESCRIPTION
## Description

The process of sending a user op requires a few bundler calls:
- One to fetch the gas price,
- Another to actually send the signed user op,
- Finally, we poll for the receipt

This PR switches us over to using the [Pimlico](https://www.pimlico.io/) bundler directly, instead of proxying them through ZeroDev. The primary benefit here is that, at least locally for me, this shaves off 400 - 500 ms of latency from each call mentioned above. This shaves ~2 seconds from each transaction flow, which is a huge UX improvement.

## Test plan

Went through the Minting + Smart Wallet Demo flow.
