### PR TITLE
Cleans up how refresh tokens are received to avoid multiple refreshes

### DIFF
--- a/.changeset/stale-eyes-think.md
+++ b/.changeset/stale-eyes-think.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+---
+
+Avoids re-renders with refresh token

--- a/apps/payments/create-react-app/package.json
+++ b/apps/payments/create-react-app/package.json
@@ -5,37 +5,18 @@
     "repository": "https://github.com/Crossmint/crossmint-sdk",
     "license": "Apache-2.0",
     "author": "Paella Labs Inc",
-    "files": [
-        "public",
-        "src",
-        ".env",
-        "LICENSE",
-        "package.json",
-        "README.md",
-        "tsconfig.json",
-        "yarn.lock"
-    ],
+    "files": ["public", "src", ".env", "LICENSE", "package.json", "README.md", "tsconfig.json", "yarn.lock"],
     "scripts": {
         "build": "react-scripts build",
         "eject": "react-scripts eject",
         "start": "react-scripts start"
     },
     "browserslist": {
-        "production": [
-            ">0.2%",
-            "not dead",
-            "not op_mini all"
-        ],
-        "development": [
-            "last 1 chrome version",
-            "last 1 firefox version",
-            "last 1 safari version"
-        ]
+        "production": [">0.2%", "not dead", "not op_mini all"],
+        "development": ["last 1 chrome version", "last 1 firefox version", "last 1 safari version"]
     },
     "eslintConfig": {
-        "extends": [
-            "react-app"
-        ]
+        "extends": ["react-app"]
     },
     "dependencies": {
         "@crossmint/client-sdk-react-ui": "workspace:*",

--- a/apps/wallets/smart-wallet/react/package.json
+++ b/apps/wallets/smart-wallet/react/package.json
@@ -10,18 +10,8 @@
         "test:e2e-ui": "pnpm exec playwright test --ui"
     },
     "browserslist": {
-        "production": [
-            "chrome >= 67",
-            "edge >= 79",
-            "firefox >= 68",
-            "opera >= 54",
-            "safari >= 14"
-        ],
-        "development": [
-            "last 1 chrome version",
-            "last 1 firefox version",
-            "last 1 safari version"
-        ]
+        "production": ["chrome >= 67", "edge >= 79", "firefox >= 68", "opera >= 54", "safari >= 14"],
+        "development": ["last 1 chrome version", "last 1 firefox version", "last 1 safari version"]
     },
     "dependencies": {
         "@crossmint/client-sdk-smart-wallet": "workspace:*",

--- a/packages/client/auth-core/package.json
+++ b/packages/client/auth-core/package.json
@@ -23,11 +23,7 @@
             "require": "./dist/client/index.cjs"
         }
     },
