### PR TITLE
Makes it impossible to call refresh twice in the client

### DIFF
--- a/.changeset/ten-mayflies-unite.md
+++ b/.changeset/ten-mayflies-unite.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-auth": patch
+---
+
+Makes it impossible to call refresh twice

--- a/packages/client/auth/package.json
+++ b/packages/client/auth/package.json
@@ -17,7 +17,7 @@
     "scripts": {
         "build": "tsup",
         "dev": "tsup --watch",
-        "test": "vitest run"
+        "test:vitest": "vitest run"
     },
     "dependencies": {
         "@crossmint/client-sdk-base": "workspace:*",

--- a/packages/client/auth/src/CrossmintAuthClient.test.ts
+++ b/packages/client/auth/src/CrossmintAuthClient.test.ts
@@ -145,6 +145,7 @@ describe("CrossmintAuthClient", () => {
             vi.spyOn(crossmintAuthClient as any, "storeAuthMaterial").mockImplementation(() => {});
             vi.mocked(getJWTExpiration).mockReturnValue(Date.now() / 1000 + 3600); // 1 hour from now
             vi.mocked(queueTask).mockReturnValue({ cancel: vi.fn() } as any);
+            (crossmintAuthClient as any).isRefreshing = false;
         });
 
         it("should refresh auth material and schedule next refresh", async () => {
@@ -166,6 +167,13 @@ describe("CrossmintAuthClient", () => {
             await crossmintAuthClient.handleRefreshAuthMaterial(mockRefreshToken);
 
             expect(crossmintAuthClient["refreshAuthMaterial"]).not.toHaveBeenCalled();
+        });
+
+        it("should not refresh when called twice in a row", async () => {
+            await crossmintAuthClient.handleRefreshAuthMaterial(mockRefreshToken);
+            await crossmintAuthClient.handleRefreshAuthMaterial(mockRefreshToken);
+
+            expect(crossmintAuthClient["refreshAuthMaterial"]).toHaveBeenCalledTimes(1);
         });
 
         it("should call onTokenRefresh callback if provided", async () => {

--- a/packages/client/auth/src/CrossmintAuthClient.test.ts
+++ b/packages/client/auth/src/CrossmintAuthClient.test.ts
@@ -166,9 +166,9 @@ describe("CrossmintAuthClient", () => {
         it("should not refresh when called twice in a row", async () => {
             const promise1 = crossmintAuthClient.handleRefreshAuthMaterial(mockRefreshToken);
             const promise2 = crossmintAuthClient.handleRefreshAuthMaterial(mockRefreshToken);
-            
+
             await Promise.all([promise1, promise2]);
-        
+
             expect(crossmintAuthClient["refreshAuthMaterial"]).toHaveBeenCalledTimes(1);
         });
 

--- a/packages/client/auth/src/CrossmintAuthClient.test.ts
+++ b/packages/client/auth/src/CrossmintAuthClient.test.ts
@@ -53,6 +53,7 @@ describe("CrossmintAuthClient", () => {
             const mockUserData = { id: "user123", email: "user@example.com" };
             mockApiClient.get.mockResolvedValue({
                 json: () => Promise.resolve(mockUserData),
+                ok: true,
             });
 
             const result = await crossmintAuthClient.getUser();
@@ -145,7 +146,7 @@ describe("CrossmintAuthClient", () => {
             vi.spyOn(crossmintAuthClient as any, "storeAuthMaterial").mockImplementation(() => {});
             vi.mocked(getJWTExpiration).mockReturnValue(Date.now() / 1000 + 3600); // 1 hour from now
             vi.mocked(queueTask).mockReturnValue({ cancel: vi.fn() } as any);
-            (crossmintAuthClient as any).isRefreshing = false;
+            (crossmintAuthClient as any).refreshPromise = null;
         });
 
         it("should refresh auth material and schedule next refresh", async () => {
@@ -162,17 +163,12 @@ describe("CrossmintAuthClient", () => {
             expect(queueTask).toHaveBeenCalledWith(expect.any(Function), expect.any(Number));
         });
 
-        it("should not refresh if already refreshing", async () => {
-            (crossmintAuthClient as any).isRefreshing = true;
-            await crossmintAuthClient.handleRefreshAuthMaterial(mockRefreshToken);
-
-            expect(crossmintAuthClient["refreshAuthMaterial"]).not.toHaveBeenCalled();
-        });
-
         it("should not refresh when called twice in a row", async () => {
-            await crossmintAuthClient.handleRefreshAuthMaterial(mockRefreshToken);
-            await crossmintAuthClient.handleRefreshAuthMaterial(mockRefreshToken);
-
+            const promise1 = crossmintAuthClient.handleRefreshAuthMaterial(mockRefreshToken);
+            const promise2 = crossmintAuthClient.handleRefreshAuthMaterial(mockRefreshToken);
+            
+            await Promise.all([promise1, promise2]);
+        
             expect(crossmintAuthClient["refreshAuthMaterial"]).toHaveBeenCalledTimes(1);
         });
 
@@ -257,6 +253,7 @@ describe("CrossmintAuthClient", () => {
             const mockOAuthUrl = "https://oauth.example.com/auth";
             mockApiClient.get.mockResolvedValue({
                 json: () => Promise.resolve({ oauthUrl: mockOAuthUrl }),
+                ok: true,
             });
 
             const result = await crossmintAuthClient.getOAuthUrl(mockProvider);
@@ -275,6 +272,7 @@ describe("CrossmintAuthClient", () => {
             const mockResponse = { success: true };
             mockApiClient.post.mockResolvedValue({
                 json: () => Promise.resolve(mockResponse),
+                ok: true,
             });
 
             const result = await crossmintAuthClient.sendEmailOtp(mockEmail);
@@ -296,7 +294,8 @@ describe("CrossmintAuthClient", () => {
             const mockToken = "otp-token-456";
             const mockOneTimeSecret = "one-time-secret-789";
             mockApiClient.post.mockResolvedValue({
-                json: () => Promise.resolve({ callbackUrl: `https://example.com?oneTimeSecret=${mockOneTimeSecret}` }),
+                json: () => Promise.resolve({ oneTimeSecret: mockOneTimeSecret }),
+                ok: true,
             });
 
             const result = await crossmintAuthClient.confirmEmailOtp(mockEmail, mockEmailId, mockToken);
@@ -318,13 +317,14 @@ describe("CrossmintAuthClient", () => {
             };
             const mockOneTimeSecret = "farcaster-one-time-secret-123";
             mockApiClient.post.mockResolvedValue({
-                json: () => Promise.resolve({ callbackUrl: `https://example.com?oneTimeSecret=${mockOneTimeSecret}` }),
+                json: () => Promise.resolve({ oneTimeSecret: mockOneTimeSecret }),
+                ok: true,
             });
 
             const result = await crossmintAuthClient.signInWithFarcaster(mockFarcasterData as StatusAPIResponse);
 
             expect(result).toBe(mockOneTimeSecret);
-            const expectedCallbackUrl = `https://api.crossmint.com/api/2024-09-26/session/sdk/auth/callback?isPopup=false`;
+            const expectedCallbackUrl = `https://api.crossmint.com/api/2024-09-26/session/sdk/auth/callback`;
             const queryParams = new URLSearchParams({
                 signinAuthenticationMethod: "farcaster",
                 callbackUrl: expectedCallbackUrl,
@@ -355,6 +355,7 @@ describe("CrossmintAuthClient", () => {
             };
             mockApiClient.post.mockResolvedValue({
                 json: () => Promise.resolve(mockResponse),
+                ok: true,
             });
 
             const result = await crossmintAuthClient.signInWithSmartWallet(mockAddress);
@@ -364,7 +365,7 @@ describe("CrossmintAuthClient", () => {
                 signinAuthenticationMethod: "evm",
             });
             expect(mockApiClient.post).toHaveBeenCalledWith(
-                `https://api.crossmint.com/api/2024-09-26/session/sdk/auth/crypto_wallets/authenticate/start?${queryParams}`,
+                `api/2024-09-26/session/sdk/auth/crypto_wallets/authenticate/start?${queryParams}`,
                 expect.objectContaining({
                     body: JSON.stringify({ walletAddress: mockAddress }),
                     headers: {
@@ -388,6 +389,7 @@ describe("CrossmintAuthClient", () => {
             };
             mockApiClient.post.mockResolvedValue({
                 json: () => Promise.resolve(mockResponse),
+                ok: true,
             });
 
             const result = await crossmintAuthClient.authenticateSmartWallet(mockAddress, mockSignature);
@@ -395,7 +397,6 @@ describe("CrossmintAuthClient", () => {
             expect(result).toEqual(mockResponse);
             const queryParams = new URLSearchParams({
                 signinAuthenticationMethod: "evm",
-                callbackUrl: `https://api.crossmint.com/api/2024-09-26/session/sdk/auth/we-dont-actually-use-this-anymore`,
             });
             expect(mockApiClient.post).toHaveBeenCalledWith(
                 `api/2024-09-26/session/sdk/auth/crypto_wallets/authenticate?${queryParams}`,

--- a/packages/client/auth/src/CrossmintAuthClient.ts
+++ b/packages/client/auth/src/CrossmintAuthClient.ts
@@ -46,8 +46,6 @@ export class CrossmintAuthClient extends CrossmintAuth {
                 headers: { "Content-Type": "application/json" },
             });
 
-            console.error("getUser", response);
-
             if (!response.ok) {
                 throw await response.text();
             }
@@ -91,7 +89,7 @@ export class CrossmintAuthClient extends CrossmintAuth {
             return;
         }
 
-        try {            
+        try {
             // Create new refresh promise if none exists
             if (this.refreshPromise == null) {
                 this.refreshPromise = this.refreshAuthMaterial(refreshToken);


### PR DESCRIPTION
## Description

Strong assurance that refresh won't be called twice

## Test plan

I created a test

## Package updates

client-auth: patch