### PR TITLE
Auth: Implements one time use refresh token to fetch auth material

### DIFF
--- a/.changeset/brown-rice-push.md
+++ b/.changeset/brown-rice-push.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": minor
+---
+
+Makes SDK listen to initial one-time refresh token to then fetch all auth material.

--- a/.changeset/fifty-tomatoes-approve.md
+++ b/.changeset/fifty-tomatoes-approve.md
@@ -1,5 +1,0 @@
----
-"@crossmint/client-sdk-react-ui": patch
----
-
-Makes sure refreshAuthMaterial is only ran once at a time

--- a/.changeset/fifty-tomatoes-approve.md
+++ b/.changeset/fifty-tomatoes-approve.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+---
+
+Makes sure refreshAuthMaterial is only ran once at a time

--- a/.changeset/moody-pigs-sneeze.md
+++ b/.changeset/moody-pigs-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-auth-core": minor
+---
+
+Updates /refresh route

--- a/apps/payments/create-react-app/CHANGELOG.md
+++ b/apps/payments/create-react-app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @crossmint/client-sdk-react-ui-starter
 
+## 1.2.29
+
+### Patch Changes
+
+- Updated dependencies [1ae2a5a]
+  - @crossmint/client-sdk-react-ui@1.4.1
+
 ## 1.2.28
 
 ### Patch Changes

--- a/apps/payments/create-react-app/package.json
+++ b/apps/payments/create-react-app/package.json
@@ -5,37 +5,18 @@
     "repository": "https://github.com/Crossmint/crossmint-sdk",
     "license": "Apache-2.0",
     "author": "Paella Labs Inc",