-    "files": [
-        "dist",
-        "src",
-        "LICENSE"
-    ],
+    "files": ["dist", "src", "LICENSE"],
     "scripts": {
         "build": "tsup server/index.ts client/index.ts --clean --format esm,cjs --outDir ./dist --minify --dts --sourcemap",
         "dev": "tsup server/index.ts client/index.ts --clean --format esm,cjs --outDir ./dist --dts --sourcemap --watch",

--- a/packages/client/ui/react-ui/package.json
+++ b/packages/client/ui/react-ui/package.json
@@ -13,11 +13,7 @@
     "main": "./dist/index.cjs",
     "module": "./dist/index.js",
     "types": "./dist/index.d.ts",
-    "files": [
-        "dist",
-        "src",
-        "LICENSE"
-    ],
+    "files": ["dist", "src", "LICENSE"],
     "scripts": {
         "build": "tsup src/index.ts --clean --external react,react-dom --format esm,cjs --outDir ./dist --minify --dts --sourcemap",
         "dev": "tsup src/index.ts --clean --external react,react-dom --format esm,cjs --outDir ./dist --dts --sourcemap --watch",

--- a/packages/client/ui/react-ui/src/components/auth/AuthModal.tsx
+++ b/packages/client/ui/react-ui/src/components/auth/AuthModal.tsx
@@ -1,5 +1,5 @@
 import { Dialog, Transition } from "@headlessui/react";
-import { type CSSProperties, Fragment, useCallback, useRef } from "react";
+import { type CSSProperties, Fragment, useRef } from "react";
 import { z } from "zod";
 
 import { IFrameWindow } from "@crossmint/client-sdk-window";
@@ -39,7 +39,7 @@ export default function AuthModal({ setModalOpen, apiKey, fetchAuthMaterial, bas
     const iframeRef = useRef<HTMLIFrameElement | null>(null);
     const iframeWindowRef = useRef<IFrameWindow<IncomingModalIframeEventsType, Record<string, never>> | null>(null);
 
-    const setupIframeWindowListener = useCallback(() => {
+    const setupIframeWindowListener = () => {
         if (iframeWindowRef.current == null) {
             return;
         }
@@ -49,9 +49,9 @@ export default function AuthModal({ setModalOpen, apiKey, fetchAuthMaterial, bas
             iframeWindowRef.current?.off("authMaterialFromAuthFrame");
             setModalOpen(false);
         });
-    }, [fetchAuthMaterial, setModalOpen]);
+    };
 
-    const handleIframeLoaded = useCallback(async () => {
+    const handleIframeLoaded = async () => {
         if (iframeRef.current == null) {
             // The iframe should be load, here we should log on DD if possible
             console.error("Something wrong happened, please try again");
@@ -67,7 +67,7 @@ export default function AuthModal({ setModalOpen, apiKey, fetchAuthMaterial, bas
             iframeWindowRef.current = initIframe;
             setupIframeWindowListener();
         }
-    }, [setupIframeWindowListener]);
+    };
 
     return (
         <Transition.Root show as={Fragment}>

--- a/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.tsx
@@ -1,5 +1,5 @@
 import { REFRESH_TOKEN_PREFIX, SESSION_PREFIX, deleteCookie, getCookie, setCookie } from "@/utils/authCookies";
-import { type ReactNode, createContext, useCallback, useEffect, useState } from "react";
+import { type ReactNode, createContext, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 
 import { CrossmintAuthService } from "@crossmint/client-sdk-auth-core/client";
@@ -47,15 +47,12 @@ export function CrossmintAuthProvider({ embeddedWallets, children, appearance }:
     const crossmintBaseUrl = validateApiKeyAndGetCrossmintBaseUrl(crossmint.apiKey);
     const [modalOpen, setModalOpen] = useState(false);
 
-    const setAuthMaterial = useCallback(
-        (authMaterial: AuthMaterial) => {
-            setCookie(SESSION_PREFIX, authMaterial.jwtToken);
-            setCookie(REFRESH_TOKEN_PREFIX, authMaterial.refreshToken.secret, authMaterial.refreshToken.expiresAt);
-            setJwt(authMaterial.jwtToken);
-            setRefreshToken(authMaterial.refreshToken.secret);
-        },
-        [setJwt, setRefreshToken]
-    );
+    const setAuthMaterial = (authMaterial: AuthMaterial) => {
+        setCookie(SESSION_PREFIX, authMaterial.jwtToken);
+        setCookie(REFRESH_TOKEN_PREFIX, authMaterial.refreshToken.secret, authMaterial.refreshToken.expiresAt);
+        setJwt(authMaterial.jwtToken);
+        setRefreshToken(authMaterial.refreshToken.secret);
+    };
 
     const logout = () => {
         deleteCookie(SESSION_PREFIX);
@@ -100,14 +97,11 @@ export function CrossmintAuthProvider({ embeddedWallets, children, appearance }:
         return "logged-out";
     };
 
-    const fetchAuthMaterial = useCallback(
-        async (refreshToken: string): Promise<AuthMaterial> => {
-            const authMaterial = await crossmintAuthService.refreshAuthMaterial(refreshToken);
-            setAuthMaterial(authMaterial);
-            return authMaterial;
-        },
-        [crossmintAuthService, setAuthMaterial]
-    );
+    const fetchAuthMaterial = async (refreshToken: string): Promise<AuthMaterial> => {
+        const authMaterial = await crossmintAuthService.refreshAuthMaterial(refreshToken);
+        setAuthMaterial(authMaterial);
+        return authMaterial;
+    };
 
     return (
         <AuthContext.Provider

--- a/packages/client/wallets/smart-wallet/package.json
+++ b/packages/client/wallets/smart-wallet/package.json
@@ -13,11 +13,7 @@
     "main": "./dist/index.cjs",
     "module": "./dist/index.js",
     "types": "./dist/index.d.ts",
-    "files": [
-        "dist",
-        "src",
-        "LICENSE"
-    ],
+    "files": ["dist", "src", "LICENSE"],
     "scripts": {
         "build": "tsup src/index.ts --clean --format esm,cjs --outDir ./dist --minify --dts --sourcemap",
         "build-no-minify": "tsup src/index.ts --clean --format esm,cjs --outDir ./dist --dts --sourcemap",


### PR DESCRIPTION
## Description

Due to how `iframeWindow` was being created and the fact that `React.StrictMode` runs all hooks twice, we were listening to the post message events on the iframe twice, and therefore calling `/refresh` twice with the same refresh secret which would sometime throw an error

## Test plan

Running the demo app in dev mode (`React.StrictMode = true`) and authenticating via email will now make a single call to `/refresh`

## Package updates

`@crossmint/client-sdk-react-ui`: patch