### PR TITLE
Auth: Makes sure refreshAuthMaterial is only ran once at a time

### DIFF
--- a/.changeset/fifty-tomatoes-approve.md
+++ b/.changeset/fifty-tomatoes-approve.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+---
+
+Makes sure refreshAuthMaterial is only ran once at a time

--- a/packages/client/ui/react-ui/src/hooks/useRefreshToken.ts
+++ b/packages/client/ui/react-ui/src/hooks/useRefreshToken.ts
@@ -23,6 +23,8 @@ type UseAuthTokenRefreshProps = {
     logout: () => void;
 };
 
+// Makes sure that everything inside the async IIFE has finished running before it can be called again.
+// The actual promise just holds that IIFE until it has finished running and it's then set to null
 let refreshPromise: Promise<void> | null = null;
 
 export function useRefreshToken({ crossmintAuthService, setAuthMaterial, logout }: UseAuthTokenRefreshProps) {


### PR DESCRIPTION
## Description

Currently, React Strict Mode triggers hooks twice, which ends up calling /refresh twice, and the second time fails logging users out. This forces that it only runs once at a time, even in dev mode.

## Test plan

Run smart wallets demo app and check in networks tab in inspector that /refresh is only triggered once.

## Package updates

@crossmint/client-sdk-react-ui patch