### PR TITLE
AA: Fix incorrect jsdoc

### DIFF
--- a/packages/client/wallets/smart-wallet/src/blockchain/wallets/SendTransactionService.ts
+++ b/packages/client/wallets/smart-wallet/src/blockchain/wallets/SendTransactionService.ts
@@ -55,7 +55,7 @@ export class EVMSendTransactionError extends CrossmintSDKError {
  *   });
  * } catch (e) {
  *   if (e instanceof SendTransactionExecutionRevertedError) {
- *     alert(`Transaction reverted: ${e.revertError.message}`);
+ *     alert(`Transaction reverted: ${e.message}`);
  *   }
  *   throw e;
  * }


### PR DESCRIPTION
## Description

Just noticed this mistake after merging the main PR

We removed this field, e.message is correct because it contains the message from the viem revert error

## Test plan

N/A