### PR TITLE
Smart Wallet: Chain <> Env Validation

### DIFF
--- a/.changeset/metal-pumpkins-taste.md
+++ b/.changeset/metal-pumpkins-taste.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-smart-wallet": patch
+---
+
+Added chain <> env validation

--- a/packages/client/wallets/smart-wallet/src/SmartWalletSDK.ts
+++ b/packages/client/wallets/smart-wallet/src/SmartWalletSDK.ts
@@ -95,11 +95,8 @@ export class SmartWalletSDK {
 
     private assertValidChain(chain: SmartWalletChain) {
         if (!this.validChain(chain)) {
-            const validChains = this.crossmintEnv === "production" ? SMART_WALLET_MAINNETS : SMART_WALLET_TESTNETS;
-            const formattedChains = validChains.map((chain) => `"${chain}"`).join(", ");
             throw new SmartWalletError(
-                `Invalid chain "${chain}" for environment "${this.crossmintEnv}" specified by API key.\n` +
-                    `Either update the API key or use one of the following compatible chains:\n ${formattedChains}`
+                `The selected chain "${chain}" is not available in "${this.crossmintEnv}". Either set a valid chain or check you're using an API key for the environment you're trying to target.`
             );
         }
     }

--- a/packages/client/wallets/smart-wallet/src/blockchain/chains.ts
+++ b/packages/client/wallets/smart-wallet/src/blockchain/chains.ts
@@ -37,6 +37,14 @@ export const SmartWalletChain = {
 export type SmartWalletChain = ObjectValues<typeof SmartWalletChain>;
 export const SMART_WALLET_CHAINS = objectValues(SmartWalletChain);
 
+export function isTestnetChain(chain: SmartWalletChain): chain is SmartWalletTestnet {
+    return (SMART_WALLET_TESTNETS as any).includes(chain);
+}
+
+export function isMainnetChain(chain: SmartWalletChain): chain is SmartWalletMainnet {
+    return (SMART_WALLET_MAINNETS as any).includes(chain);
+}
+
 export const viemNetworks: Record<SmartWalletChain, Chain> = {
     polygon: polygon,
     "polygon-amoy": polygonAmoy,


### PR DESCRIPTION
## Description

This PR adds chain <> env validation, so if a dev provides a staging API key and a mainnet chain (or vice versa), they'll get an error message that looks like this:

<img width="532" alt="Screenshot 2024-09-03 at 2 52 51 PM" src="https://github.com/user-attachments/assets/d0864f28-1b0f-45cf-b7bb-0d3582cc77b5">

## Test plan

Locally, within the smart wallet SDK playground:
- Confirmed the error case works as expected, as pictured above, for both staging & production keys.
- Sanity checked that the happy path still works.

## Package updates

patch `@crossmint/client-sdk-smart-wallet`