### PR TITLE
Crossmint Provider: Hydration Fix (Resolves WAL-2880)

### DIFF
--- a/.changeset/smooth-mirrors-protect.md
+++ b/.changeset/smooth-mirrors-protect.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+---
+
+Fix hydration error issue

--- a/packages/client/ui/react-ui/src/hooks/useCrossmint.tsx
+++ b/packages/client/ui/react-ui/src/hooks/useCrossmint.tsx
@@ -2,8 +2,6 @@ import { ReactNode, createContext, useCallback, useContext, useMemo, useRef, use
 
 import { Crossmint, createCrossmint } from "@crossmint/common-sdk-base";
 
-import { getCachedJwt } from "../utils";
-
 export interface CrossmintContext {
     crossmint: Crossmint;
     setJwt: (jwt: string | undefined) => void;
@@ -18,17 +16,14 @@ export function CrossmintProvider({
     const [version, setVersion] = useState(0);
 
     const crossmintRef = useRef<Crossmint>(
-        new Proxy<Crossmint>(
-            createCrossmint({ ...createCrossmintParams, jwt: createCrossmintParams.jwt ?? getCachedJwt() }),
-            {
-                set(target, prop, value) {
-                    if (prop === "jwt" && target.jwt !== value) {
-                        setVersion((v) => v + 1);
-                    }
-                    return Reflect.set(target, prop, value);
-                },
-            }
-        )
+        new Proxy<Crossmint>(createCrossmint(createCrossmintParams), {
+            set(target, prop, value) {
+                if (prop === "jwt" && target.jwt !== value) {
+                    setVersion((v) => v + 1);
+                }
+                return Reflect.set(target, prop, value);
+            },
+        })
     );
 
     const setJwt = useCallback((jwt: string | undefined) => {

--- a/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.tsx
@@ -8,6 +8,8 @@ import AuthModal from "../components/auth/AuthModal";
 import { useCrossmint, useWallet } from "../hooks";
 import { CrossmintWalletProvider } from "./CrossmintWalletProvider";
 
+const SESSION_PREFIX = "crossmint-session";
+
 export type CrossmintAuthWalletConfig = {
     defaultChain: EVMSmartWalletChain;
     createOnLogin: "all-users" | "off";
@@ -41,7 +43,7 @@ export function CrossmintAuthProvider({ embeddedWallets, children, appearance }:
     const [modalOpen, setModalOpen] = useState(false);
 
     useEffect(() => {
-        const session = getCachedJwt();
+        const session = sessionFromClient();
         if (session != null) {
             setJwt(session);
         }
@@ -143,12 +145,7 @@ function WalletManager({
     return <>{children}</>;
 }
 
-function getCachedJwt(): string | undefined {
-    if (typeof document === "undefined") {
-        return undefined; // Check if we're on the client-side
-    }
+function sessionFromClient(): string | undefined {
     const crossmintSession = document.cookie.split("; ").find((row) => row.startsWith(SESSION_PREFIX));
     return crossmintSession ? crossmintSession.split("=")[1] : undefined;
 }
-
-const SESSION_PREFIX = "crossmint-session";

--- a/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.tsx
@@ -6,7 +6,6 @@ import { type UIConfig, validateApiKeyAndGetCrossmintBaseUrl } from "@crossmint/
 
 import AuthModal from "../components/auth/AuthModal";
 import { useCrossmint, useWallet } from "../hooks";
-import { SESSION_PREFIX } from "../utils";
 import { CrossmintWalletProvider } from "./CrossmintWalletProvider";
 
 export type CrossmintAuthWalletConfig = {
@@ -40,6 +39,13 @@ export function CrossmintAuthProvider({ embeddedWallets, children, appearance }:
     const { crossmint, setJwt } = useCrossmint("CrossmintAuthProvider must be used within CrossmintProvider");
     const crossmintBaseUrl = validateApiKeyAndGetCrossmintBaseUrl(crossmint.apiKey);
     const [modalOpen, setModalOpen] = useState(false);
+
+    useEffect(() => {
+        const session = getCachedJwt();
+        if (session != null) {
+            setJwt(session);
+        }
+    }, []);
 
     const login = () => {
         if (crossmint.jwt != null) {
@@ -136,3 +142,13 @@ function WalletManager({
 
     return <>{children}</>;
 }
+
+function getCachedJwt(): string | undefined {
+    if (typeof document === "undefined") {
+        return undefined; // Check if we're on the client-side
+    }
+    const crossmintSession = document.cookie.split("; ").find((row) => row.startsWith(SESSION_PREFIX));
+    return crossmintSession ? crossmintSession.split("=")[1] : undefined;
+}
+
+const SESSION_PREFIX = "crossmint-session";

--- a/packages/client/ui/react-ui/src/utils/constants.ts
+++ b/packages/client/ui/react-ui/src/utils/constants.ts
@@ -1,1 +1,0 @@
-export const SESSION_PREFIX = "crossmint-session";

--- a/packages/client/ui/react-ui/src/utils/index.ts
+++ b/packages/client/ui/react-ui/src/utils/index.ts
@@ -1,2 +1,0 @@
-export * from "./constants";
-export * from "./jwt";

--- a/packages/client/ui/react-ui/src/utils/jwt.ts
+++ b/packages/client/ui/react-ui/src/utils/jwt.ts
@@ -1,9 +1,0 @@
-import { SESSION_PREFIX } from "./constants";
-
-export function getCachedJwt(): string | undefined {
-    if (typeof document === "undefined") {
-        return undefined; // Check if we're on the client-side
-    }
-    const crossmintSession = document.cookie.split("; ").find((row) => row.startsWith(SESSION_PREFIX));
-    return crossmintSession ? crossmintSession.split("=")[1] : undefined;
-}


### PR DESCRIPTION
## Description

Right now, within the `CrossmintProvider` component, we read from cookies for Crossmint Auth sessions to populate the initial JWT. Since Next.js generates a static page when possible, the first render, which is that static page, would not have a JWT value. The subsequent hydration would read in the cookies, and cause an error because the static page and first client render would be different, which is not allowed.

This PR moves reading the cookie to a `useEffect` that only happens once on render client side, fixing the hydration error.

## Test plan

There's pretty solid unit test coverage over `CrossmintProvider`, `CrossmintAuthProvider`, which should continue to pass here.

Locally, I ran through the demo flow and confirmed everything worked as expected, w/ no hydration issues.

## Package updates

<!-- 
  List any package updates and ensure you've added the necessary changesets, running `pnpm change:add` to do so.
-->