### PR TITLE
New packages for Auth SDK

### DIFF
--- a/.changeset/empty-bees-occur.md
+++ b/.changeset/empty-bees-occur.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/server-sdk-auth": minor
+---
+
+Initial release

--- a/.changeset/good-months-hear.md
+++ b/.changeset/good-months-hear.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-auth": minor
+---
+
+Initial release

--- a/.changeset/serious-camels-hang.md
+++ b/.changeset/serious-camels-hang.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+---
+
+Moves from auth core to new auth sdk

--- a/.changeset/stale-eyes-think.md
+++ b/.changeset/stale-eyes-think.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+---
+
+Avoids re-renders with refresh token

--- a/.changeset/strange-knives-relax.md
+++ b/.changeset/strange-knives-relax.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-auth-core": patch
+---
+
+Deprecated in favour of @crossmint/common-sdk-auth

--- a/.changeset/stupid-socks-scream.md
+++ b/.changeset/stupid-socks-scream.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/common-sdk-auth": minor
+---
+
+Initial release

--- a/apps/payments/create-react-app/package.json
+++ b/apps/payments/create-react-app/package.json
@@ -5,37 +5,18 @@
     "repository": "https://github.com/Crossmint/crossmint-sdk",
     "license": "Apache-2.0",
     "author": "Paella Labs Inc",
-    "files": [
-        "public",
-        "src",
-        ".env",
-        "LICENSE",
-        "package.json",
-        "README.md",
-        "tsconfig.json",
-        "yarn.lock"
-    ],
+    "files": ["public", "src", ".env", "LICENSE", "package.json", "README.md", "tsconfig.json", "yarn.lock"],
     "scripts": {
         "build": "react-scripts build",
         "eject": "react-scripts eject",
         "start": "react-scripts start"
     },
     "browserslist": {
-        "production": [
-            ">0.2%",
-            "not dead",
-            "not op_mini all"
-        ],
-        "development": [
-            "last 1 chrome version",
-            "last 1 firefox version",
-            "last 1 safari version"
-        ]
+        "production": [">0.2%", "not dead", "not op_mini all"],
+        "development": ["last 1 chrome version", "last 1 firefox version", "last 1 safari version"]
     },
     "eslintConfig": {
-        "extends": [
-            "react-app"
-        ]
+        "extends": ["react-app"]
     },
     "dependencies": {
         "@crossmint/client-sdk-react-ui": "workspace:*",

--- a/apps/wallets/smart-wallet/react/package.json
+++ b/apps/wallets/smart-wallet/react/package.json
@@ -10,18 +10,8 @@
         "test:e2e-ui": "pnpm exec playwright test --ui"
     },
     "browserslist": {
-        "production": [
-            "chrome >= 67",
-            "edge >= 79",
-            "firefox >= 68",
-            "opera >= 54",
-            "safari >= 14"
-        ],
-        "development": [
-            "last 1 chrome version",
-            "last 1 firefox version",
-            "last 1 safari version"
-        ]
+        "production": ["chrome >= 67", "edge >= 79", "firefox >= 68", "opera >= 54", "safari >= 14"],
+        "development": ["last 1 chrome version", "last 1 firefox version", "last 1 safari version"]
     },
     "dependencies": {
         "@crossmint/client-sdk-smart-wallet": "workspace:*",

--- a/crossmint-sdk.code-workspace
+++ b/crossmint-sdk.code-workspace
@@ -21,8 +21,16 @@
             "path": "packages/common/base"
         },
         {
+            "name": "🧬 @crossmint/common-sdk-auth",
+            "path": "packages/common/auth"
+        },
+        {
             "name": "🧬 @crossmint/client-sdk-base",
             "path": "packages/client/base"
+        },
+        {
+            "name": "⚛️ @crossmint/client-sdk-auth",
+            "path": "packages/client/auth"
         },
         {
             "name": "⚛️ @crossmint/client-sdk-react-ui",

--- a/packages/client/auth-core/README.md
+++ b/packages/client/auth-core/README.md
@@ -1,0 +1,3 @@
+# @crossmint/client-sdk-auth-core
+
+DEPRECATED: This package is deprecated and has been replaced by @crossmint/common-sdk-auth, @crossmint/client-sdk-auth and @crossmint/server-sdk-auth.

--- a/packages/client/auth-core/package.json
+++ b/packages/client/auth-core/package.json
@@ -23,11 +23,7 @@
             "require": "./dist/client/index.cjs"
         }
     },
