### PR TITLE
Smart Wallets: Re-use `executeContract` Within `transferToken` + Fix `executeTransaction` Simulation Bug (Resolves WAL-2919)

### DIFF
--- a/.changeset/afraid-items-fly.md
+++ b/.changeset/afraid-items-fly.md
@@ -1,0 +1,6 @@
+---
+"@crossmint/client-sdk-smart-wallet": patch
+"@crossmint/client-sdk-base": patch
+---
+
+Strip transferToken function

--- a/packages/client/base/src/error/index.ts
+++ b/packages/client/base/src/error/index.ts
@@ -6,12 +6,6 @@ export class CrossmintSDKError extends Error {
     }
 }
 
-export class TransferError extends CrossmintSDKError {
-    constructor(message: string) {
-        super(message, CrossmintErrors.TRANSFER);
-    }
-}
-
 export class CrossmintServiceError extends CrossmintSDKError {
     public status?: number;
 

--- a/packages/client/wallets/smart-wallet/src/blockchain/wallets/EVMSmartWallet.ts
+++ b/packages/client/wallets/smart-wallet/src/blockchain/wallets/EVMSmartWallet.ts
@@ -1,22 +1,20 @@
-import {
+import type {
     Abi,
+    Address,
     ContractFunctionArgs,
     ContractFunctionName,
     Hex,
-    type HttpTransport,
-    type PublicClient,
+    HttpTransport,
+    PublicClient,
     WriteContractParameters,
-    isAddress,
-    publicActions,
 } from "viem";
 
-import { TransferError } from "@crossmint/client-sdk-base";
-
 import type { CrossmintWalletService } from "../../api/CrossmintWalletService";
+import { SmartWalletError } from "../../error";
 import { scwLogger } from "../../services/logger";
-import { SmartWalletClient } from "../../types/internal";
+import type { SmartWalletClient } from "../../types/internal";
 import type { TransferType } from "../../types/token";
-import { SmartWalletChain } from "../chains";
+import type { SmartWalletChain } from "../chains";
 import { transferParams } from "../transfer";
 import { SendTransactionOptions, SendTransactionService } from "./SendTransactionService";
 
@@ -66,54 +64,28 @@ export class EVMSmartWallet {
     }
 
     /**
+     * Transfers tokens from the smart wallet to a specified address.
+     * @param toAddress The recipient's address.
+     * @param config The transfer configuration, including token details and amount.
      * @returns The transaction hash.
+     * @throws {SmartWalletError} If there's a chain mismatch between this wallet and the input configuration.
+     * @throws {SendTransactionError} If the transaction fails to send. Contains the error thrown by the viem client.
+     * @throws {SendTransactionExecutionRevertedError} A subclass of SendTransactionError if the transaction fails due to a contract execution error.
      */
-    public async transferToken(toAddress: string, config: TransferType): Promise<string> {
-        return this.logger.logPerformance(
-            "TRANSFER",
-            async () => {
-                if (this.chain !== config.token.chain) {
-                    throw new Error(
-                        `Chain mismatch: Expected ${config.token.chain}, but got ${this.chain}. Ensure you are interacting with the correct blockchain.`
-                    );
-                }
+    public async transferToken(toAddress: Address, config: TransferType): Promise<string> {
+        if (this.chain !== config.token.chain) {
+            throw new SmartWalletError(
+                `Chain mismatch: Expected ${config.token.chain}, but got ${this.chain}. Ensure you are interacting with the correct blockchain.`
+            );
+        }
 
-                if (!isAddress(toAddress)) {
-                    throw new Error(`Invalid recipient address: '${toAddress}' is not a valid EVM address.`);
-                }
-
-                if (!isAddress(config.token.contractAddress)) {
-                    throw new Error(
-                        `Invalid contract address: '${config.token.contractAddress}' is not a valid EVM address.`
-                    );
-                }
-
-                const tx = transferParams({
-                    contract: config.token.contractAddress,
-                    to: toAddress,
-                    from: this.accountClient.account,
-                    config,
-                });
-
-                try {
-                    const client = this.accountClient.extend(publicActions);
-                    const { request } = await client.simulateContract(tx);
-                    const hash = await client.writeContract(request);
-                    this.logger.log(`[TRANSFER] - Transaction hash from transfer: ${hash}`);
-
-                    return hash;
-                } catch (error) {
-                    this.logger.error("[TRANSFER] - ERROR_TRANSFERRING_TOKEN", {
-                        error: error instanceof Error ? error.message : JSON.stringify(error),
-                        tokenId: tx.tokenId,
-                        contractAddress: config.token.contractAddress,
-                        chain: config.token.chain,
-                    });
-                    const tokenIdString = tx.tokenId == null ? "" : `:${tx.tokenId}}`;
-                    throw new TransferError(`Error transferring token ${config.token.contractAddress}${tokenIdString}`);
-                }
-            },
-            { toAddress, config }
+        return this.executeContract(
+            transferParams({
+                contract: config.token.contractAddress,
+                to: toAddress,
+                from: this.accountClient.account,
+                config,
+            })
         );
     }
 

--- a/packages/client/wallets/smart-wallet/src/blockchain/wallets/SendTransactionService.test.ts
+++ b/packages/client/wallets/smart-wallet/src/blockchain/wallets/SendTransactionService.test.ts
@@ -29,7 +29,7 @@ function makeMockError<E extends Error, F extends object>(error: E, fields?: F):
 describe("SendTransactionService", () => {
     const mockPublicClient = mock<PublicClient>();
     const mockAccountClient = mock<SmartAccountClient<EntryPoint, Transport, Chain, SmartAccount<EntryPoint>>>();
-    const sendTransactionService = new SendTransactionService(mockPublicClient);
+    const sendTransactionService = new SendTransactionService({ public: mockPublicClient, wallet: mockAccountClient });
 
     beforeEach(() => {
         vi.resetAllMocks();
@@ -49,15 +49,12 @@ describe("SendTransactionService", () => {
         mockPublicClient.simulateContract.mockRejectedValue(mockError);
         let rejected = false;
         try {
-            await sendTransactionService.sendTransaction(
-                {
-                    address: zeroAddress,
-                    abi: [],
-                    functionName: "mockFunction",
-                    args: [],
-                },
-                mockAccountClient
-            );
+            await sendTransactionService.sendTransaction({
+                address: zeroAddress,
+                abi: [],
+                functionName: "mockFunction",
+                args: [],
+            });
         } catch (e) {
             rejected = true;
             expect(e).toBeInstanceOf(EVMSendTransactionExecutionRevertedError);
@@ -74,15 +71,12 @@ describe("SendTransactionService", () => {
         mockPublicClient.waitForTransactionReceipt.mockResolvedValueOnce(mockReceipt);
         let rejected = false;
         try {
-            await sendTransactionService.sendTransaction(
-                {
-                    address: zeroAddress,
-                    abi: [],
-                    functionName: "mockFunction",
-                    args: [],
-                },
-                mockAccountClient
-            );
+            await sendTransactionService.sendTransaction({
+                address: zeroAddress,
+                abi: [],
+                functionName: "mockFunction",
+                args: [],
+            });
         } catch (e) {
             rejected = true;
             expect(e).toBeInstanceOf(EVMSendTransactionExecutionRevertedError);
@@ -96,15 +90,12 @@ describe("SendTransactionService", () => {
         mockPublicClient.waitForTransactionReceipt.mockRejectedValue(mockError);
         let rejected = false;
         try {
-            await sendTransactionService.sendTransaction(
-                {
-                    address: zeroAddress,
-                    abi: [],
-                    functionName: "mockFunction",
-                    args: [],
-                },
-                mockAccountClient
-            );
+            await sendTransactionService.sendTransaction({
+                address: zeroAddress,
+                abi: [],
+                functionName: "mockFunction",
+                args: [],
+            });
         } catch (e) {
             rejected = true;
             expect(e).toBeInstanceOf(EVMSendTransactionError);
@@ -118,15 +109,12 @@ describe("SendTransactionService", () => {
         mockAccountClient.writeContract.mockRejectedValue(mockError);
         let rejected = false;
         try {
-            await sendTransactionService.sendTransaction(
-                {
-                    address: zeroAddress,
-                    abi: [],
-                    functionName: "mockFunction",
-                    args: [],
-                },
-                mockAccountClient
-            );
+            await sendTransactionService.sendTransaction({
+                address: zeroAddress,
+                abi: [],
+                functionName: "mockFunction",
+                args: [],
+            });
         } catch (e) {
             rejected = true;
             expect(e).toBeInstanceOf(EVMSendTransactionError);
@@ -148,15 +136,12 @@ describe("SendTransactionService", () => {
             return "0xmockTxHash";
         });
         await expect(
-            sendTransactionService.sendTransaction(
-                {
-                    address: zeroAddress,
-                    abi: [],
-                    functionName: "mockFunction",
-                    args: [],
-                },
-                mockAccountClient
-            )
+            sendTransactionService.sendTransaction({
+                address: zeroAddress,
+                abi: [],
+                functionName: "mockFunction",
+                args: [],
+            })
         ).resolves.toBeDefined();
         expect(callOrder).toEqual(["simulateContract", "sendTransaction"]);
     });

--- a/packages/client/wallets/smart-wallet/src/blockchain/wallets/SendTransactionService.test.ts
+++ b/packages/client/wallets/smart-wallet/src/blockchain/wallets/SendTransactionService.test.ts
@@ -2,6 +2,7 @@ import { SmartAccountClient } from "permissionless";
 import { SmartAccount } from "permissionless/accounts";
 import { EntryPoint } from "permissionless/types";
 import {
+    Address,
     BaseError,
     Chain,
     ContractFunctionRevertedError,
@@ -27,8 +28,12 @@ function makeMockError<E extends Error, F extends object>(error: E, fields?: F):
 }
 
 describe("SendTransactionService", () => {
+    const walletAddress: Address = "0xE898BBd704CCE799e9593a9ADe2c1cA0351Ab660";
+    const mockSmartAccount = mock<SmartAccount<EntryPoint>>({ address: walletAddress });
     const mockPublicClient = mock<PublicClient>();
-    const mockAccountClient = mock<SmartAccountClient<EntryPoint, Transport, Chain, SmartAccount<EntryPoint>>>();
+    const mockAccountClient = mock<SmartAccountClient<EntryPoint, Transport, Chain, SmartAccount<EntryPoint>>>({
+        account: mockSmartAccount,
+    });
     const sendTransactionService = new SendTransactionService({ public: mockPublicClient, wallet: mockAccountClient });
 
     beforeEach(() => {
@@ -144,5 +149,11 @@ describe("SendTransactionService", () => {
             })
         ).resolves.toBeDefined();
         expect(callOrder).toEqual(["simulateContract", "sendTransaction"]);
+
+        expect(mockPublicClient.simulateContract).toHaveBeenCalledWith(
+            expect.objectContaining({
+                account: walletAddress,
+            })
+        );
     });
 });

--- a/packages/client/wallets/smart-wallet/src/blockchain/wallets/service.ts
+++ b/packages/client/wallets/smart-wallet/src/blockchain/wallets/service.ts
@@ -71,10 +71,9 @@ export class SmartWalletService {
         }
 
         return new EVMSmartWallet(
-            this.crossmintService,
-            this.smartAccountClient(chain, account, user),
-            publicClient,
-            chain
+            { wallet: this.smartAccountClient(chain, account, user), public: publicClient },
+            chain,
+            this.crossmintService
         );
     }
 

--- a/packages/client/wallets/smart-wallet/src/index.ts
+++ b/packages/client/wallets/smart-wallet/src/index.ts
@@ -37,7 +37,6 @@ export {
     SmartWalletErrorCode,
     CrossmintSDKError,
     CrossmintServiceError,
-    TransferError,
     JWTDecryptionError,
     JWTExpiredError,
     JWTIdentifierError,

--- a/packages/client/wallets/smart-wallet/src/types/token.ts
+++ b/packages/client/wallets/smart-wallet/src/types/token.ts
@@ -1,8 +1,10 @@
+import type { Address } from "viem";
+
 import type { SmartWalletChain } from "../blockchain/chains";
 
 export interface EVMToken {
     chain: SmartWalletChain;
-    contractAddress: string;
+    contractAddress: Address;
 }
 
 export interface NFTEVMToken extends EVMToken {


### PR DESCRIPTION
## Description

This PR does two things:
- Re-uses `executeContract` within `transferToken` for improved and consistent error handling within our transaction helper functions on `EVMSmartWallet`.
- Fixes an error within the `executeContract` function where we simulate the transaction with the wrong address.

I've annotated the PR with more detail where appropriate.

## Test plan

Initially I found the issue when attempting to transfer an NFT I had just minted, to test these changes locally, I made sure the mint flow, along with transferring the NFT worked within the wallets playground. I also sanity checked the Auth + Smart Wallet demo.

I also added a unit test coverage within `SendTransactionService` making sure the right address gets used.

## Package updates

patch `@crossmint/client-sdk-base`
patch `@crossmint/client-sdk-smart-wallet`