### PR TITLE
embedded-v3: send sdk info in iframe

### DIFF
--- a/packages/client/base/src/services/embed/v3/crossmintEmbeddedCheckoutV3Service.ts
+++ b/packages/client/base/src/services/embed/v3/crossmintEmbeddedCheckoutV3Service.ts
@@ -4,7 +4,7 @@ import { embeddedCheckoutV3IncomingEvents, embeddedCheckoutV3OutgoingEvents } fr
 import { IFrameWindow } from "@crossmint/client-sdk-window";
 import type { CrossmintApiClient } from "@crossmint/common-sdk-base";
 
-export type CrossmintEmbeddedCheckoutV3ServiceProps = { 
+export type CrossmintEmbeddedCheckoutV3ServiceProps = {
     apiClient: CrossmintApiClient,
 };
 

--- a/packages/client/base/src/services/embed/v3/crossmintEmbeddedCheckoutV3Service.ts
+++ b/packages/client/base/src/services/embed/v3/crossmintEmbeddedCheckoutV3Service.ts
@@ -6,14 +6,11 @@ import type { CrossmintApiClient } from "@crossmint/common-sdk-base";
 
 export type CrossmintEmbeddedCheckoutV3ServiceProps = { 
     apiClient: CrossmintApiClient,
-    sdkMetadata: {
-        name: string;
-        version: string;
-    }
 };
 
-export function crossmintEmbeddedCheckoutV3Service({ apiClient, sdkMetadata }: CrossmintEmbeddedCheckoutV3ServiceProps) {
+export function crossmintEmbeddedCheckoutV3Service({ apiClient }: CrossmintEmbeddedCheckoutV3ServiceProps) {
     function getIFrameUrl(props: CrossmintEmbeddedCheckoutV3Props) {
+        const sdkMetadata = apiClient["internalConfig"].sdkMetadata;
         const urlWithPath = apiClient.buildUrl("/sdk/2024-03-05/embedded-checkout");
         const queryParams = new URLSearchParams();
 

--- a/packages/client/base/src/services/embed/v3/crossmintEmbeddedCheckoutV3Service.ts
+++ b/packages/client/base/src/services/embed/v3/crossmintEmbeddedCheckoutV3Service.ts
@@ -4,9 +4,15 @@ import { embeddedCheckoutV3IncomingEvents, embeddedCheckoutV3OutgoingEvents } fr
 import { IFrameWindow } from "@crossmint/client-sdk-window";
 import type { CrossmintApiClient } from "@crossmint/common-sdk-base";
 
-export type CrossmintEmbeddedCheckoutV3ServiceProps = { apiClient: CrossmintApiClient };
+export type CrossmintEmbeddedCheckoutV3ServiceProps = { 
+    apiClient: CrossmintApiClient,
+    sdkMetadata: {
+        name: string;
+        version: string;
+    }
+};
 
-export function crossmintEmbeddedCheckoutV3Service({ apiClient }: CrossmintEmbeddedCheckoutV3ServiceProps) {
+export function crossmintEmbeddedCheckoutV3Service({ apiClient, sdkMetadata }: CrossmintEmbeddedCheckoutV3ServiceProps) {
     function getIFrameUrl(props: CrossmintEmbeddedCheckoutV3Props) {
         const urlWithPath = apiClient.buildUrl("/sdk/2024-03-05/embedded-checkout");
         const queryParams = new URLSearchParams();
@@ -34,6 +40,7 @@ export function crossmintEmbeddedCheckoutV3Service({ apiClient }: CrossmintEmbed
         }
 
         queryParams.append("apiKey", apiClient.crossmint.apiKey);
+        queryParams.append("sdkMetadata", JSON.stringify(sdkMetadata));
 
         return `${urlWithPath}?${queryParams.toString()}`;
     }

--- a/packages/client/base/src/services/embed/v3/crossmintEmbeddedCheckoutV3Service.ts
+++ b/packages/client/base/src/services/embed/v3/crossmintEmbeddedCheckoutV3Service.ts
@@ -5,7 +5,7 @@ import { IFrameWindow } from "@crossmint/client-sdk-window";
 import type { CrossmintApiClient } from "@crossmint/common-sdk-base";
 
 export type CrossmintEmbeddedCheckoutV3ServiceProps = {
-    apiClient: CrossmintApiClient,
+    apiClient: CrossmintApiClient;
 };
 
 export function crossmintEmbeddedCheckoutV3Service({ apiClient }: CrossmintEmbeddedCheckoutV3ServiceProps) {

--- a/packages/client/ui/react-ui/src/components/embed/v3/EmbeddedCheckoutV3IFrame.tsx
+++ b/packages/client/ui/react-ui/src/components/embed/v3/EmbeddedCheckoutV3IFrame.tsx
@@ -15,16 +15,15 @@ export function EmbeddedCheckoutV3IFrame(props: CrossmintEmbeddedCheckoutV3Props
     const [height, setHeight] = useState(0);
 
     const { crossmint } = useCrossmint();
-    const sdkMetadata = {
-        name: "@crossmint/client-sdk-react-ui",
-        version: LIB_VERSION,
-    };
     const apiClient = new CrossmintApiClient(crossmint, {
         internalConfig: {
-            sdkMetadata,
+            sdkMetadata: {
+                name: "@crossmint/client-sdk-react-ui",
+                version: LIB_VERSION,
+            },
         },
     });
-    const embedV3Service = crossmintEmbeddedCheckoutV3Service({ apiClient, sdkMetadata });
+    const embedV3Service = crossmintEmbeddedCheckoutV3Service({ apiClient });
 
     const ref = useRef<HTMLIFrameElement>(null);
 

--- a/packages/client/ui/react-ui/src/components/embed/v3/EmbeddedCheckoutV3IFrame.tsx
+++ b/packages/client/ui/react-ui/src/components/embed/v3/EmbeddedCheckoutV3IFrame.tsx
@@ -15,15 +15,16 @@ export function EmbeddedCheckoutV3IFrame(props: CrossmintEmbeddedCheckoutV3Props
     const [height, setHeight] = useState(0);
 
     const { crossmint } = useCrossmint();
+    const sdkMetadata = {
+        name: "@crossmint/client-sdk-react-ui",
+        version: LIB_VERSION,
+    };
     const apiClient = new CrossmintApiClient(crossmint, {
         internalConfig: {
-            sdkMetadata: {
-                name: "@crossmint/client-sdk-react-ui",
-                version: LIB_VERSION,
-            },
+            sdkMetadata,
         },
     });
-    const embedV3Service = crossmintEmbeddedCheckoutV3Service({ apiClient });
+    const embedV3Service = crossmintEmbeddedCheckoutV3Service({ apiClient, sdkMetadata });
 
     const ref = useRef<HTMLIFrameElement>(null);
 


### PR DESCRIPTION
## Description

<!-- Human must describe here why are we doing this change, and roughly what it does -->
<!-- Optional screenshot or video -->
Sending SDK info to the iframe

## Test plan

<!--
  Example:
   * Unit tests which cover functionality X, Y, Z
   * V was tested via UI tests
   * W was tested manually
-->

<img width="953" alt="Screenshot 2024-10-17 at 18 35 18" src="https://github.com/user-attachments/assets/3afcb214-c68d-41e9-b2e6-c1ef39673f31">


## Package updates

<!-- 
  List any package updates and ensure you've added the necessary changesets, running `pnpm change:add` to do so.
-->