### PR TITLE
embedded-v2: flag component as deprecated

### DIFF
--- a/.changeset/gentle-planes-search.md
+++ b/.changeset/gentle-planes-search.md
@@ -1,0 +1,6 @@
+---
+"@crossmint/client-sdk-react-ui": minor
+"@crossmint/client-sdk-nextjs-starter": patch
+---
+
+Flagging Embedded v2 component as deprecated

--- a/apps/payments/nextjs/pages/payment-element/eth.tsx
+++ b/apps/payments/nextjs/pages/payment-element/eth.tsx
@@ -3,7 +3,7 @@ import { DynamicConnectButton, DynamicContextProvider, useDynamicContext } from 
 import { useEffect, useState } from "react";
 
 import type { InitialQuotePayload } from "@crossmint/client-sdk-base";
-import { CrossmintPaymentElement } from "@crossmint/client-sdk-react-ui";
+import { CrossmintPaymentElement_DEPRECATED } from "@crossmint/client-sdk-react-ui";
 
 import QuoteSummary from "../../components/quote-summary";
 
@@ -87,7 +87,7 @@ function Content({ count }: { count: number }) {
         <>
             {quoteMessage != null ? <QuoteSummary initialQuotePayload={quoteMessage} /> : "Loading..."}
 
-            <CrossmintPaymentElement
+            <CrossmintPaymentElement_DEPRECATED
                 environment="staging"
                 clientId="1bd7b6b4-a390-4716-82f3-f78f9f2aa335"
                 recipient={{ wallet: address }}

--- a/apps/payments/nextjs/pages/payment-element/fiat.tsx
+++ b/apps/payments/nextjs/pages/payment-element/fiat.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
 import type { InitialQuotePayload } from "@crossmint/client-sdk-base";
-import { CrossmintPaymentElement } from "@crossmint/client-sdk-react-ui";
+import { CrossmintPaymentElement_DEPRECATED } from "@crossmint/client-sdk-react-ui";
 
 import QuoteSummary from "../../components/quote-summary";
 
@@ -41,7 +41,7 @@ function Content({ count }: { count: number }) {
         <>
             {quoteMessage != null ? <QuoteSummary initialQuotePayload={quoteMessage} /> : "Loading..."}
 
-            <CrossmintPaymentElement
+            <CrossmintPaymentElement_DEPRECATED
                 environment="staging"
                 clientId="02dbf2b7-bbaa-4fb3-a962-05b65518fd4d"
                 recipient={{ wallet: "0xdC9bb9929b79b62d630A7C3568c979a2843eFd8b" }}

--- a/apps/payments/nextjs/pages/payment-element/sol.tsx
+++ b/apps/payments/nextjs/pages/payment-element/sol.tsx
@@ -3,7 +3,7 @@ import { SolanaWalletConnectors } from "@dynamic-labs/solana-all";
 import { useEffect, useState } from "react";
 
 import type { InitialQuotePayload } from "@crossmint/client-sdk-base";
-import { CrossmintPaymentElement } from "@crossmint/client-sdk-react-ui";
+import { CrossmintPaymentElement_DEPRECATED } from "@crossmint/client-sdk-react-ui";
 
 import QuoteSummary from "../../components/quote-summary";
 
@@ -83,7 +83,7 @@ function Content({ count }: { count: number }) {
         <>
             {quoteMessage != null ? <QuoteSummary initialQuotePayload={quoteMessage} /> : "Loading..."}
 
-            <CrossmintPaymentElement
+            <CrossmintPaymentElement_DEPRECATED
                 environment="staging"
                 clientId="94273c86-b888-4734-a851-6464c7cce707"
                 recipient={{ wallet: signer.publicKey.toString() }}

--- a/packages/client/ui/react-ui/src/components/embed/CrossmintPaymentElement.test.tsx
+++ b/packages/client/ui/react-ui/src/components/embed/CrossmintPaymentElement.test.tsx
@@ -4,15 +4,15 @@ import { describe, expect, it, vi } from "vitest";
 
 import { CrossmintEvents } from "@crossmint/client-sdk-base";
 
-import { CrossmintPaymentElement } from ".";
+import { CrossmintPaymentElement_DEPRECATED } from ".";
 
 const embeddedCheckoutProps = {
     clientId: "db218e78-d042-4761-83af-3c4e5e6659dd",
 };
 
-describe("CrossmintPaymentElement", () => {
+describe("CrossmintPaymentElement_DEPRECATED", () => {
     it("renders an iframe with the correct props", () => {
-        render(<CrossmintPaymentElement {...embeddedCheckoutProps} />);
+        render(<CrossmintPaymentElement_DEPRECATED {...embeddedCheckoutProps} />);
         const iframe = screen.getByRole("crossmint-embedded-checkout.iframe");
 
         expect(iframe).toHaveAttribute("src");
@@ -32,7 +32,7 @@ describe("CrossmintPaymentElement", () => {
 
     it("calls the onEvent prop when a CrossmintEvents is received", () => {
         const onEvent = vi.fn();
-        render(<CrossmintPaymentElement {...embeddedCheckoutProps} onEvent={onEvent} environment="" />);
+        render(<CrossmintPaymentElement_DEPRECATED {...embeddedCheckoutProps} onEvent={onEvent} environment="" />);
         screen.getByRole("crossmint-embedded-checkout.iframe");
 
         // Simulate receiving a CrossmintEvents message
@@ -45,7 +45,7 @@ describe("CrossmintPaymentElement", () => {
 
     it("does not call the onEvent prop when a different origin than the environment is received in the event", () => {
         const onEvent = vi.fn();
-        render(<CrossmintPaymentElement {...embeddedCheckoutProps} onEvent={onEvent} environment="" />);
+        render(<CrossmintPaymentElement_DEPRECATED {...embeddedCheckoutProps} onEvent={onEvent} environment="" />);
         screen.getByRole("crossmint-embedded-checkout.iframe");
 
         // Simulate receiving a CrossmintEvents message
@@ -57,21 +57,21 @@ describe("CrossmintPaymentElement", () => {
     });
 
     it("should add the `whPassThroughArgs` prop when passed", async () => {
-        render(<CrossmintPaymentElement {...embeddedCheckoutProps} whPassThroughArgs={{ hello: "hi" }} />);
+        render(<CrossmintPaymentElement_DEPRECATED {...embeddedCheckoutProps} whPassThroughArgs={{ hello: "hi" }} />);
         const iframe = screen.getByRole("crossmint-embedded-checkout.iframe");
 
         expect(iframe.getAttribute("src")).toContain("whPassThroughArgs=%7B%22hello%22%3A%22hi%22%7D");
     });
 
     it("should add the clientId when passing the collectionId prop", () => {
-        render(<CrossmintPaymentElement collectionId={embeddedCheckoutProps.clientId} />);
+        render(<CrossmintPaymentElement_DEPRECATED collectionId={embeddedCheckoutProps.clientId} />);
         const iframe = screen.getByRole("crossmint-embedded-checkout.iframe");
 
         expect(iframe.getAttribute("src")).toContain(`clientId=${embeddedCheckoutProps.clientId}`);
     });
 
     it("should add projectId when added", () => {
-        render(<CrossmintPaymentElement collectionId={embeddedCheckoutProps.clientId} projectId="123" />);
+        render(<CrossmintPaymentElement_DEPRECATED collectionId={embeddedCheckoutProps.clientId} projectId="123" />);
         const iframe = screen.getByRole("crossmint-embedded-checkout.iframe");
 
         expect(iframe.getAttribute("src")).toContain("projectId=123");

--- a/packages/client/ui/react-ui/src/components/embed/index.tsx
+++ b/packages/client/ui/react-ui/src/components/embed/index.tsx
@@ -8,7 +8,9 @@ import { CrossmintCryptoEmbeddedCheckout } from "./crypto/CryptoEmbeddedCheckout
 import { CrossmintFiatEmbeddedCheckout } from "./fiat/FiatEmbeddedCheckout";
 
 // TODO: Rename to CrossmintEmbeddedCheckout on v2 major publish, prior announcement since its a breaking change
-export function CrossmintPaymentElement(props: CrossmintEmbeddedCheckoutProps) {
+export function CrossmintPaymentElement_DEPRECATED(props: CrossmintEmbeddedCheckoutProps) {
+    console.error("[CrossmintPaymentElement] 🚨 This SDK is now deprecated. We encourage you to migrate to our Embedded Checkout V3, which is faster, easier to integrate and provides many more functionality. Read the docs here: https://docs.crossmint.com/nft-checkout/embedded/overview")
+
     if (isFiatEmbeddedCheckoutProps(props)) {
         return <CrossmintFiatEmbeddedCheckout {...props} />;
     }

--- a/packages/client/ui/react-ui/src/components/embed/index.tsx
+++ b/packages/client/ui/react-ui/src/components/embed/index.tsx
@@ -9,7 +9,9 @@ import { CrossmintFiatEmbeddedCheckout } from "./fiat/FiatEmbeddedCheckout";
 
 // TODO: Rename to CrossmintEmbeddedCheckout on v2 major publish, prior announcement since its a breaking change
 export function CrossmintPaymentElement_DEPRECATED(props: CrossmintEmbeddedCheckoutProps) {
-    console.error("[CrossmintPaymentElement_DEPRECATED] 🚨 This SDK is now deprecated. We encourage you to migrate to our Embedded Checkout V3, which is faster, easier to integrate and provides many more functionality. Read the docs here: https://docs.crossmint.com/nft-checkout/embedded/overview")
+    console.error(
+        "[CrossmintPaymentElement_DEPRECATED] 🚨 This SDK is now deprecated. We encourage you to migrate to our Embedded Checkout V3, which is faster, easier to integrate and provides many more functionality. Read the docs here: https://docs.crossmint.com/nft-checkout/embedded/overview"
+    );
 
     if (isFiatEmbeddedCheckoutProps(props)) {
         return <CrossmintFiatEmbeddedCheckout {...props} />;

--- a/packages/client/ui/react-ui/src/components/embed/index.tsx
+++ b/packages/client/ui/react-ui/src/components/embed/index.tsx
@@ -7,10 +7,9 @@ import {
 import { CrossmintCryptoEmbeddedCheckout } from "./crypto/CryptoEmbeddedCheckout";
 import { CrossmintFiatEmbeddedCheckout } from "./fiat/FiatEmbeddedCheckout";
 
-// TODO: Rename to CrossmintEmbeddedCheckout on v2 major publish, prior announcement since its a breaking change
 export function CrossmintPaymentElement_DEPRECATED(props: CrossmintEmbeddedCheckoutProps) {
     console.error(
-        "[CrossmintPaymentElement_DEPRECATED] 🚨 This SDK is now deprecated. We encourage you to migrate to our Embedded Checkout V3, which is faster, easier to integrate and provides many more functionality. Read the docs here: https://docs.crossmint.com/nft-checkout/embedded/overview"
+        "[CrossmintPaymentElement_DEPRECATED] ⚠️ This SDK version is deprecated. Please upgrade to Embedded Checkout V3 for improved performance, simplified integration, and enhanced functionality. Learn more: https://docs.crossmint.com/nft-checkout/embedded/overview"
     );
 
     if (isFiatEmbeddedCheckoutProps(props)) {

--- a/packages/client/ui/react-ui/src/components/embed/index.tsx
+++ b/packages/client/ui/react-ui/src/components/embed/index.tsx
@@ -9,7 +9,7 @@ import { CrossmintFiatEmbeddedCheckout } from "./fiat/FiatEmbeddedCheckout";
 
 // TODO: Rename to CrossmintEmbeddedCheckout on v2 major publish, prior announcement since its a breaking change
 export function CrossmintPaymentElement_DEPRECATED(props: CrossmintEmbeddedCheckoutProps) {
-    console.error("[CrossmintPaymentElement] 🚨 This SDK is now deprecated. We encourage you to migrate to our Embedded Checkout V3, which is faster, easier to integrate and provides many more functionality. Read the docs here: https://docs.crossmint.com/nft-checkout/embedded/overview")
+    console.error("[CrossmintPaymentElement_DEPRECATED] 🚨 This SDK is now deprecated. We encourage you to migrate to our Embedded Checkout V3, which is faster, easier to integrate and provides many more functionality. Read the docs here: https://docs.crossmint.com/nft-checkout/embedded/overview")
 
     if (isFiatEmbeddedCheckoutProps(props)) {
         return <CrossmintFiatEmbeddedCheckout {...props} />;


### PR DESCRIPTION
## Description

<!-- Human must describe here why are we doing this change, and roughly what it does -->
<!-- Optional screenshot or video -->

Embedded v3 is the default and recommended version. Flag the old component as deprecated.

## Test plan

<!--
  Example:
   * Unit tests which cover functionality X, Y, Z
   * V was tested via UI tests
   * W was tested manually
-->

## Package updates

<!-- 
  List any package updates and ensure you've added the necessary changesets, running `pnpm change:add` to do so.
-->