### PR TITLE
embed: fix weird recipient ts behavior

### DIFF
--- a/.changeset/light-balloons-promise.md
+++ b/.changeset/light-balloons-promise.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-base": patch
+---
+
+embed: fix ts recipient discrimnator

--- a/packages/client/base/src/types/embed/v3/CrossmintEmbeddedCheckoutV3Props.ts
+++ b/packages/client/base/src/types/embed/v3/CrossmintEmbeddedCheckoutV3Props.ts
@@ -12,7 +12,16 @@ export interface CrossmintEmbeddedCheckoutV3Props {
     payment: EmbeddedCheckoutV3Payment;
 }
 
-export type EmbeddedCheckoutV3Recipient = { email: string } | { walletAddress: string };
+export type EmbeddedCheckoutV3Recipient = EmbeddedCheckoutV3EmailRecipient | EmbeddedCheckoutV3WalletAddressRecipient;
+
+export type EmbeddedCheckoutV3EmailRecipient = {
+    email: string;
+    walletAddress?: never;
+};
+export type EmbeddedCheckoutV3WalletAddressRecipient = {
+    walletAddress: string;
+    email?: never;
+};
 
 export type EmbeddedCheckoutV3LineItem = {
     collectionLocator: string;


### PR DESCRIPTION
## Description

this is really strange, havnt seen this before but for some reason the `|` in ts isnt working as expected, and still allowing both email AND walletAddress

this should force it to be only one or the other

## Test plan
before:
![image](https://github.com/user-attachments/assets/7b786863-21c2-4919-9598-5069f6315408)


now:
errors
![image](https://github.com/user-attachments/assets/a8dc63fd-905a-4deb-95ef-c16a1659d4b6)

passes with 1 or the other
![image](https://github.com/user-attachments/assets/1288c3b5-63ec-4e3a-bea1-03365cb5cb89)
![image](https://github.com/user-attachments/assets/9bc6c95a-6c56-4aa2-9145-361123a38e55)
