### PR TITLE
Adds entrypoint to react-ui to force loading twind

### DIFF
--- a/.changeset/silent-trains-explode.md
+++ b/.changeset/silent-trains-explode.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+---
+
+Adds entrypoint to make sure twind is instantiated

--- a/packages/client/ui/react-ui/tsup.config.ts
+++ b/packages/client/ui/react-ui/tsup.config.ts
@@ -5,6 +5,7 @@ import { treeShakableConfig } from "../../../../tsup.config.base";
 const config: Options = {
     ...treeShakableConfig,
     external: ["react", "react-dom"],
+    entry: ["src/index.ts"],
 };
 
 export default config;


### PR DESCRIPTION
## Description

Otherwise, the twind instantiation in `index.ts` doesn't occur as we're only importing the specific named imports and it doesn't go through `index.ts`

## Test plan

Loaded the smarter wallet demo and saw that the passkey prompt now shows up

## Package updates

react-ui: patch