### PR TITLE
Window: allow many origins

### DIFF
--- a/.changeset/little-meals-move.md
+++ b/.changeset/little-meals-move.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-window": minor
+---
+
+allow many origins

--- a/packages/client/window/src/handshake/Child.ts
+++ b/packages/client/window/src/handshake/Child.ts
@@ -19,7 +19,7 @@ export class HandshakeChild<IncomingEvents extends EventMap, OutgoingEvents exte
 
     constructor(
         otherWindow: Window,
-        targetOrigin: string,
+        targetOrigin: string | string[],
         options?: EventEmitterWithHandshakeOptions<IncomingEvents, OutgoingEvents>
     ) {
         const mergedIncomingEvents = {

--- a/packages/client/window/src/windows/Child.ts
+++ b/packages/client/window/src/windows/Child.ts
@@ -8,7 +8,7 @@ export class ChildWindow<IncomingEvents extends EventMap, OutgoingEvents extends
 > {
     constructor(
         parentWindow: Window,
-        targetOrigin: string,
+        targetOrigin: string | string[],
         options?: Omit<EventEmitterWithHandshakeOptions<IncomingEvents, OutgoingEvents>, "targetOrigin">
     ) {
         super(parentWindow, targetOrigin, options);


### PR DESCRIPTION
## Description

We need to allow many origins to avoid a security flag explained [here](https://linear.app/crossmint/issue/WAL-3075/security-issue-replace-wildcard-in-postmessage-with-specific-origin)

## Test plan

✅ `*`: Sign in any domain
✅ `whitelistedOrigins`: Sign in a whitelisted origin

❌ `whitelistedOrigins`: Sign in an origin that isn't whitelisted:

https://www.loom.com/share/34f4ed0180e14d8b8fd172b90235a83c

## Package updates

Window