### PR TITLE
v3: remove webhook passthrough field

### DIFF
--- a/packages/client/base/src/types/embed/v3/CrossmintEmbeddedCheckoutV3Props.ts
+++ b/packages/client/base/src/types/embed/v3/CrossmintEmbeddedCheckoutV3Props.ts
@@ -11,7 +11,6 @@ interface CrossmintEmbeddedCheckoutV3CommonProps {
 export interface CrossmintEmbeddedCheckoutV3ExistingOrderProps extends CrossmintEmbeddedCheckoutV3CommonProps {
     orderId: string;
     lineItems?: never;
-    webhookPassthroughData?: never;
     recipient?: never;
     locale?: never;
 }
@@ -19,7 +18,6 @@ export interface CrossmintEmbeddedCheckoutV3ExistingOrderProps extends Crossmint
 export interface CrossmintEmbeddedCheckoutV3NewOrderProps extends CrossmintEmbeddedCheckoutV3CommonProps {
     orderId?: never;
     lineItems: EmbeddedCheckoutV3LineItem | EmbeddedCheckoutV3LineItem[];
-    webhookPassthroughData?: any;
     recipient?: EmbeddedCheckoutV3Recipient;
     locale?: Locale;
 }

--- a/packages/client/base/src/types/hosted/v3/CrossmintHostedCheckoutV3Props.ts
+++ b/packages/client/base/src/types/hosted/v3/CrossmintHostedCheckoutV3Props.ts
@@ -5,7 +5,6 @@ import type { BlockchainIncludingTestnet } from "@crossmint/common-sdk-base";
 export interface CrossmintHostedCheckoutV3Props {
     recipient?: EmbeddedCheckoutV3Recipient;
     locale?: Locale;
-    webhookPassthroughData?: any;
     lineItems: EmbeddedCheckoutV3LineItem | EmbeddedCheckoutV3LineItem[];
     payment: HostedCheckoutV3Payment;
     appearance?: CrossmintHostedCheckoutV3Appearance;

--- a/packages/client/ui/react-ui/src/components/hosted/v3/CrossmintHostedCheckoutV3.tsx
+++ b/packages/client/ui/react-ui/src/components/hosted/v3/CrossmintHostedCheckoutV3.tsx
@@ -18,11 +18,10 @@ export function CrossmintHostedCheckout_Alpha(props: CrossmintHostedCheckoutV3Re
     const apiClient = createCrossmintApiClient(crossmint);
 
     // separate custom props from jsx button props
-    const { recipient, locale, webhookPassthroughData, lineItems, payment, appearance, ...buttonProps } = props;
+    const { recipient, locale, lineItems, payment, appearance, ...buttonProps } = props;
     const customProps: CrossmintHostedCheckoutV3Props = {
         recipient,
         locale,
-        webhookPassthroughData,
         lineItems,
         payment,
         appearance,


### PR DESCRIPTION
## Description

<!-- Human must describe here why are we doing this change, and roughly what it does -->
<!-- Optional screenshot or video -->
Removing webhook passthrough field. This does not apply on the new checkout webhooks.

## Test plan

<!--
  Example:
   * Unit tests which cover functionality X, Y, Z
   * V was tested via UI tests
   * W was tested manually
-->
Relying on CI/CD + compiler


## Package updates

<!-- 
  List any package updates and ensure you've added the necessary changesets, running `pnpm change:add` to do so.
-->