### PR TITLE
removes server-sdk-auth changeset

### DIFF
--- a/.changeset/empty-bees-occur.md
+++ b/.changeset/empty-bees-occur.md
@@ -1,5 +1,0 @@
----
-"@crossmint/server-sdk-auth": minor
----
-
-Initial release


### PR DESCRIPTION
## Description

We deleted the library before it publishes so don't need the change set.

## Test plan

None

## Package updates

None