### PR TITLE
docs: add line to fix links during generation

### DIFF
--- a/packages/client/wallets/smart-wallet/custom-plugin.mjs
+++ b/packages/client/wallets/smart-wallet/custom-plugin.mjs
@@ -38,5 +38,8 @@ export function load(app) {
   app.renderer.on(MarkdownPageEvent.END, (page) => {
     // remove .mdx from links so it works with mintlify
     page.contents = page.contents.replace(/\.mdx/g, "");
+
+    // add "./" to beginning of links so they open in same tab in mintlify
+    page.contents = page.contents.replace(/\]\((?!http)/g, '](./');
   });
 }

--- a/packages/client/wallets/smart-wallet/custom-plugin.mjs
+++ b/packages/client/wallets/smart-wallet/custom-plugin.mjs
@@ -40,6 +40,6 @@ export function load(app) {
     page.contents = page.contents.replace(/\.mdx/g, "");
 
     // add "./" to beginning of links so they open in same tab in mintlify
-    page.contents = page.contents.replace(/\]\((?!http)/g, '](./');
+    page.contents = page.contents.replace(/\]\((?!http|\.{2}\/)/g, '](./');
   });
 }


### PR DESCRIPTION
## Description

problem:
- typedoc generates markdown style links that lack the `./` preceding them
- this confuses mintlify and the links open in a new tab.

solution:
this adds code to the custom plugin file for typedoc that searches for all occurrences of `](` not followed by http or `../` (to avoid breaking correct external links and relative path) and replaces it with `](./`

## Test plan

- tested locally by running `npx typedoc` and examining the generated docs directory
- previously 304 occurrences matching regex: `\]\((?!http|\.{2}\/)` and now zero (when adding negative look ahead for `./` also