### PR TITLE
Auth OTP: fixed bug with api request

### DIFF
--- a/.changeset/funny-hornets-behave.md
+++ b/.changeset/funny-hornets-behave.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-auth": patch
+---
+
+fixed issue with code being deprecated too soon

--- a/packages/client/auth/src/CrossmintAuthClient.ts
+++ b/packages/client/auth/src/CrossmintAuthClient.ts
@@ -158,6 +158,8 @@ export class CrossmintAuthClient extends CrossmintAuth {
                 token,
                 locale: "en",
                 state: emailId,
+                // TODO: Remove this when we deprecate frames
+                callbackUrl: `${this.apiClient.baseUrl}/${AUTH_SDK_ROOT_ENDPOINT}/callback`,
             });
 
             const response = await this.apiClient.post(`${AUTH_SDK_ROOT_ENDPOINT}/authenticate?${queryParams}`, {
@@ -234,6 +236,7 @@ export class CrossmintAuthClient extends CrossmintAuth {
         try {
             const queryParams = new URLSearchParams({
                 signinAuthenticationMethod: "evm",
+                // TODO: Remove this when we deprecate frames
                 callbackUrl: `${this.apiClient.baseUrl}/${AUTH_SDK_ROOT_ENDPOINT}/callback`,
             });
             const response = await this.apiClient.post(


### PR DESCRIPTION
## Description

We accidentally deprecated some sdk code before backend changes landed. Just needed to revert that change.

## Test plan

tested all auth flows, work as expected

## Package updates

@crossmint/client-sdk-auth:patch