### PR TITLE
Changes jwt cookie name to crossmint-jwt

### DIFF
--- a/.changeset/funny-countries-shave.md
+++ b/.changeset/funny-countries-shave.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+---
+
+Changes jwt cookie name

--- a/packages/client/ui/react-ui/src/utils/authCookies.ts
+++ b/packages/client/ui/react-ui/src/utils/authCookies.ts
@@ -1,4 +1,4 @@
-export const SESSION_PREFIX = "crossmint-session";
+export const SESSION_PREFIX = "crossmint-jwt";
 export const REFRESH_TOKEN_PREFIX = "crossmint-refresh-token";
 
 export function getCookie(name: string): string | undefined {


### PR DESCRIPTION
## Description

We decided `crossmint-jwt` is clearer than `crossmint-session` as the refresh token would count as the session. The `server-sdk` will only work with the new name and with versions of `react-ui` that include this change.

This will not log out users as the refresh token doesn't change and it will use that on page load to fetch a new jwt and set the new cookie. But this also doesn't delete the old `crossmint-session` cookie. I think this is okay as we're not in Prod yet and it's only a few projects testing, this way, we avoid having to follow a deprecation process.

## Test plan

Ran smarter wallets demo

## Package updates

`@crossmint/client-sdk-react-ui`: patch