### PR TITLE
Auth modal: Fixed uri string bug

### DIFF
--- a/.changeset/sweet-poems-decide.md
+++ b/.changeset/sweet-poems-decide.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+---
+
+Fixed auth modal string url bug

--- a/packages/client/ui/react-ui/src/components/auth/AuthModal.tsx
+++ b/packages/client/ui/react-ui/src/components/auth/AuthModal.tsx
@@ -36,7 +36,7 @@ type AuthModalProps = {
 };
 
 export default function AuthModal({ setModalOpen, setJwtToken, apiKey, baseUrl, appearance }: AuthModalProps) {
-    let iframeSrc = `${baseUrl}/sdk/auth/frame?apiKey=${apiKey}`;
+    let iframeSrc = `${baseUrl}sdk/auth/frame?apiKey=${apiKey}`;
     if (appearance != null) {
         // The appearance object is serialized into a query parameter
         iframeSrc += `&uiConfig=${encodeURIComponent(JSON.stringify(appearance))}`;


### PR DESCRIPTION
## Description

Fixed bug with uri that the iframe calls was improperly formatted.

## Test plan

Development and staging still work and bug is now exterminated 
## Package updates

**@crossmint/client-sdk-react-ui**