### PR TITLE
Removes horizontal padding in auth iframe

### DIFF
--- a/.changeset/tricky-lobsters-exercise.md
+++ b/.changeset/tricky-lobsters-exercise.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+---
+
+Removes horizontal padding from the AuthModal to avoid clipping iframe.

--- a/packages/client/ui/react-ui/src/components/auth/AuthModal.tsx
+++ b/packages/client/ui/react-ui/src/components/auth/AuthModal.tsx
@@ -145,7 +145,7 @@ export default function AuthModal({ setModalOpen, setJwtToken, apiKey, baseUrl, 
                                 height: "500px",
                                 border: `1px solid ${appearance?.colors?.border ?? "#D0D5DD"}`,
                                 borderRadius: appearance?.borderRadius ?? "16px",
-                                padding: "48px 40px 32px",
+                                padding: "48px 0 32px",
                                 backgroundColor: appearance?.colors?.background ?? "#FFFFFF",
                                 animation: "fadeIn 3s ease-in-out",
                             }}

--- a/packages/client/ui/react-ui/src/consts/version.ts
+++ b/packages/client/ui/react-ui/src/consts/version.ts
@@ -1,1 +1,1 @@
-export const LIB_VERSION = "1.3.13";
+export const LIB_VERSION = "1.3.16";


### PR DESCRIPTION
## Description

Padding has been added for auth view in crossbit-main and it breaks otp in mobile

## Test plan

Open auth modal in next demo

## Package updates

@crossmint/client-sdk-react-ui