### PR TITLE
Auth modal: Default close icon color

### DIFF
--- a/.changeset/hip-bats-remember.md
+++ b/.changeset/hip-bats-remember.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+---
+
+Changed auth modal close button default color

--- a/packages/client/ui/react-ui/src/components/auth/AuthModal.tsx
+++ b/packages/client/ui/react-ui/src/components/auth/AuthModal.tsx
@@ -126,7 +126,7 @@ export default function AuthModal({ setModalOpen, setJwtToken, apiKey, baseUrl, 
                                     right: "1.5rem",
                                     top: "1.5rem",
                                     cursor: "pointer",
-                                    color: appearance?.colors?.border,
+                                    color: appearance?.colors?.border ?? "#909ca3",
                                     outlineOffset: "4px",
                                     borderRadius: "100%",
                                 }}

--- a/packages/client/ui/react-ui/src/consts/version.ts
+++ b/packages/client/ui/react-ui/src/consts/version.ts
@@ -1,1 +1,1 @@
-export const LIB_VERSION = "1.3.16";
+export const LIB_VERSION = "1.3.18";


### PR DESCRIPTION
## Description

Added a default color for the modal close button.

<img width="778" alt="Screenshot 2024-09-12 at 2 59 39 PM" src="https://github.com/user-attachments/assets/a559e3e7-fb68-4f0b-832e-d0a0e4b3d116">


## Test plan

Button color is applied for both custom appearance and default.

## Package updates

@crossmint/client-sdk-react-ui