### PR TITLE
Also send api key in header in oauth fetch to support backend change

### DIFF
--- a/.changeset/neat-dots-vanish.md
+++ b/.changeset/neat-dots-vanish.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+---
+
+Send api key in header in oauth fetch

--- a/packages/client/ui/react-ui/src/providers/auth/AuthFormProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/auth/AuthFormProvider.tsx
@@ -95,7 +95,12 @@ async function getOAuthUrl(provider: OAuthProvider, options: { baseUrl: string; 
     try {
         const queryParams = new URLSearchParams({ apiKey: options.apiKey });
         const response = await fetch(
-            `${options.baseUrl}api/2024-09-26/session/sdk/auth/social/${provider}/start?${queryParams}`
+            `${options.baseUrl}api/2024-09-26/session/sdk/auth/social/${provider}/start?${queryParams}`,
+            {
+                headers: {
+                    "x-api-key": options.apiKey,
+                },
+            }
         );
 
         if (!response.ok) {


### PR DESCRIPTION
## Description

With [this PR](https://github.com/Paella-Labs/crossbit-main/pull/15388), we need all Auth requests to send the API key in the header instead of as a query parameter. We were missing this oauth fetch.

## Test plan

Opened smarter wallet and saw in the console the api key is now sent in the header.

## Package updates

react-ui: patch