### PR TITLE
Smart Wallets + Auth: Enable All Smart Wallet Chains For `CrossmintAuthProvider` & `CrossmintWalletProvider`

### DIFF
--- a/.changeset/good-pumpkins-laugh.md
+++ b/.changeset/good-pumpkins-laugh.md
@@ -3,4 +3,4 @@
 "@crossmint/client-sdk-react-ui": patch
 ---
 
-allow auth and wallet providers to use all smart wallet supported chains
+allow auth and wallet providers to use all smart wallet supported chains. Rename smart wallet SDK chain export.

--- a/.changeset/good-pumpkins-laugh.md
+++ b/.changeset/good-pumpkins-laugh.md
@@ -1,0 +1,6 @@
+---
+"@crossmint/client-sdk-smart-wallet": patch
+"@crossmint/client-sdk-react-ui": patch
+---
+
+allow auth and wallet providers to use all smart wallet supported chains

--- a/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.tsx
@@ -1,10 +1,10 @@
 import { useCrossmint } from "@/hooks";
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 
 import { AuthProvider as AuthCoreProvider } from "@crossmint/client-sdk-auth-core/client";
-import { UIConfig } from "@crossmint/common-sdk-base";
+import type { UIConfig } from "@crossmint/common-sdk-base";
 
-import { CrossmintWalletConfig, CrossmintWalletProvider } from "./CrossmintWalletProvider";
+import { type CrossmintWalletConfig, CrossmintWalletProvider } from "./CrossmintWalletProvider";
 
 type CrossmintAuthProviderProps = {
     embeddedWallets: CrossmintWalletConfig;

--- a/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
@@ -1,11 +1,16 @@
 import { useCrossmint } from "@/hooks";
 import { ReactNode, createContext, useEffect, useMemo, useState } from "react";
 
-import { EVMSmartWallet, SmartWalletChain, SmartWalletError, SmartWalletSDK } from "@crossmint/client-sdk-smart-wallet";
+import {
+    EVMSmartWallet,
+    EVMSmartWalletChain,
+    SmartWalletError,
+    SmartWalletSDK,
+} from "@crossmint/client-sdk-smart-wallet";
 
 export type CrossmintWalletConfig = {
     type: "evm-smart-wallet";
-    defaultChain: SmartWalletChain;
+    defaultChain: EVMSmartWalletChain;
     createOnLogin: "all-users" | "off";
 };
 

--- a/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
@@ -1,11 +1,11 @@
 import { useCrossmint } from "@/hooks";
 import { ReactNode, createContext, useEffect, useMemo, useState } from "react";
 
-import { EVMSmartWallet, SmartWalletError, SmartWalletSDK } from "@crossmint/client-sdk-smart-wallet";
+import { EVMSmartWallet, SmartWalletChain, SmartWalletError, SmartWalletSDK } from "@crossmint/client-sdk-smart-wallet";
 
 export type CrossmintWalletConfig = {
     type: "evm-smart-wallet";
-    defaultChain: "polygon-amoy" | "base-sepolia" | "optimism-sepolia" | "arbitrum-sepolia";
+    defaultChain: SmartWalletChain;
     createOnLogin: "all-users" | "off";
 };
 

--- a/packages/client/wallets/smart-wallet/src/index.ts
+++ b/packages/client/wallets/smart-wallet/src/index.ts
@@ -11,6 +11,8 @@ export type {
     WalletParams,
 } from "./types/params";
 
+export type { SmartWalletChain } from "./blockchain/chains";
+
 export type { TransferType, ERC20TransferType, NFTTransferType, SFTTransferType } from "./types/token";
 
 export {

--- a/packages/client/wallets/smart-wallet/src/index.ts
+++ b/packages/client/wallets/smart-wallet/src/index.ts
@@ -11,7 +11,7 @@ export type {
     WalletParams,
 } from "./types/params";
 
-export type { SmartWalletChain } from "./blockchain/chains";
+export type { SmartWalletChain as EVMSmartWalletChain } from "./blockchain/chains";
 
 export type { TransferType, ERC20TransferType, NFTTransferType, SFTTransferType } from "./types/token";
 


### PR DESCRIPTION
## Description

We temporarily only had staging chains enabled for these providers, this PR updates the SDK to enable the use of all Smart Wallet supported chains.

## Test plan

Sanity checked that the auth + smart wallet demo flow still works.

## Package updates

This PR patches both `@crossmint/client-sdk-smart-wallet` and `@crossmint/client-sdk-react-ui`