### PR TITLE
React UI Lib: Convert Testing Suite To Vitest

### DIFF
--- a/packages/client/ui/react-ui/jest.config.js
+++ b/packages/client/ui/react-ui/jest.config.js
@@ -1,8 +1,0 @@
-/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
-export default {
-    preset: "ts-jest",
-    testEnvironment: "jest-environment-jsdom",
-    moduleNameMapper: {
-        "^@/(.*)$": "<rootDir>/src/$1",
-    },
-};

--- a/packages/client/ui/react-ui/package.json
+++ b/packages/client/ui/react-ui/package.json
@@ -23,7 +23,7 @@
         "build": "tsup src/index.ts --clean --external react,react-dom --format esm,cjs --outDir ./dist --minify --dts --sourcemap",
         "create-version-file": "node -p \"'export const LIB_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > src/consts/version.ts",
         "dev": "tsup src/index.ts --clean --external react,react-dom --format esm,cjs --outDir ./dist --dts --sourcemap --watch",
-        "test": "jest",
+        "test": "vitest run",
         "version": "pnpm run create-version-file && git add ."
     },
     "dependencies": {

--- a/packages/client/ui/react-ui/src/components/CrossmintCollectionView.test.tsx
+++ b/packages/client/ui/react-ui/src/components/CrossmintCollectionView.test.tsx
@@ -1,34 +1,40 @@
-import "@testing-library/jest-dom";
-import { render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, test } from "vitest";
 
 import { CrossmintNFTCollectionView } from "./CrossmintNFTCollectionView";
 
 const wallets = [{ chain: "solana", publicKey: "12345" }];
 
-describe("when only passing mandatory fields", () => {
-    test("should add them to the iframe query params", () => {
-        render(<CrossmintNFTCollectionView wallets={wallets} />);
-        const iframe = screen.getByRole("nft-collection-view");
-        const src = iframe.getAttribute("src");
-        expect(src).toContain("wallets=%5B%7B%22chain%22%3A%22solana%22%2C%22publicKey%22%3A%2212345%22%7D%5D");
-        expect(src).toContain("clientVersion=");
+describe("CrossmintNFTCollectionView", () => {
+    beforeEach(() => {
+        cleanup();
     });
-});
 
-describe("when not setting any environment", () => {
-    test("should default to production", () => {
-        render(<CrossmintNFTCollectionView wallets={wallets} />);
-        const iframe = screen.getByRole("nft-collection-view");
-        const src = iframe.getAttribute("src");
-        expect(src).toContain("https://www.crossmint.com/");
+    describe("when only passing mandatory fields", () => {
+        test("should add them to the iframe query params", () => {
+            render(<CrossmintNFTCollectionView wallets={wallets} />);
+            const iframe = screen.getByRole("nft-collection-view");
+            const src = iframe.getAttribute("src");
+            expect(src).toContain("wallets=%5B%7B%22chain%22%3A%22solana%22%2C%22publicKey%22%3A%2212345%22%7D%5D");
+            expect(src).toContain("clientVersion=");
+        });
     });
-});
 
-describe("when setting the environment to staging", () => {
-    test("should use the staging url", () => {
-        render(<CrossmintNFTCollectionView wallets={wallets} environment="staging" />);
-        const iframe = screen.getByRole("nft-collection-view");
-        const src = iframe.getAttribute("src");
-        expect(src).toContain("https://staging.crossmint.com/");
+    describe("when not setting any environment", () => {
+        test("should default to production", () => {
+            render(<CrossmintNFTCollectionView wallets={wallets} />);
+            const iframe = screen.getByRole("nft-collection-view");
+            const src = iframe.getAttribute("src");
+            expect(src).toContain("https://www.crossmint.com/");
+        });
+    });
+
+    describe("when setting the environment to staging", () => {
+        test("should use the staging url", () => {
+            render(<CrossmintNFTCollectionView wallets={wallets} environment="staging" />);
+            const iframe = screen.getByRole("nft-collection-view");
+            const src = iframe.getAttribute("src");
+            expect(src).toContain("https://staging.crossmint.com/");
+        });
     });
 });

--- a/packages/client/ui/react-ui/src/components/CrossmintCollectionView.test.tsx
+++ b/packages/client/ui/react-ui/src/components/CrossmintCollectionView.test.tsx
@@ -1,15 +1,11 @@
-import { cleanup, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
 
 import { CrossmintNFTCollectionView } from "./CrossmintNFTCollectionView";
 
 const wallets = [{ chain: "solana", publicKey: "12345" }];
 
 describe("CrossmintNFTCollectionView", () => {
-    beforeEach(() => {
-        cleanup();
-    });
-
     describe("when only passing mandatory fields", () => {
         test("should add them to the iframe query params", () => {
             render(<CrossmintNFTCollectionView wallets={wallets} />);

--- a/packages/client/ui/react-ui/src/components/CrossmintNFTDetail.test.tsx
+++ b/packages/client/ui/react-ui/src/components/CrossmintNFTDetail.test.tsx
@@ -1,5 +1,5 @@
-import "@testing-library/jest-dom";
-import { render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
 
 import { NFT } from "@crossmint/common-sdk-base";
 
@@ -7,30 +7,36 @@ import { CrossmintNFTDetail } from "./CrossmintNFTDetail";
 
 const nft: NFT = { chain: "ethereum", contractAddress: "0x12345", tokenId: "12" };
 
-describe("when only passing mandatory fields", () => {
-    test("should add them to the iframe query params", () => {
-        render(<CrossmintNFTDetail nft={nft} />);
-        const iframe = screen.getByRole("nft-details");
-        const src = iframe.getAttribute("src");
-        expect(src).toContain("/sdk/wallets/tokens/ethereum:0x12345:12");
-        expect(src).toContain("clientVersion=");
+describe("CrossmintNFTDetail", () => {
+    beforeEach(() => {
+        cleanup();
     });
-});
 
-describe("when not setting any environment", () => {
-    test("should default to production", () => {
-        render(<CrossmintNFTDetail nft={nft} />);
-        const iframe = screen.getByRole("nft-details");
-        const src = iframe.getAttribute("src");
-        expect(src).toContain("https://www.crossmint.com/");
+    describe("when only passing mandatory fields", () => {
+        it("should add them to the iframe query params", () => {
+            render(<CrossmintNFTDetail nft={nft} />);
+            const iframe = screen.getByRole("nft-details");
+            const src = iframe.getAttribute("src");
+            expect(src).toContain("/sdk/wallets/tokens/ethereum:0x12345:12");
+            expect(src).toContain("clientVersion=");
+        });
     });
-});
 
-describe("when setting the environment to staging", () => {
-    test("should use the staging url", () => {
-        render(<CrossmintNFTDetail nft={nft} environment="staging" />);
-        const iframe = screen.getByRole("nft-details");
-        const src = iframe.getAttribute("src");
-        expect(src).toContain("https://staging.crossmint.com/");
+    describe("when not setting any environment", () => {
+        it("should default to production", () => {
+            render(<CrossmintNFTDetail nft={nft} />);
+            const iframe = screen.getByRole("nft-details");
+            const src = iframe.getAttribute("src");
+            expect(src).toContain("https://www.crossmint.com/");
+        });
+    });
+
+    describe("when setting the environment to staging", () => {
+        it("should use the staging url", () => {
+            render(<CrossmintNFTDetail nft={nft} environment="staging" />);
+            const iframe = screen.getByRole("nft-details");
+            const src = iframe.getAttribute("src");
+            expect(src).toContain("https://staging.crossmint.com/");
+        });
     });
 });

--- a/packages/client/ui/react-ui/src/components/CrossmintNFTDetail.test.tsx
+++ b/packages/client/ui/react-ui/src/components/CrossmintNFTDetail.test.tsx
@@ -1,5 +1,5 @@
-import { cleanup, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
 
 import { NFT } from "@crossmint/common-sdk-base";
 
@@ -8,10 +8,6 @@ import { CrossmintNFTDetail } from "./CrossmintNFTDetail";
 const nft: NFT = { chain: "ethereum", contractAddress: "0x12345", tokenId: "12" };
 
 describe("CrossmintNFTDetail", () => {
-    beforeEach(() => {
-        cleanup();
-    });
-
     describe("when only passing mandatory fields", () => {
         it("should add them to the iframe query params", () => {
             render(<CrossmintNFTDetail nft={nft} />);

--- a/packages/client/ui/react-ui/src/components/embed/CrossmintPaymentElement.test.tsx
+++ b/packages/client/ui/react-ui/src/components/embed/CrossmintPaymentElement.test.tsx
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom/vitest";
-import { cleanup, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 
 import { CrossmintEvents } from "@crossmint/client-sdk-base";
 
@@ -11,10 +11,6 @@ const embeddedCheckoutProps = {
 };
 
 describe("CrossmintPaymentElement", () => {
-    beforeEach(() => {
-        cleanup();
-    });
-
     it("renders an iframe with the correct props", () => {
         render(<CrossmintPaymentElement {...embeddedCheckoutProps} />);
         const iframe = screen.getByRole("crossmint-embedded-checkout.iframe");

--- a/packages/client/ui/react-ui/src/components/embed/CrossmintPaymentElement.test.tsx
+++ b/packages/client/ui/react-ui/src/components/embed/CrossmintPaymentElement.test.tsx
@@ -1,5 +1,6 @@
-import "@testing-library/jest-dom";
-import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { CrossmintEvents } from "@crossmint/client-sdk-base";
 
@@ -10,6 +11,10 @@ const embeddedCheckoutProps = {
 };
 
 describe("CrossmintPaymentElement", () => {
+    beforeEach(() => {
+        cleanup();
+    });
+
     it("renders an iframe with the correct props", () => {
         render(<CrossmintPaymentElement {...embeddedCheckoutProps} />);
         const iframe = screen.getByRole("crossmint-embedded-checkout.iframe");
@@ -30,7 +35,7 @@ describe("CrossmintPaymentElement", () => {
     });
 
     it("calls the onEvent prop when a CrossmintEvents is received", () => {
-        const onEvent = jest.fn();
+        const onEvent = vi.fn();
         render(<CrossmintPaymentElement {...embeddedCheckoutProps} onEvent={onEvent} environment="" />);
         screen.getByRole("crossmint-embedded-checkout.iframe");
 
@@ -43,7 +48,7 @@ describe("CrossmintPaymentElement", () => {
     });
 
     it("does not call the onEvent prop when a different origin than the environment is received in the event", () => {
-        const onEvent = jest.fn();
+        const onEvent = vi.fn();
         render(<CrossmintPaymentElement {...embeddedCheckoutProps} onEvent={onEvent} environment="" />);
         screen.getByRole("crossmint-embedded-checkout.iframe");
 

--- a/packages/client/ui/react-ui/src/components/embed/EmbeddedCheckoutIFrame.tsx
+++ b/packages/client/ui/react-ui/src/components/embed/EmbeddedCheckoutIFrame.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useState } from "react";
 
-import { IncomingInternalEvent, IncomingInternalEvents, crossmintIFrameService } from "@crossmint/client-sdk-base";
-import { CrossmintEmbeddedCheckoutProps } from "@crossmint/client-sdk-base";
+import {
+    CrossmintEmbeddedCheckoutProps,
+    IncomingInternalEvent,
+    IncomingInternalEvents,
+    crossmintIFrameService,
+} from "@crossmint/client-sdk-base";
 
 type CrossmintEmbeddedCheckoutIFrameProps = CrossmintEmbeddedCheckoutProps & {
     onInternalEvent?: (event: IncomingInternalEvent) => void;

--- a/packages/client/ui/react-ui/src/components/embed/crypto/CryptoEmbeddedCheckoutIFrame.tsx
+++ b/packages/client/ui/react-ui/src/components/embed/crypto/CryptoEmbeddedCheckoutIFrame.tsx
@@ -1,4 +1,3 @@
-import useDeepEffect from "@/hooks/useDeepEffect";
 import bs58 from "bs58";
 
 import {
@@ -13,6 +12,7 @@ import {
 } from "@crossmint/client-sdk-base";
 import { EVMBlockchainIncludingTestnet } from "@crossmint/common-sdk-base";
 
+import useDeepEffect from "../../../hooks/useDeepEffect";
 import CrossmintEmbeddedCheckoutIFrame from "../EmbeddedCheckoutIFrame";
 
 export default function CryptoEmbeddedCheckoutIFrame(props: CryptoEmbeddedCheckoutPropsWithSigner) {

--- a/packages/client/ui/react-ui/src/components/embed/fiat/FiatEmbeddedCheckout.tsx
+++ b/packages/client/ui/react-ui/src/components/embed/fiat/FiatEmbeddedCheckout.tsx
@@ -1,6 +1,6 @@
-import FiatEmbeddedCheckoutIFrame from "@/components/embed/fiat/FiatEmbeddedCheckoutIFrame";
-
 import { FiatEmbeddedCheckoutProps } from "@crossmint/client-sdk-base";
+
+import FiatEmbeddedCheckoutIFrame from "../../../components/embed/fiat/FiatEmbeddedCheckoutIFrame";
 
 export function CrossmintFiatEmbeddedCheckout(props: FiatEmbeddedCheckoutProps) {
     return <FiatEmbeddedCheckoutIFrame {...props} />;

--- a/packages/client/ui/react-ui/src/components/embed/fiat/FiatEmbeddedCheckoutIFrame.tsx
+++ b/packages/client/ui/react-ui/src/components/embed/fiat/FiatEmbeddedCheckoutIFrame.tsx
@@ -1,11 +1,10 @@
-import useDeepEffect from "@/hooks/useDeepEffect";
-
 import {
     FiatEmbeddedCheckoutProps,
     crossmintIFrameService,
     embeddedCheckoutPropsToUpdatableParamsPayload,
 } from "@crossmint/client-sdk-base";
 
+import useDeepEffect from "../../../hooks/useDeepEffect";
 import CrossmintEmbeddedCheckoutIFrame from "../EmbeddedCheckoutIFrame";
 
 export default function FiatEmbeddedCheckoutIFrame(props: FiatEmbeddedCheckoutProps) {

--- a/packages/client/ui/react-ui/src/components/hosted/CrossmintPayButton.test.tsx
+++ b/packages/client/ui/react-ui/src/components/hosted/CrossmintPayButton.test.tsx
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom/vitest";
-import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { CrossmintPayButton } from ".";
 import { LIB_VERSION } from "../../consts/version";
@@ -25,10 +25,6 @@ const defaultProps = {
 };
 
 describe("CrossmintPayButton", () => {
-    beforeEach(() => {
-        cleanup();
-    });
-
     afterEach(() => {
         vi.clearAllMocks();
     });

--- a/packages/client/ui/react-ui/src/components/hosted/CrossmintPayButton.test.tsx
+++ b/packages/client/ui/react-ui/src/components/hosted/CrossmintPayButton.test.tsx
@@ -1,5 +1,6 @@
-import "@testing-library/jest-dom";
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { CrossmintPayButton } from ".";
 import { LIB_VERSION } from "../../consts/version";
@@ -8,27 +9,31 @@ import { LIB_VERSION } from "../../consts/version";
 const fetchReturns = Promise.resolve({
     json: () => Promise.resolve({}),
 }) as any;
-global.fetch = jest.fn(() => fetchReturns);
+global.fetch = vi.fn(() => fetchReturns);
 
 // TODO(#61): make this automatically mocked in every test suite
 const openReturns = {} as Window;
-global.open = jest.fn(() => openReturns);
+global.open = vi.fn(() => openReturns);
 global.console = {
-    log: jest.fn(),
-    error: jest.fn(),
-    warn: jest.fn(),
+    log: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
 } as any;
 
 const defaultProps = {
     clientId: "a4e1bfcc-9884-11ec-b909-0242ac120002",
 };
 
-afterEach(() => {
-    jest.clearAllMocks();
-});
-
 describe("CrossmintPayButton", () => {
-    test("should open window with correct url", async () => {
+    beforeEach(() => {
+        cleanup();
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("should open window with correct url", async () => {
         render(<CrossmintPayButton {...defaultProps} />);
 
         await act(async () => {
@@ -61,7 +66,7 @@ describe("CrossmintPayButton", () => {
         );
     });
 
-    test("should add the `whPassThroughArgs` prop on the window url", async () => {
+    it("should add the `whPassThroughArgs` prop on the window url", async () => {
         const whPassThroughArgs = { hello: "hi" };
         render(<CrossmintPayButton {...defaultProps} whPassThroughArgs={whPassThroughArgs} />);
 
@@ -76,7 +81,7 @@ describe("CrossmintPayButton", () => {
     });
 
     describe("when passing the prepay prop", () => {
-        test("should pass the prepay query param", async () => {
+        it("should pass the prepay query param", async () => {
             render(<CrossmintPayButton {...defaultProps} prepay />);
 
             await act(async () => {
@@ -91,7 +96,7 @@ describe("CrossmintPayButton", () => {
     });
 
     describe("when passing the prepay prop as false", () => {
-        test("should not pass the prepay query param", async () => {
+        it("should not pass the prepay query param", async () => {
             render(<CrossmintPayButton {...defaultProps} prepay={false} />);
 
             await act(async () => {
@@ -106,7 +111,7 @@ describe("CrossmintPayButton", () => {
     });
 
     describe("when passing the loginEmail prop", () => {
-        test("should pass an email in the email query param", async () => {
+        it("should pass an email in the email query param", async () => {
             render(<CrossmintPayButton {...defaultProps} loginEmail="user@gmail.com" />);
 
             await act(async () => {
@@ -119,7 +124,7 @@ describe("CrossmintPayButton", () => {
             );
         });
 
-        test("should pass the email query param empty if loginEmail is empty", async () => {
+        it("should pass the email query param empty if loginEmail is empty", async () => {
             render(<CrossmintPayButton {...defaultProps} loginEmail="" />);
 
             await act(async () => {
@@ -132,7 +137,7 @@ describe("CrossmintPayButton", () => {
             );
         });
 
-        test("should pass the email query param empty if loginEmail is not present as a param", async () => {
+        it("should pass the email query param empty if loginEmail is not present as a param", async () => {
             render(<CrossmintPayButton {...defaultProps} />);
 
             await act(async () => {
@@ -147,7 +152,7 @@ describe("CrossmintPayButton", () => {
     });
 
     describe("when passing collectionId instead of clientId", () => {
-        test("should open window with correct url", async () => {
+        it("should open window with correct url", async () => {
             render(<CrossmintPayButton collectionId={defaultProps.clientId} />);
 
             await act(async () => {
@@ -163,7 +168,7 @@ describe("CrossmintPayButton", () => {
     });
 
     describe("when passing projectId", () => {
-        test("should open window with projectId included in query params", async () => {
+        it("should open window with projectId included in query params", async () => {
             render(<CrossmintPayButton {...defaultProps} projectId="123" />);
 
             await act(async () => {
@@ -179,7 +184,7 @@ describe("CrossmintPayButton", () => {
     });
 
     describe("when passing getButtonText prop", () => {
-        test("should show custom text", async () => {
+        it("should show custom text", async () => {
             render(<CrossmintPayButton {...defaultProps} getButtonText={() => "Custom text"} />);
             expect(screen.getByText("Custom text")).toBeInTheDocument();
         });

--- a/packages/client/ui/react-ui/src/hooks/useCrossmint.test.tsx
+++ b/packages/client/ui/react-ui/src/hooks/useCrossmint.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { useEffect } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -26,7 +26,6 @@ function renderCrossmintProvider({ children }: { children: JSX.Element }) {
 
 describe("CrossmintProvider", () => {
     beforeEach(() => {
-        cleanup();
         vi.resetAllMocks();
         vi.mocked(createCrossmint).mockImplementation(() => ({
             apiKey: MOCK_API_KEY,

--- a/packages/client/ui/react-ui/src/hooks/useCrossmint.test.tsx
+++ b/packages/client/ui/react-ui/src/hooks/useCrossmint.test.tsx
@@ -1,23 +1,17 @@
-import { act, render } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import { useEffect } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { Crossmint } from "@crossmint/common-sdk-base";
+import { Crossmint, createCrossmint } from "@crossmint/common-sdk-base";
 
 import { CrossmintProvider, useCrossmint } from "./useCrossmint";
 
 const MOCK_API_KEY =
     "sk_development_5ZUNkuhjP8aYZEgUTDfWToqFpo5zakEqte1db4pHZgPAVKZ9JuSvnKeGiqY654DoBuuZEzYz4Eb8gRV2ePqQ1fxTjEP8tTaUQdzbGfyG9RgyeN5YbqViXinqxk8EayEkAGtvSSgjpjEr6iaBptJtUFwPW59DjQzTQP6P8uZdiajenVg7bARGKjzFyByNuVEoz41DpRB4hDZNFdwCTuf5joFv";
 
-jest.mock("@crossmint/common-sdk-base", () => {
-    const actualModule = jest.requireActual("@crossmint/common-sdk-base");
-
-    return {
-        ...actualModule,
-        createCrossmint: jest.fn(() => ({
-            apiKey: MOCK_API_KEY,
-        })),
-    };
-});
+vi.mock("@crossmint/common-sdk-base", () => ({
+    createCrossmint: vi.fn(),
+}));
 
 class MockSDK {
     constructor(public crossmint: Crossmint) {}
@@ -31,6 +25,15 @@ function renderCrossmintProvider({ children }: { children: JSX.Element }) {
 }
 
 describe("CrossmintProvider", () => {
+    beforeEach(() => {
+        cleanup();
+        vi.resetAllMocks();
+        vi.mocked(createCrossmint).mockImplementation(() => ({
+            apiKey: MOCK_API_KEY,
+            jwt: "",
+        }));
+    });
+
     it("provides initial JWT value", () => {
         const TestComponent = () => {
             const { crossmint } = useCrossmint();
@@ -51,9 +54,7 @@ describe("CrossmintProvider", () => {
             );
         };
         const { getByTestId, getByText } = renderCrossmintProvider({ children: <TestComponent /> });
-        act(() => {
-            getByText("Update JWT").click();
-        });
+        fireEvent.click(getByText("Update JWT"));
         expect(getByTestId("jwt").textContent).toBe("new_jwt");
     });
 
@@ -71,7 +72,7 @@ describe("CrossmintProvider", () => {
     });
 
     it("triggers re-render on JWT change", () => {
-        const renderCount = jest.fn();
+        const renderCount = vi.fn();
         const TestComponent = () => {
             const { crossmint, setJwt } = useCrossmint();
             useEffect(() => {
@@ -89,9 +90,7 @@ describe("CrossmintProvider", () => {
 
         expect(renderCount).toHaveBeenCalledTimes(1);
 
-        act(() => {
-            getByText("Update JWT").click();
-        });
+        fireEvent.click(getByText("Update JWT"));
 
         expect(renderCount).toHaveBeenCalledTimes(2);
     });

--- a/packages/client/ui/react-ui/vitest.config.ts
+++ b/packages/client/ui/react-ui/vitest.config.ts
@@ -5,5 +5,6 @@ export default defineConfig({
         environment: "jsdom",
         include: ["**/*.test.{ts,tsx}"],
         exclude: ["node_modules"],
+        globals: true,
     },
 });

--- a/packages/client/ui/react-ui/vitest.config.ts
+++ b/packages/client/ui/react-ui/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    test: {
+        environment: "jsdom",
+        include: ["**/*.test.{ts,tsx}"],
+        exclude: ["node_modules"],
+    },
+});


### PR DESCRIPTION
## Description

Jest (or at least how we've configured it) often struggles to build things to test, and when it fails does not provide useful error messages. This has caused me to get waste hours multiple times, bit the bullet here and converted the package to use vitest, which is much better and provides error messages that let you actually fix any build issues that come up!

Newer packages all use vitest, this change pushes the repo further in that direction.

This PR also converts a few imports that look like this `@/x/y` into `../../x/y` to fix some build issues (that vitest reported, maybe there's some config we could set to enable, but less drama to just have the regular imports instead.)

## Test plan

Existing tests run and pass.