-    "files": [
-        "public",
-        "src",
-        ".env",
-        "LICENSE",
-        "package.json",
-        "README.md",
-        "tsconfig.json",
-        "yarn.lock"
-    ],
+    "files": ["public", "src", ".env", "LICENSE", "package.json", "README.md", "tsconfig.json", "yarn.lock"],
     "scripts": {
         "build": "react-scripts build",
         "eject": "react-scripts eject",
         "start": "react-scripts start"
     },
     "browserslist": {
-        "production": [
-            ">0.2%",
-            "not dead",
-            "not op_mini all"
-        ],
-        "development": [
-            "last 1 chrome version",
-            "last 1 firefox version",
-            "last 1 safari version"
-        ]
+        "production": [">0.2%", "not dead", "not op_mini all"],
+        "development": ["last 1 chrome version", "last 1 firefox version", "last 1 safari version"]
     },
     "eslintConfig": {
-        "extends": [
-            "react-app"
-        ]
+        "extends": ["react-app"]
     },
     "dependencies": {
         "@crossmint/client-sdk-react-ui": "workspace:*",

--- a/apps/payments/create-react-app/package.json
+++ b/apps/payments/create-react-app/package.json
@@ -1,22 +1,41 @@
 {
     "name": "@crossmint/client-sdk-react-ui-starter",
-    "version": "1.2.28",
+    "version": "1.2.29",
     "private": true,
     "repository": "https://github.com/Crossmint/crossmint-sdk",
     "license": "Apache-2.0",
     "author": "Paella Labs Inc",
-    "files": ["public", "src", ".env", "LICENSE", "package.json", "README.md", "tsconfig.json", "yarn.lock"],
+    "files": [
+        "public",
+        "src",
+        ".env",
+        "LICENSE",
+        "package.json",
+        "README.md",
+        "tsconfig.json",
+        "yarn.lock"
+    ],
     "scripts": {
         "build": "react-scripts build",
         "eject": "react-scripts eject",
         "start": "react-scripts start"
     },
     "browserslist": {
-        "production": [">0.2%", "not dead", "not op_mini all"],
-        "development": ["last 1 chrome version", "last 1 firefox version", "last 1 safari version"]
+        "production": [
+            ">0.2%",
+            "not dead",
+            "not op_mini all"
+        ],
+        "development": [
+            "last 1 chrome version",
+            "last 1 firefox version",
+            "last 1 safari version"
+        ]
     },
     "eslintConfig": {
-        "extends": ["react-app"]
+        "extends": [
+            "react-app"
+        ]
     },
     "dependencies": {
         "@crossmint/client-sdk-react-ui": "workspace:*",

--- a/apps/payments/nextjs/CHANGELOG.md
+++ b/apps/payments/nextjs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @crossmint/client-sdk-nextjs-starter
 
+## 1.2.29
+
+### Patch Changes
+
+- Updated dependencies [1ae2a5a]
+  - @crossmint/client-sdk-react-ui@1.4.1
+
 ## 1.2.28
 
 ### Patch Changes

--- a/apps/payments/nextjs/package.json
+++ b/apps/payments/nextjs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@crossmint/client-sdk-nextjs-starter",
-    "version": "1.2.28",
+    "version": "1.2.29",
     "private": true,
     "repository": "https://github.com/Crossmint/crossmint-sdk",
     "license": "Apache-2.0",

--- a/apps/wallets/smart-wallet/next/CHANGELOG.md
+++ b/apps/wallets/smart-wallet/next/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @crossmint/client-sdk-smart-wallet-next-starter
 
+## 0.1.22
+
+### Patch Changes
+
+- Updated dependencies [1ae2a5a]
+  - @crossmint/client-sdk-react-ui@1.4.1
+
 ## 0.1.21
 
 ### Patch Changes

--- a/apps/wallets/smart-wallet/next/package.json
+++ b/apps/wallets/smart-wallet/next/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@crossmint/client-sdk-smart-wallet-next-starter",
-    "version": "0.1.21",
+    "version": "0.1.22",
     "private": true,
     "scripts": {
         "build": "next build",

--- a/packages/client/auth-core/src/services/CrossmintAuthService.ts
+++ b/packages/client/auth-core/src/services/CrossmintAuthService.ts
@@ -12,7 +12,7 @@ export class CrossmintAuthService extends BaseCrossmintService {
 
     async refreshAuthMaterial(refreshToken: string) {
         const result = await this.fetchCrossmintAPI(
-            "session/sdk/auth/refresh",
+            "2024-09-26/session/sdk/auth/refresh",
             { method: "POST", body: JSON.stringify({ refresh: refreshToken }) },
             "Error fetching new refresh and access tokans."
         );

--- a/packages/client/ui/react-ui/CHANGELOG.md
+++ b/packages/client/ui/react-ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @crossmint/client-sdk-react-ui
 
+## 1.4.1
+
+### Patch Changes
+
+- 1ae2a5a: Makes sure refreshAuthMaterial is only ran once at a time
+
 ## 1.4.0
 
 ### Minor Changes

--- a/packages/client/ui/react-ui/package.json
+++ b/packages/client/ui/react-ui/package.json
@@ -13,11 +13,7 @@
     "main": "./dist/index.cjs",
     "module": "./dist/index.js",
     "types": "./dist/index.d.ts",
-    "files": [
-        "dist",
-        "src",
-        "LICENSE"
-    ],
+    "files": ["dist", "src", "LICENSE"],
     "scripts": {
         "build": "tsup src/index.ts --clean --external react,react-dom --format esm,cjs --outDir ./dist --minify --dts --sourcemap",
         "dev": "tsup src/index.ts --clean --external react,react-dom --format esm,cjs --outDir ./dist --dts --sourcemap --watch",

--- a/packages/client/ui/react-ui/package.json
+++ b/packages/client/ui/react-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@crossmint/client-sdk-react-ui",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "repository": "https://github.com/Crossmint/crossmint-sdk",
     "license": "Apache-2.0",
     "author": "Paella Labs Inc",
@@ -13,7 +13,11 @@
     "main": "./dist/index.cjs",
     "module": "./dist/index.js",
     "types": "./dist/index.d.ts",
-    "files": ["dist", "src", "LICENSE"],
+    "files": [
+        "dist",
+        "src",
+        "LICENSE"
+    ],
     "scripts": {
         "build": "tsup src/index.ts --clean --external react,react-dom --format esm,cjs --outDir ./dist --minify --dts --sourcemap",
         "dev": "tsup src/index.ts --clean --external react,react-dom --format esm,cjs --outDir ./dist --dts --sourcemap --watch",

--- a/packages/client/ui/react-ui/src/components/auth/AuthModal.tsx
+++ b/packages/client/ui/react-ui/src/components/auth/AuthModal.tsx
@@ -68,7 +68,7 @@ export default function AuthModal({ setModalOpen, apiKey, fetchAuthMaterial, bas
 
         const initIframe = await IFrameWindow.init(iframeRef.current, {
             incomingEvents: incomingModalIframeEvents,
-            outgoingEvents: outgoingModalIframeEvents,
+            outgoingEvents: {},
         });
         setIframe(initIframe);
     };

--- a/packages/client/ui/react-ui/src/components/auth/AuthModal.tsx
+++ b/packages/client/ui/react-ui/src/components/auth/AuthModal.tsx
@@ -30,7 +30,7 @@ type AuthModalProps = {
 };
 
 export default function AuthModal({ setModalOpen, apiKey, fetchAuthMaterial, baseUrl, appearance }: AuthModalProps) {
-    let iframeSrc = `${baseUrl}sdk/auth/frame?apiKey=${apiKey}`;
+    let iframeSrc = `${baseUrl}sdk/2024-09-26/auth/frame?apiKey=${apiKey}`;
     if (appearance != null) {
         // The appearance object is serialized into a query parameter
         iframeSrc += `&uiConfig=${encodeURIComponent(JSON.stringify(appearance))}`;

--- a/packages/client/ui/react-ui/src/components/auth/AuthModal.tsx
+++ b/packages/client/ui/react-ui/src/components/auth/AuthModal.tsx
@@ -7,40 +7,29 @@ import type { UIConfig } from "@crossmint/common-sdk-base";
 
 import X from "../../icons/x";
 import { classNames } from "../../utils/classNames";
+import type { AuthMaterial } from "@/hooks/useRefreshToken";
+
+const authMaterialSchema = z.object({
+    oneTimeSecret: z.string(),
+});
 
 const incomingModalIframeEvents = {
-    authMaterialFromAuthFrame: z.object({
-        jwtToken: z.string(),
-        refreshToken: z.object({
-            secret: z.string(),
-            expiresAt: z.string(),
-        }),
-    }),
-};
-
-const outgoingModalIframeEvents = {
-    closeWindow: z.object({
-        closeWindow: z.string(),
-    }),
+    authMaterialFromAuthFrame: authMaterialSchema,
 };
 
 type IncomingModalIframeEventsType = {
     authMaterialFromAuthFrame: typeof incomingModalIframeEvents.authMaterialFromAuthFrame;
 };
 
-type OutgoingModalIframeEventsType = {
-    closeWindow: typeof outgoingModalIframeEvents.closeWindow;
-};
-
 type AuthModalProps = {
     setModalOpen: (open: boolean) => void;
-    setAuthMaterial: (authMaterial: { jwtToken: string; refreshToken: { secret: string; expiresAt: string } }) => void;
     apiKey: string;
+    fetchAuthMaterial: (refreshToken: string) => Promise<AuthMaterial>;
     baseUrl: string;
     appearance?: UIConfig;
 };
 
-export default function AuthModal({ setModalOpen, setAuthMaterial, apiKey, baseUrl, appearance }: AuthModalProps) {
+export default function AuthModal({ setModalOpen, apiKey, fetchAuthMaterial, baseUrl, appearance }: AuthModalProps) {
     let iframeSrc = `${baseUrl}sdk/auth/frame?apiKey=${apiKey}`;
     if (appearance != null) {
         // The appearance object is serialized into a query parameter
@@ -48,10 +37,9 @@ export default function AuthModal({ setModalOpen, setAuthMaterial, apiKey, baseU
     }
 
     const iframeRef = useRef<HTMLIFrameElement | null>(null);
-    const [iframe, setIframe] = useState<IFrameWindow<
-        IncomingModalIframeEventsType,
-        OutgoingModalIframeEventsType
-    > | null>(null);
+    const [iframe, setIframe] = useState<IFrameWindow<IncomingModalIframeEventsType, Record<string, never>> | null>(
+        null
+    );
 
     useEffect(() => {
         if (iframe == null) {
@@ -59,29 +47,17 @@ export default function AuthModal({ setModalOpen, setAuthMaterial, apiKey, baseU
         }
 
         iframe.on("authMaterialFromAuthFrame", (data) => {
-            setAuthMaterial(data);
+            fetchAuthMaterial(data.oneTimeSecret);
             iframe.off("authMaterialFromAuthFrame");
-
-            iframe.send("closeWindow", {
-                closeWindow: "closeWindow",
-            });
-
-            if (iframe?.iframe.contentWindow != null) {
-                iframe.iframe.contentWindow.close();
-            }
             setModalOpen(false);
         });
 
         return () => {
             if (iframe) {
                 iframe.off("authMaterialFromAuthFrame");
-
-                if (iframe.iframe.contentWindow != null) {
-                    iframe.iframe.contentWindow.close();
-                }
             }
         };
-    }, [iframe, setAuthMaterial, setModalOpen]);
+    }, [iframe, fetchAuthMaterial, setModalOpen]);
 
     const handleIframeLoaded = async () => {
         if (iframeRef.current == null) {

--- a/packages/client/ui/react-ui/src/hooks/useRefreshToken.ts
+++ b/packages/client/ui/react-ui/src/hooks/useRefreshToken.ts
@@ -23,31 +23,43 @@ type UseAuthTokenRefreshProps = {
     logout: () => void;
 };
 
+// Makes sure that everything inside the async IIFE has finished running before it can be called again.
+// The actual promise just holds that IIFE until it has finished running and it's then set to null
+let refreshPromise: Promise<void> | null = null;
+
 export function useRefreshToken({ crossmintAuthService, setAuthMaterial, logout }: UseAuthTokenRefreshProps) {
     const refreshTaskRef = useRef<CancellableTask | null>(null);
 
-    const refreshAuthMaterial = useCallback(async () => {
+    const refreshAuthMaterial = useCallback(() => {
+        if (refreshPromise != null) {
+            return refreshPromise;
+        }
+
         const refreshToken = getCookie(REFRESH_TOKEN_PREFIX);
         if (refreshToken != null) {
-            try {
-                const result = await crossmintAuthService.refreshAuthMaterial(refreshToken);
-                setAuthMaterial(result);
-                const jwtExpiration = getJWTExpiration(result.jwtToken);
+            refreshPromise = (async () => {
+                try {
+                    const result = await crossmintAuthService.refreshAuthMaterial(refreshToken);
+                    setAuthMaterial(result);
+                    const jwtExpiration = getJWTExpiration(result.jwtToken);
 
-                if (jwtExpiration == null) {
-                    throw new Error("Invalid JWT");
-                }
+                    if (jwtExpiration == null) {
+                        throw new Error("Invalid JWT");
+                    }
 
-                const currentTime = Date.now() / 1000;
-                const timeToExpire = jwtExpiration - currentTime - TIME_BEFORE_EXPIRING_JWT_IN_SECONDS;
-                if (timeToExpire > 0) {
-                    const endTime = Date.now() + timeToExpire * 1000;
-                    refreshTaskRef.current = queueTask(refreshAuthMaterial, endTime);
+                    const currentTime = Date.now() / 1000;
+                    const timeToExpire = jwtExpiration - currentTime - TIME_BEFORE_EXPIRING_JWT_IN_SECONDS;
+                    if (timeToExpire > 0) {
+                        const endTime = Date.now() + timeToExpire * 1000;
+                        refreshTaskRef.current = queueTask(refreshAuthMaterial, endTime);
+                    }
+                } catch (error) {
+                    logout();
+                    console.error(error);
+                } finally {
+                    refreshPromise = null;
                 }
-            } catch (error) {
-                logout();
-                console.error(error);
-            }
+            })();
         }
     }, []);
 

--- a/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.tsx
@@ -96,6 +96,12 @@ export function CrossmintAuthProvider({ embeddedWallets, children, appearance }:
         return "logged-out";
     };
 
+    const fetchAuthMaterial = async (refreshToken: string): Promise<AuthMaterial> => {
+        const authMaterial = await crossmintAuthService.refreshAuthMaterial(refreshToken);
+        setAuthMaterial(authMaterial);
+        return authMaterial;
+    };
+
     return (
         <AuthContext.Provider
             value={{
@@ -115,7 +121,7 @@ export function CrossmintAuthProvider({ embeddedWallets, children, appearance }:
                           <AuthModal
                               baseUrl={crossmintBaseUrl}
                               setModalOpen={setModalOpen}
-                              setAuthMaterial={setAuthMaterial}
+                              fetchAuthMaterial={fetchAuthMaterial}
                               apiKey={crossmint.apiKey}
                               appearance={appearance}
                           />,


### PR DESCRIPTION
## Description

Makes SDK listen to initial one-time refresh token to then fetch all auth material.

Also removes unused popup/iframe events. Please test locally to double check it's working.

## Test plan

Delete cookies => Log in with both OTP and OAuth

## Package updates

@crossmint/client-sdk-react-ui v1.5.0