### PR TITLE
Crossmint Provider: Drop `jwt` prop (Resolves WAL-2884)

### DIFF
--- a/.changeset/silver-swans-brush.md
+++ b/.changeset/silver-swans-brush.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+---
+
+Remove jwt prop from `CrossmintProvider`

--- a/packages/client/ui/react-ui/src/hooks/useCrossmint.tsx
+++ b/packages/client/ui/react-ui/src/hooks/useCrossmint.tsx
@@ -11,12 +11,15 @@ const CrossmintContext = createContext<CrossmintContext | null>(null);
 
 export function CrossmintProvider({
     children,
-    ...createCrossmintParams
-}: { children: ReactNode } & Parameters<typeof createCrossmint>[0]) {
+    apiKey,
+    overrideBaseUrl,
+}: Omit<Crossmint, "jwt"> & {
+    children: ReactNode;
+}) {
     const [version, setVersion] = useState(0);
 
     const crossmintRef = useRef<Crossmint>(
-        new Proxy<Crossmint>(createCrossmint(createCrossmintParams), {
+        new Proxy<Crossmint>(createCrossmint({ apiKey, overrideBaseUrl }), {
             set(target, prop, value) {
                 if (prop === "jwt" && target.jwt !== value) {
                     setVersion((v) => v + 1);


### PR DESCRIPTION
## Description

atm we let developers set jwt from the props, or via setJwt, but there's no clear way they can co-exist. For example, what if a developer uses the jwt prop, but then calls setJwt? Do the jwt prop and actual jwt differ in value? etc.

This PR removes the `jwt` prop. I considered removing `setJwt` instead, but that's not possible atm since `CrossmintAuthProvider` relies on it.

## Test plan

Existing unit tests.

Locally, I went through the auth + smart wallet demo flow just in case XD.

## Package updates

patch `@crossmint/client-sdk-react-ui`