### PR TITLE
Smart Wallets: Fix Error Loop Issue

### DIFF
--- a/.changeset/three-pots-rescue.md
+++ b/.changeset/three-pots-rescue.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+---
+
+fix error handling issue

--- a/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
@@ -27,7 +27,7 @@ function deriveErrorState(error: unknown): { status: "loading-error"; error: Sma
 }
 
 function shouldGetOrCreateWallet(status: WalletStatus, jwt: string | undefined): jwt is string {
-    return jwt != null && !(status === "in-progress" || status === "loaded");
+    return jwt != null && status === "not-loaded";
 }
 
 type WalletContext = {

--- a/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
@@ -68,7 +68,7 @@ export function CrossmintWalletProvider({ children, config }: { config: Crossmin
         }
     }, [crossmint.jwt, config.createOnLogin, state.status]);
 
-    const getOrCreateWallet = async () => {
+    const getOrCreateWalletExternal = async () => {
         if (crossmint.jwt == null) {
             console.log("No authenticated user, not creating wallet.");
             return;
@@ -82,5 +82,9 @@ export function CrossmintWalletProvider({ children, config }: { config: Crossmin
         return getOrCreateWalletInternal(crossmint.jwt);
     };
 
-    return <WalletContext.Provider value={{ ...state, getOrCreateWallet }}>{children}</WalletContext.Provider>;
+    return (
+        <WalletContext.Provider value={{ ...state, getOrCreateWallet: getOrCreateWalletExternal }}>
+            {children}
+        </WalletContext.Provider>
+    );
 }

--- a/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
@@ -74,7 +74,7 @@ export function CrossmintWalletProvider({ children, config }: { config: Crossmin
             return;
         }
 
-        if (!(state.status === "not-loaded" || state.status === "loading-error")) {
+        if (state.status === "loaded" || state.status === "in-progress") {
             console.log("Wallet is already loaded, or is currently loading.");
             return;
         }

--- a/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
@@ -75,7 +75,7 @@ export function CrossmintWalletProvider({ children, config }: { config: Crossmin
         }
 
         if (!(state.status === "not-loaded" || state.status === "loading-error")) {
-            console.log("Wallet is already loaded, or is currently loading, not creating wallet.");
+            console.log("Wallet is already loaded, or is currently loading.");
             return;
         }
 

--- a/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
@@ -26,10 +26,6 @@ function deriveErrorState(error: unknown): { status: "loading-error"; error: Sma
     return { status: "loading-error", error: new SmartWalletError(`Unknown Wallet Error: ${message}`, stack) };
 }
 
-function shouldGetOrCreateWallet(status: WalletStatus, jwt: string | undefined): jwt is string {
-    return jwt != null && status === "not-loaded";
-}
-
 type WalletContext = {
     status: WalletStatus;
     wallet?: EVMSmartWallet;
@@ -47,14 +43,10 @@ export function CrossmintWalletProvider({ children, config }: { config: Crossmin
     const [state, setState] = useState<ValidWalletState>({ status: "not-loaded" });
     const smartWalletSDK = useMemo(() => SmartWalletSDK.init({ clientApiKey: crossmint.apiKey }), [crossmint.apiKey]);
 
-    const getOrCreateWallet = async () => {
-        if (!shouldGetOrCreateWallet(state.status, crossmint.jwt)) {
-            return;
-        }
-
+    const getOrCreateWalletInternal = async (jwt: string) => {
         try {
             setState({ status: "in-progress" });
-            const wallet = await smartWalletSDK.getOrCreateWallet({ jwt: crossmint.jwt }, config.defaultChain);
+            const wallet = await smartWalletSDK.getOrCreateWallet({ jwt }, config.defaultChain);
             setState({ status: "loaded", wallet });
         } catch (error: unknown) {
             console.error("There was an error creating a wallet ", error);
@@ -63,9 +55,9 @@ export function CrossmintWalletProvider({ children, config }: { config: Crossmin
     };
 
     useEffect(() => {
-        if (config.createOnLogin === "all-users" && shouldGetOrCreateWallet(state.status, crossmint.jwt)) {
+        if (config.createOnLogin === "all-users" && crossmint.jwt != null && state.status === "not-loaded") {
             console.log("Getting or Creating wallet");
-            getOrCreateWallet();
+            getOrCreateWalletInternal(crossmint.jwt);
             return;
         }
 
@@ -75,6 +67,20 @@ export function CrossmintWalletProvider({ children, config }: { config: Crossmin
             return;
         }
     }, [crossmint.jwt, config.createOnLogin, state.status]);
+
+    const getOrCreateWallet = async () => {
+        if (crossmint.jwt == null) {
+            console.log("No authenticated user, not creating wallet.");
+            return;
+        }
+
+        if (!(state.status === "not-loaded" || state.status === "loading-error")) {
+            console.log("Wallet is already loaded, or is currently loading, not creating wallet.");
+            return;
+        }
+
+        return getOrCreateWalletInternal(crossmint.jwt);
+    };
 
     return <WalletContext.Provider value={{ ...state, getOrCreateWallet }}>{children}</WalletContext.Provider>;
 }


### PR DESCRIPTION
## Description

This PR fixes an issue where, in the event of an error in `SmartWalletSdk.getOrCreateWallet`, we'd call it again in repeat. @jmderby, who'll be reviewing this PR, and I are in the same room and we've shared more context in person.

## Test plan

On the Smart Wallet + auth  Demo:
- Happy path, login and mint flow.
- Confirmed we're no longer repeating requests in the event of an error.
- Confirmed that the `getOrCreateWallet` function we expose from `useWallet` can be used to successfully recover from the error state.
