### PR TITLE
Smart Wallets: Rename `EOASigner` => `ExternalSigner`

### DIFF
--- a/.changeset/fast-suns-accept.md
+++ b/.changeset/fast-suns-accept.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-smart-wallet": patch
+---
+
+rename `EOASigner` => `ExternalSigner`

--- a/packages/client/wallets/smart-wallet/src/index.ts
+++ b/packages/client/wallets/smart-wallet/src/index.ts
@@ -7,7 +7,7 @@ export type {
     UserParams,
     ViemAccount,
     PasskeySigner,
-    EOASigner,
+    ExternalSigner,
     WalletParams,
 } from "./types/params";
 

--- a/packages/client/wallets/smart-wallet/src/types/internal.ts
+++ b/packages/client/wallets/smart-wallet/src/types/internal.ts
@@ -7,7 +7,7 @@ import type { Address, Chain, HttpTransport, PublicClient } from "viem";
 import type { SmartWalletChain } from "../blockchain/chains";
 import type { EOASignerConfig, PasskeySignerConfig, SignerConfig } from "../blockchain/wallets/account/signer";
 import { SUPPORTED_ENTRYPOINT_VERSIONS, SUPPORTED_KERNEL_VERSIONS } from "../utils/constants";
-import type { EOASigner, PasskeySigner, UserParams, WalletParams } from "./params";
+import type { ExternalSigner, PasskeySigner, UserParams, WalletParams } from "./params";
 
 export type SupportedKernelVersion = (typeof SUPPORTED_KERNEL_VERSIONS)[number];
 export function isSupportedKernelVersion(version: string): version is SupportedKernelVersion {
@@ -40,7 +40,7 @@ export interface PasskeyCreationContext extends WalletCreationContext {
 }
 
 export interface EOACreationContext extends WalletCreationContext {
-    walletParams: WalletParams & { signer: EOASigner };
+    walletParams: WalletParams & { signer: ExternalSigner };
     existing?: { signerConfig: EOASignerConfig; address: Address };
 }
 
@@ -54,7 +54,7 @@ export function isPasskeyCreationContext(params: WalletCreationContext): params 
     return isPasskeyWalletParams(params.walletParams) && signerIsPasskeyOrUndefined;
 }
 
-export function isEOAWalletParams(params: WalletParams): params is WalletParams & { signer: EOASigner } {
+export function isEOAWalletParams(params: WalletParams): params is WalletParams & { signer: ExternalSigner } {
     return (
         "signer" in params &&
         (("type" in params.signer && params.signer.type === "VIEM_ACCOUNT") ||

--- a/packages/client/wallets/smart-wallet/src/types/params.ts
+++ b/packages/client/wallets/smart-wallet/src/types/params.ts
@@ -24,7 +24,7 @@ export type PasskeySigner = {
     passkeyName?: string;
 };
 
-export type EOASigner = EIP1193Provider | ViemAccount;
+export type ExternalSigner = EIP1193Provider | ViemAccount;
 export interface WalletParams {
-    signer: EOASigner | PasskeySigner;
+    signer: ExternalSigner | PasskeySigner;
 }


### PR DESCRIPTION
## Description

This PR renames `EOASigner` to `ExternalSigner` for a couple reasons:
- It's not accurate, `1193Provider` a valid `EOASigner` is a generic interface for wallets and can even represent AA wallets.
- It's confusing, if I wanted to use a privy, dynamic, or web3auth signer `EOASigner` is not obvious, but `ExternalSigner` is!

Ofc open to further naming improvements.

## Test plan

N/A

## Package updates

patch `@crossmint/client-sdk-smart-wallet` (XD will respect semver after the public announcement)