### PR TITLE
Fix: stale JWT re-render bug

### DIFF
--- a/.changeset/wild-news-cheat.md
+++ b/.changeset/wild-news-cheat.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+---
+
+Fixed bug with stale jwt re-render

--- a/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.tsx
@@ -163,6 +163,7 @@ export function CrossmintAuthProvider({
                 }}
             >
                 <CrossmintWalletProvider
+                    key={crossmint.jwt}
                     defaultChain={embeddedWallets.defaultChain}
                     showPasskeyHelpers={embeddedWallets.showPasskeyHelpers}
                     appearance={appearance}


### PR DESCRIPTION
## Description

Fixed issue with React not re-rendering upon jwt invalidation and new one being set

## Test plan

1. repro bug
2. fix and remove ability to repro bug

## Package updates

@crossmint/client-sdk-react-ui