-    "files": [
-        "dist",
-        "src",
-        "LICENSE"
-    ],
+    "files": ["dist", "src", "LICENSE"],
     "scripts": {
         "build": "tsup server/index.ts client/index.ts --clean --format esm,cjs --outDir ./dist --minify --dts --sourcemap",
         "dev": "tsup server/index.ts client/index.ts --clean --format esm,cjs --outDir ./dist --dts --sourcemap --watch",

--- a/packages/client/auth/README.md
+++ b/packages/client/auth/README.md
@@ -1,0 +1,2 @@
+# @crossmint/client-sdk-auth
+

--- a/packages/client/auth/package.json
+++ b/packages/client/auth/package.json
@@ -16,8 +16,7 @@
     "files": ["dist", "src", "LICENSE"],
     "scripts": {
         "build": "tsup src/index.ts --clean --format esm,cjs --outDir ./dist --minify --dts --sourcemap",
-        "dev": "tsup src/index.ts --clean --format esm,cjs --outDir ./dist --dts --sourcemap --watch",
-        "test": "vitest run"
+        "dev": "tsup src/index.ts --clean --format esm,cjs --outDir ./dist --dts --sourcemap --watch"
     },
     "dependencies": {
         "@crossmint/common-sdk-auth": "workspace:*",

--- a/packages/client/auth/package.json
+++ b/packages/client/auth/package.json
@@ -1,0 +1,26 @@
+{
+    "name": "@crossmint/client-sdk-auth",
+    "version": "0.1.0",
+    "repository": "https://github.com/Crossmint/crossmint-sdk",
+    "license": "Apache-2.0",
+    "author": "Paella Labs Inc",
+    "sideEffects": false,
+    "type": "module",
+    "exports": {
+        "import": "./dist/index.js",
+        "require": "./dist/index.cjs"
+    },
+    "main": "./dist/index.cjs",
+    "module": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "files": ["dist", "src", "LICENSE"],
+    "scripts": {
+        "build": "tsup src/index.ts --clean --format esm,cjs --outDir ./dist --minify --dts --sourcemap",
+        "dev": "tsup src/index.ts --clean --format esm,cjs --outDir ./dist --dts --sourcemap --watch",
+        "test": "vitest run"
+    },
+    "dependencies": {
+        "@crossmint/common-sdk-auth": "workspace:*",
+        "jwt-decode": "4.0.0"
+    }
+}

--- a/packages/client/auth/src/index.ts
+++ b/packages/client/auth/src/index.ts
@@ -1,0 +1,2 @@
+export { CrossmintAuthService } from "@crossmint/common-sdk-auth";
+export * from "./utils";

--- a/packages/client/auth/src/utils/index.ts
+++ b/packages/client/auth/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./jwt";

--- a/packages/client/auth/src/utils/jwt.ts
+++ b/packages/client/auth/src/utils/jwt.ts
@@ -1,0 +1,6 @@
+import { jwtDecode } from "jwt-decode";
+
+export function getJWTExpiration(token: string) {
+    const decoded = jwtDecode(token);
+    return decoded.exp;
+}

--- a/packages/client/auth/tsconfig.json
+++ b/packages/client/auth/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../../tsconfig.base.json",
+    "compilerOptions": {
+        "rootDir": "src",
+        "baseUrl": ".",
+        "paths": {
+            "@/*": ["src/*"]
+        }
+    },
+    "include": ["src/**/*"]
+}

--- a/packages/client/ui/react-ui/package.json
+++ b/packages/client/ui/react-ui/package.json
@@ -13,11 +13,7 @@
     "main": "./dist/index.cjs",
     "module": "./dist/index.js",
     "types": "./dist/index.d.ts",
-    "files": [
-        "dist",
-        "src",
-        "LICENSE"
-    ],
+    "files": ["dist", "src", "LICENSE"],
     "scripts": {
         "build": "tsup src/index.ts --clean --external react,react-dom --format esm,cjs --outDir ./dist --minify --dts --sourcemap",
         "dev": "tsup src/index.ts --clean --external react,react-dom --format esm,cjs --outDir ./dist --dts --sourcemap --watch",

--- a/packages/client/ui/react-ui/package.json
+++ b/packages/client/ui/react-ui/package.json
@@ -20,7 +20,7 @@
         "test": "vitest run"
     },
     "dependencies": {
-        "@crossmint/client-sdk-auth-core": "workspace:*",
+        "@crossmint/client-sdk-auth": "workspace:*",
         "@crossmint/client-sdk-base": "workspace:*",
         "@crossmint/client-sdk-smart-wallet": "workspace:*",
         "@crossmint/client-sdk-window": "workspace:*",

--- a/packages/client/ui/react-ui/src/components/auth/AuthModal.tsx
+++ b/packages/client/ui/react-ui/src/components/auth/AuthModal.tsx
@@ -1,5 +1,5 @@
 import { Dialog, Transition } from "@headlessui/react";
-import { type CSSProperties, Fragment, useCallback, useRef } from "react";
+import { type CSSProperties, Fragment, useRef } from "react";
 import { z } from "zod";
 
 import { IFrameWindow } from "@crossmint/client-sdk-window";
@@ -39,7 +39,7 @@ export default function AuthModal({ setModalOpen, apiKey, fetchAuthMaterial, bas
     const iframeRef = useRef<HTMLIFrameElement | null>(null);
     const iframeWindowRef = useRef<IFrameWindow<IncomingModalIframeEventsType, Record<string, never>> | null>(null);
 
-    const setupIframeWindowListener = useCallback(() => {
+    const setupIframeWindowListener = () => {
         if (iframeWindowRef.current == null) {
             return;
         }
@@ -49,9 +49,9 @@ export default function AuthModal({ setModalOpen, apiKey, fetchAuthMaterial, bas
             iframeWindowRef.current?.off("authMaterialFromAuthFrame");
             setModalOpen(false);
         });
-    }, [fetchAuthMaterial, setModalOpen]);
+    };
 
-    const handleIframeLoaded = useCallback(async () => {
+    const handleIframeLoaded = async () => {
         if (iframeRef.current == null) {
             // The iframe should be load, here we should log on DD if possible
             console.error("Something wrong happened, please try again");
@@ -67,7 +67,7 @@ export default function AuthModal({ setModalOpen, apiKey, fetchAuthMaterial, bas
             iframeWindowRef.current = initIframe;
             setupIframeWindowListener();
         }
-    }, [setupIframeWindowListener]);
+    };
 
     return (
         <Transition.Root show as={Fragment}>

--- a/packages/client/ui/react-ui/src/hooks/useRefreshToken.test.ts
+++ b/packages/client/ui/react-ui/src/hooks/useRefreshToken.test.ts
@@ -1,13 +1,13 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { type CrossmintAuthService, getJWTExpiration } from "@crossmint/client-sdk-auth-core/client";
+import { type CrossmintAuthService, getJWTExpiration } from "@crossmint/client-sdk-auth";
 import { queueTask } from "@crossmint/client-sdk-base";
 
 import * as authCookies from "../utils/authCookies";
 import { type AuthMaterial, useRefreshToken } from "./useRefreshToken";
 
-vi.mock("@crossmint/client-sdk-auth-core", () => ({
+vi.mock("@crossmint/client-sdk-auth", () => ({
     CrossmintAuthService: vi.fn(),
     getJWTExpiration: vi.fn(),
 }));

--- a/packages/client/ui/react-ui/src/hooks/useRefreshToken.ts
+++ b/packages/client/ui/react-ui/src/hooks/useRefreshToken.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef } from "react";
 
-import type { CrossmintAuthService } from "@crossmint/client-sdk-auth-core/client";
-import { getJWTExpiration } from "@crossmint/client-sdk-auth-core/client";
+import type { CrossmintAuthService } from "@crossmint/client-sdk-auth";
+import { getJWTExpiration } from "@crossmint/client-sdk-auth";
 import { queueTask, type CancellableTask } from "@crossmint/client-sdk-base";
 
 import { REFRESH_TOKEN_PREFIX, getCookie } from "../utils/authCookies";

--- a/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.test.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.test.tsx
@@ -4,7 +4,7 @@ import { type ReactNode, act } from "react";
 import { beforeEach, describe, expect, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import { CrossmintAuthService, getJWTExpiration } from "@crossmint/client-sdk-auth-core/client";
+import { CrossmintAuthService, getJWTExpiration } from "@crossmint/client-sdk-auth";
 import { type EVMSmartWallet, SmartWalletSDK } from "@crossmint/client-sdk-smart-wallet";
 import { createCrossmint } from "@crossmint/common-sdk-base";
 
@@ -32,8 +32,8 @@ vi.mock("@crossmint/common-sdk-base", async () => {
     };
 });
 
-vi.mock("@crossmint/client-sdk-auth-core/client", async () => {
-    const actual = await vi.importActual("@crossmint/client-sdk-auth-core/client");
+vi.mock("@crossmint/client-sdk-auth", async () => {
+    const actual = await vi.importActual("@crossmint/client-sdk-auth");
     return {
         ...actual,
         getJWTExpiration: vi.fn(),

--- a/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.tsx
@@ -2,7 +2,7 @@ import { REFRESH_TOKEN_PREFIX, SESSION_PREFIX, deleteCookie, getCookie, setCooki
 import { type ReactNode, createContext, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 
-import { CrossmintAuthService } from "@crossmint/client-sdk-auth-core/client";
+import { CrossmintAuthService } from "@crossmint/client-sdk-auth";
 import type { EVMSmartWalletChain } from "@crossmint/client-sdk-smart-wallet";
 import { type UIConfig, validateApiKeyAndGetCrossmintBaseUrl } from "@crossmint/common-sdk-base";
 

--- a/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.tsx
@@ -1,5 +1,5 @@
 import { REFRESH_TOKEN_PREFIX, SESSION_PREFIX, deleteCookie, getCookie, setCookie } from "@/utils/authCookies";
-import { type ReactNode, createContext, useCallback, useEffect, useState } from "react";
+import { type ReactNode, createContext, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 
 import { CrossmintAuthService } from "@crossmint/client-sdk-auth-core/client";
@@ -47,15 +47,12 @@ export function CrossmintAuthProvider({ embeddedWallets, children, appearance }:
     const crossmintBaseUrl = validateApiKeyAndGetCrossmintBaseUrl(crossmint.apiKey);
     const [modalOpen, setModalOpen] = useState(false);
 
-    const setAuthMaterial = useCallback(
-        (authMaterial: AuthMaterial) => {
-            setCookie(SESSION_PREFIX, authMaterial.jwtToken);
-            setCookie(REFRESH_TOKEN_PREFIX, authMaterial.refreshToken.secret, authMaterial.refreshToken.expiresAt);
-            setJwt(authMaterial.jwtToken);
-            setRefreshToken(authMaterial.refreshToken.secret);
-        },
-        [setJwt, setRefreshToken]
-    );
+    const setAuthMaterial = (authMaterial: AuthMaterial) => {
+        setCookie(SESSION_PREFIX, authMaterial.jwtToken);
+        setCookie(REFRESH_TOKEN_PREFIX, authMaterial.refreshToken.secret, authMaterial.refreshToken.expiresAt);
+        setJwt(authMaterial.jwtToken);
+        setRefreshToken(authMaterial.refreshToken.secret);
+    };
 
     const logout = () => {
         deleteCookie(SESSION_PREFIX);
@@ -100,14 +97,11 @@ export function CrossmintAuthProvider({ embeddedWallets, children, appearance }:
         return "logged-out";
     };
 
-    const fetchAuthMaterial = useCallback(
-        async (refreshToken: string): Promise<AuthMaterial> => {
-            const authMaterial = await crossmintAuthService.refreshAuthMaterial(refreshToken);
-            setAuthMaterial(authMaterial);
-            return authMaterial;
-        },
-        [crossmintAuthService, setAuthMaterial]
-    );
+    const fetchAuthMaterial = async (refreshToken: string): Promise<AuthMaterial> => {
+        const authMaterial = await crossmintAuthService.refreshAuthMaterial(refreshToken);
+        setAuthMaterial(authMaterial);
+        return authMaterial;
+    };
 
     return (
         <AuthContext.Provider

--- a/packages/client/wallets/smart-wallet/package.json
+++ b/packages/client/wallets/smart-wallet/package.json
@@ -13,11 +13,7 @@
     "main": "./dist/index.cjs",
     "module": "./dist/index.js",
     "types": "./dist/index.d.ts",
-    "files": [
-        "dist",
-        "src",
-        "LICENSE"
-    ],
+    "files": ["dist", "src", "LICENSE"],
     "scripts": {
         "build": "tsup src/index.ts --clean --format esm,cjs --outDir ./dist --minify --dts --sourcemap",
         "build-no-minify": "tsup src/index.ts --clean --format esm,cjs --outDir ./dist --dts --sourcemap",

--- a/packages/common/auth/README.md
+++ b/packages/common/auth/README.md
@@ -1,0 +1,2 @@
+# @crossmint/common-sdk-auth
+

--- a/packages/common/auth/package.json
+++ b/packages/common/auth/package.json
@@ -16,8 +16,7 @@
     "files": ["dist", "src", "LICENSE"],
     "scripts": {
         "build": "tsup src/index.ts --clean --format esm,cjs --outDir ./dist --minify --dts --sourcemap",
-        "dev": "tsup src/index.ts --clean --format esm,cjs --outDir ./dist --dts --sourcemap --watch",
-        "test": "vitest run"
+        "dev": "tsup src/index.ts --clean --format esm,cjs --outDir ./dist --dts --sourcemap --watch"
     },
     "dependencies": {
         "@crossmint/client-sdk-base": "workspace:*"

--- a/packages/common/auth/package.json
+++ b/packages/common/auth/package.json
@@ -1,0 +1,25 @@
+{
+    "name": "@crossmint/common-sdk-auth",
+    "version": "0.1.0",
+    "repository": "https://github.com/Crossmint/crossmint-sdk",
+    "license": "Apache-2.0",
+    "author": "Paella Labs Inc",
+    "sideEffects": false,
+    "type": "module",
+    "main": "./dist/index.cjs",
+    "module": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+        "import": "./dist/index.js",
+        "require": "./dist/index.cjs"
+    },
+    "files": ["dist", "src", "LICENSE"],
+    "scripts": {
+        "build": "tsup src/index.ts --clean --format esm,cjs --outDir ./dist --minify --dts --sourcemap",
+        "dev": "tsup src/index.ts --clean --format esm,cjs --outDir ./dist --dts --sourcemap --watch",
+        "test": "vitest run"
+    },
+    "dependencies": {
+        "@crossmint/client-sdk-base": "workspace:*"
+    }
+}

--- a/packages/common/auth/src/index.ts
+++ b/packages/common/auth/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./services";
+export * from "./utils";

--- a/packages/common/auth/src/services/CrossmintAuthService.ts
+++ b/packages/common/auth/src/services/CrossmintAuthService.ts
@@ -1,0 +1,25 @@
+import { APIErrorService, BaseCrossmintService } from "@crossmint/client-sdk-base";
+
+import { authLogger } from "./logger";
+
+export class CrossmintAuthService extends BaseCrossmintService {
+    protected apiErrorService = new APIErrorService<never>({});
+    protected logger = authLogger;
+
+    public getJWKSUri() {
+        return `${this.crossmintBaseUrl}/.well-known/jwks.json`;
+    }
+
+    async refreshAuthMaterial(refreshToken: string) {
+        const result = await this.fetchCrossmintAPI(
+            "2024-09-26/session/sdk/auth/refresh",
+            { method: "POST", body: JSON.stringify({ refresh: refreshToken }) },
+            "Error fetching new refresh and access tokans."
+        );
+
+        return {
+            jwtToken: result.jwt,
+            refreshToken: result.refresh,
+        };
+    }
+}

--- a/packages/common/auth/src/services/index.ts
+++ b/packages/common/auth/src/services/index.ts
@@ -1,0 +1,2 @@
+export * from "./CrossmintAuthService";
+export * from "./logger";

--- a/packages/common/auth/src/services/logger.ts
+++ b/packages/common/auth/src/services/logger.ts
@@ -1,0 +1,5 @@
+import { SDKLogger } from "@crossmint/client-sdk-base";
+
+import { AUTH_SERVICE } from "../utils/constants";
+
+export const authLogger = new SDKLogger(AUTH_SERVICE);

--- a/packages/common/auth/src/utils/constants.ts
+++ b/packages/common/auth/src/utils/constants.ts
@@ -1,0 +1,1 @@
+export const AUTH_SERVICE = "AUTH_SDK";

--- a/packages/common/auth/src/utils/index.ts
+++ b/packages/common/auth/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./constants";

--- a/packages/common/auth/tsconfig.json
+++ b/packages/common/auth/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../../tsconfig.base.json",
+    "compilerOptions": {
+        "rootDir": "src",
+        "baseUrl": ".",
+        "paths": {
+            "@/*": ["src/*"]
+        }
+    },
+    "include": ["src/**/*"]
+}

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -1,3 +1,1 @@
 # @crossmint/server-sdk
-
-TODO

--- a/packages/server/auth/README.md
+++ b/packages/server/auth/README.md
@@ -1,0 +1,3 @@
+# @crossmint/client-sdk-auth-core
+
+DEPRECATED: This package is deprecated and has been replaced by @crossmint/common-sdk-auth, @crossmint/client-sdk-auth and @crossmint/server-sdk-auth.

--- a/packages/server/auth/package.json
+++ b/packages/server/auth/package.json
@@ -16,8 +16,7 @@
     "files": ["dist", "src", "LICENSE"],
     "scripts": {
         "build": "tsup src/index.ts --clean --format esm,cjs --outDir ./dist --minify --dts --sourcemap",
-        "dev": "tsup src/index.ts --clean --format esm,cjs --outDir ./dist --dts --sourcemap --watch",
-        "test": "vitest run"
+        "dev": "tsup src/index.ts --clean --format esm,cjs --outDir ./dist --dts --sourcemap --watch"
     },
     "dependencies": {
         "@crossmint/common-sdk-auth": "workspace:*",

--- a/packages/server/auth/package.json
+++ b/packages/server/auth/package.json
@@ -1,0 +1,30 @@
+{
+    "name": "@crossmint/server-sdk-auth",
+    "version": "0.1.0",
+    "repository": "https://github.com/Crossmint/crossmint-sdk",
+    "license": "Apache-2.0",
+    "author": "Paella Labs Inc",
+    "sideEffects": false,
+    "type": "module",
+    "exports": {
+        "import": "./dist/index.js",
+        "require": "./dist/index.cjs"
+    },
+    "main": "./dist/index.cjs",
+    "module": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "files": ["dist", "src", "LICENSE"],
+    "scripts": {
+        "build": "tsup src/index.ts --clean --format esm,cjs --outDir ./dist --minify --dts --sourcemap",
+        "dev": "tsup src/index.ts --clean --format esm,cjs --outDir ./dist --dts --sourcemap --watch",
+        "test": "vitest run"
+    },
+    "dependencies": {
+        "@crossmint/common-sdk-auth": "workspace:*",
+        "jsonwebtoken": "9.0.2",
+        "jwks-rsa": "3.1.0"
+    },
+    "devDependencies": {
+        "@types/jsonwebtoken": "9.0.6"
+    }
+}

--- a/packages/server/auth/src/index.ts
+++ b/packages/server/auth/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./utils";

--- a/packages/server/auth/src/utils/index.ts
+++ b/packages/server/auth/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./jwt";

--- a/packages/server/auth/src/utils/jwt.ts
+++ b/packages/server/auth/src/utils/jwt.ts
@@ -7,7 +7,8 @@ export async function verifyCrossmintSessionToken(apiKey: string, token: string)
     const crossmintService = new CrossmintAuthService(apiKey);
     try {
         return await verifyJWTWithPublicKey(crossmintService, token);
-    } catch (_) {
+    } catch (error) {
+        console.log("Error verifying JWT", error);
         throw new Error("Invalid token");
     }
 }

--- a/packages/server/auth/src/utils/jwt.ts
+++ b/packages/server/auth/src/utils/jwt.ts
@@ -1,0 +1,44 @@
+import { CrossmintAuthService } from "@crossmint/common-sdk-auth";
+import { JsonWebTokenError, TokenExpiredError, verify } from "jsonwebtoken";
+
+import { getPublicKey } from "./tokenAuth/publicKey";
+
+export async function verifyCrossmintSessionToken(apiKey: string, token: string) {
+    const crossmintService = new CrossmintAuthService(apiKey);
+    try {
+        return await verifyJWTWithPublicKey(crossmintService, token);
+    } catch (_) {
+        throw new Error("Invalid token");
+    }
+}
+
+function verifyJWT(signingKey: string, token: string) {
+    try {
+        const verifiedToken = verify(token, signingKey);
+
+        if (verifiedToken == null || typeof verifiedToken === "string") {
+            throw new Error("Invalid token");
+        }
+        return verifiedToken;
+    } catch (err: unknown) {
+        if (err != null && err instanceof TokenExpiredError) {
+            throw new Error(`JWT provided expired at timestamp ${err.expiredAt.toISOString()}`);
+        }
+
+        if (
+            err != null &&
+            err instanceof JsonWebTokenError &&
+            (err.message.includes("invalid signature") || err.message.includes("invalid algorithm"))
+        ) {
+            throw new Error(err.message);
+        }
+
+        throw new Error("Invalid token");
+    }
+}
+
+async function verifyJWTWithPublicKey(crossmintService: CrossmintAuthService, token: string) {
+    const publicKey = await getPublicKey(token, crossmintService.getJWKSUri());
+
+    return verifyJWT(publicKey, token);
+}

--- a/packages/server/auth/src/utils/tokenAuth/publicKey.ts
+++ b/packages/server/auth/src/utils/tokenAuth/publicKey.ts
@@ -1,0 +1,28 @@
+import { decode } from "jsonwebtoken";
+import { JwksClient } from "jwks-rsa";
+
+export async function getPublicKey(token: string, jwksUri: string) {
+    const decoded = decode(token, { complete: true });
+    if (decoded?.header == null) {
+        throw new Error("Invalid Token: Header Formatted Incorrectly");
+    }
+
+    const signingKey = await getSigningKey(jwksUri, decoded.header.kid);
+    const publicKey = signingKey.getPublicKey();
+
+    return publicKey;
+}
+
+async function getSigningKey(jwksUri: string, kid?: string) {
+    const client = new JwksClient({
+        jwksUri,
+        cache: true,
+    });
+
+    try {
+        const signingKey = await client.getSigningKey(kid);
+        return signingKey;
+    } catch (error) {
+        throw new Error("Unable to retrieve signing key");
+    }
+}

--- a/packages/server/auth/tsconfig.json
+++ b/packages/server/auth/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "extends": "../../../tsconfig.base.json",
+    "compilerOptions": {
+        "rootDir": "src",
+        "baseUrl": ".",
+        "paths": {
+            "@/*": ["src/*"]
+        },
+        "module": "commonjs"
+    },
+    "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -386,6 +386,15 @@ importers:
         specifier: ^0.11.0
         version: 0.11.3
 
+  packages/client/auth:
+    dependencies:
+      '@crossmint/common-sdk-auth':
+        specifier: workspace:*
+        version: link:../../common/auth
+      jwt-decode:
+        specifier: 4.0.0
+        version: 4.0.0
+
   packages/client/auth-core:
     dependencies:
       '@crossmint/client-sdk-base':
@@ -432,9 +441,9 @@ importers:
 
   packages/client/ui/react-ui:
     dependencies:
-      '@crossmint/client-sdk-auth-core':
+      '@crossmint/client-sdk-auth':
         specifier: workspace:*
-        version: link:../../auth-core
+        version: link:../../auth
       '@crossmint/client-sdk-base':
         specifier: workspace:*
         version: link:../../base
@@ -754,6 +763,12 @@ importers:
         specifier: 3.22.4
         version: 3.22.4
 
+  packages/common/auth:
+    dependencies:
+      '@crossmint/client-sdk-base':
+        specifier: workspace:*
+        version: link:../../client/base
+
   packages/common/base:
     dependencies:
       bs58:
@@ -766,6 +781,22 @@ importers:
       '@types/bs58':
         specifier: ^4.0.4
         version: 4.0.4
+
+  packages/server/auth:
+    dependencies:
+      '@crossmint/common-sdk-auth':
+        specifier: workspace:*
+        version: link:../../common/auth
+      jsonwebtoken:
+        specifier: 9.0.2
+        version: 9.0.2
+      jwks-rsa:
+        specifier: 3.1.0
+        version: 3.1.0
+    devDependencies:
+      '@types/jsonwebtoken':
+        specifier: 9.0.6
+        version: 9.0.6
 
 packages:
 


### PR DESCRIPTION
## Description

Implemented new package structure for [Auth SDK](https://docs.google.com/document/d/1HXvDK3tM64aSfUB6QUp1Ed59kEA1lxxM59j1B4l6HAI/edit#heading=h.aayn9uu0jxur) that we agreed on.

Closes issues [1](https://linear.app/crossmint/issue/WAL-2956/deprecate-auth-core), [2](https://linear.app/crossmint/issue/WAL-2954/create-crossmintcommon-sdk-auth), [3](https://linear.app/crossmint/issue/WAL-2955/create-crossmintclient-sdk-auth), [4](https://linear.app/crossmint/issue/WAL-2952/create-crossmintserver-sdk-auth)

## Test plan

Used new libraries in `react-ui` and loaded them in the smart wallets demo

## Package updates

`@crossmint/client-sdk-react-ui`: patch
`@crossmint/client-sdk-auth-core`: patch for deprecation
`@crossmint/common-sdk-auth`: initial release
`@crossmint/client-sdk-atuh`: initial release
`@crossmint/server-sdk-auth`: initial release