### PR TITLE
hosted: removing alpha flag from SDK name

### DIFF
--- a/.changeset/calm-badgers-lie.md
+++ b/.changeset/calm-badgers-lie.md
@@ -1,0 +1,6 @@
+---
+"@crossmint/client-sdk-react-ui": minor
+"@crossmint/client-sdk-nextjs-starter": patch
+---
+
+Removing the alpha flag from Hosted V3 SDK

--- a/apps/payments/nextjs/pages/hosted-checkout/v3.tsx
+++ b/apps/payments/nextjs/pages/hosted-checkout/v3.tsx
@@ -1,4 +1,4 @@
-import { CrossmintHostedCheckout_Alpha } from "@crossmint/client-sdk-react-ui";
+import { CrossmintHostedCheckout } from "@crossmint/client-sdk-react-ui";
 import { HostedCheckoutV3ClientProviders } from "../../components/hosted-v3/HostedCheckoutV3ClientProviders";
 import type { CrossmintHostedCheckoutV3ButtonTheme, Locale } from "@crossmint/client-sdk-base";
 
@@ -80,7 +80,7 @@ function createCrossmintButtonSection(
                 padding: "20px",
             }}
         >
-            <CrossmintHostedCheckout_Alpha
+            <CrossmintHostedCheckout
                 locale={locale}
                 lineItems={{
                     collectionLocator: "crossmint:206b3146-f526-444e-bd9d-0607d581b0e9",

--- a/packages/client/ui/react-ui/src/components/hosted/v3/CrossmintHostedCheckoutV3.tsx
+++ b/packages/client/ui/react-ui/src/components/hosted/v3/CrossmintHostedCheckoutV3.tsx
@@ -11,7 +11,7 @@ import { type MouseEvent, type JSX, useEffect, useState } from "react";
 
 export type CrossmintHostedCheckoutV3ReactProps = CrossmintHostedCheckoutV3Props & JSX.IntrinsicElements["button"];
 
-export function CrossmintHostedCheckout_Alpha(props: CrossmintHostedCheckoutV3ReactProps) {
+export function CrossmintHostedCheckout(props: CrossmintHostedCheckoutV3ReactProps) {
     const [didInjectCss, setDidInjectCss] = useState(false);
 
     const { crossmint } = useCrossmint();


### PR DESCRIPTION
## Description

<!-- Human must describe here why are we doing this change, and roughly what it does -->
<!-- Optional screenshot or video -->
Removing the Alpha flag, since hosted v3 will now be the default version

## Test plan

<!--
  Example:
   * Unit tests which cover functionality X, Y, Z
   * V was tested via UI tests
   * W was tested manually
-->
Relying on build + CI/CD


## Package updates

<!-- 
  List any package updates and ensure you've added the necessary changesets, running `pnpm change:add` to do so.
-->