### PR TITLE
UI design overhaul

### DIFF
--- a/.changeset/bright-foxes-hope.md
+++ b/.changeset/bright-foxes-hope.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": minor
+---
+
+New UI look and feel

--- a/packages/client/ui/react-ui/src/components/auth/AuthForm.tsx
+++ b/packages/client/ui/react-ui/src/components/auth/AuthForm.tsx
@@ -19,7 +19,7 @@ const Web3AuthFlow = lazy(() =>
 );
 
 export function AuthForm({ className }: { className?: string }) {
-    const { step, appearance, loginMethods, baseUrl, error, termsOfServiceText } = useAuthForm();
+    const { step, appearance, loginMethods, baseUrl, error, termsOfServiceText, authModalTitle } = useAuthForm();
 
     return (
         <div
@@ -50,7 +50,7 @@ export function AuthForm({ className }: { className?: string }) {
                         className="text-2xl font-bold text-cm-text-primary"
                         style={{ color: appearance?.colors?.textPrimary }}
                     >
-                        Sign in to Crossmint
+                        {authModalTitle ?? "Sign in to Crossmint"}
                     </h1>
                     <p
                         className="text-base font-normal mb-3 text-cm-text-secondary"
@@ -77,18 +77,18 @@ export function AuthForm({ className }: { className?: string }) {
                 </div>
             ) : null}
 
-            {termsOfServiceText != null ? (
-                <p
+            {step === "initial" && termsOfServiceText != null ? (
+                <div
                     className="text-sm text-center text-cm-text-secondary mt-2"
                     style={{ color: appearance?.colors?.textSecondary }}
                 >
                     <style>{`
                         p a {
-                            color: ${appearance?.colors?.accent ?? "#04AA6D"};
+                            color: ${appearance?.colors?.textLink ?? "#1A74E9"};
                         }
                     `}</style>
                     {termsOfServiceText}
-                </p>
+                </div>
             ) : null}
 
             {step === "initial" || step === "otp" ? (

--- a/packages/client/ui/react-ui/src/components/auth/AuthForm.tsx
+++ b/packages/client/ui/react-ui/src/components/auth/AuthForm.tsx
@@ -19,12 +19,12 @@ const Web3AuthFlow = lazy(() =>
 );
 
 export function AuthForm({ className }: { className?: string }) {
-    const { step, appearance, loginMethods, baseUrl, error } = useAuthForm();
+    const { step, appearance, loginMethods, baseUrl, error, termsOfServiceText } = useAuthForm();
 
     return (
         <div
             className={classNames(
-                "relative p-6 pb-4 !min-[480px]:p-10 !min-[480px]:pb-8 flex flex-col gap-[10px] antialiased animate-none",
+                "relative pt-10 pb-[30px] px-6 !min-[480px]:px-10 flex flex-col gap-[10px] antialiased animate-none",
                 className
             )}
         >
@@ -50,22 +50,15 @@ export function AuthForm({ className }: { className?: string }) {
                         className="text-2xl font-bold text-cm-text-primary"
                         style={{ color: appearance?.colors?.textPrimary }}
                     >
-                        Sign In
+                        Sign in to Crossmint
                     </h1>
                     <p
                         className="text-base font-normal mb-3 text-cm-text-secondary"
                         style={{ color: appearance?.colors?.textSecondary }}
                     >
-                        Sign in using one of the options below
+                        Access using one of the options below.
                     </p>
                 </div>
-            ) : null}
-
-            {loginMethods.includes("email") ? (
-                <>
-                    <EmailAuthFlow />
-                    {loginMethods.length > 1 ? <Divider appearance={appearance} text="OR" /> : null}
-                </>
             ) : null}
 
             {loginMethods.includes("google") ? <GoogleSignIn /> : null}
@@ -76,6 +69,27 @@ export function AuthForm({ className }: { className?: string }) {
             ) : null}
             {loginMethods.includes("twitter") ? <TwitterSignIn /> : null}
             {loginMethods.includes("web3") ? <Web3AuthFlow /> : null}
+
+            {loginMethods.includes("email") ? (
+                <div>
+                    {loginMethods.length > 1 ? <Divider appearance={appearance} text="OR" /> : null}
+                    <EmailAuthFlow />
+                </div>
+            ) : null}
+
+            {termsOfServiceText != null ? (
+                <p
+                    className="text-sm text-center text-cm-text-secondary mt-2"
+                    style={{ color: appearance?.colors?.textSecondary }}
+                >
+                    <style>{`
+                        p a {
+                            color: ${appearance?.colors?.accent ?? "#04AA6D"};
+                        }
+                    `}</style>
+                    {termsOfServiceText}
+                </p>
+            ) : null}
 
             {step === "initial" || step === "otp" ? (
                 <SecuredByCrossmint

--- a/packages/client/ui/react-ui/src/components/auth/AuthFormDialog.tsx
+++ b/packages/client/ui/react-ui/src/components/auth/AuthFormDialog.tsx
@@ -18,7 +18,7 @@ export default function AuthFormDialog({ open }: { open: boolean }) {
                 onOpenAutoFocus={(e) => e.preventDefault()}
                 closeButtonColor={appearance?.colors?.textPrimary}
                 closeButtonRingColor={appearance?.colors?.accent}
-                className="cm-responsive-border-radius-auth-dialog !p-0 !min-[480px]:p-0"
+                className="!p-0 !min-[480px]:p-0"
                 style={{
                     borderRadius: appearance?.borderRadius,
                     backgroundColor: appearance?.colors?.background,

--- a/packages/client/ui/react-ui/src/components/auth/methods/email/EmailOTPInput.tsx
+++ b/packages/client/ui/react-ui/src/components/auth/methods/email/EmailOTPInput.tsx
@@ -5,6 +5,7 @@ import { useAuthForm } from "@/providers/auth/AuthFormProvider";
 import type { OtpEmailPayload } from "@/types/auth";
 import { AuthFormBackButton } from "../../AuthFormBackButton";
 import { useCrossmintAuth } from "@/hooks/useCrossmintAuth";
+import { CountdownButton } from "@/components/common/CountdownButton";
 
 export const EMAIL_VERIFICATION_TOKEN_LENGTH = 6;
 
@@ -19,7 +20,7 @@ export function EmailOTPInput({
     const [hasError, setHasError] = useState(false);
     const [loading, setLoading] = useState(false);
 
-    const handleOnSubmit = async () => {
+    const handleOnSubmitOTP = async () => {
         setLoading(true);
         try {
             const oneTimeSecret = await crossmintAuth?.confirmEmailOtp(
@@ -37,6 +38,14 @@ export function EmailOTPInput({
             setHasError(true);
         } finally {
             setLoading(false);
+        }
+    };
+
+    const handleOnResendCode = async () => {
+        try {
+            await crossmintAuth?.sendEmailOtp(otpEmailData?.email ?? "");
+        } catch (_e: unknown) {
+            setError("Failed to resend code. Please try again.");
         }
     };
 
@@ -71,7 +80,8 @@ export function EmailOTPInput({
                     className="text-center text-cm-text-secondary px-4"
                     style={{ color: appearance?.colors?.textSecondary }}
                 >
-                    {"A temporary login code has been sent to your email"}
+                    A temporary login code has been sent to{" "}
+                    {otpEmailData?.email ? otpEmailData.email : "your email address"}
                 </p>
                 <div className="py-8">
                     <InputOTP
@@ -82,7 +92,7 @@ export function EmailOTPInput({
                             setHasError(false);
                             setError(null);
                         }}
-                        onComplete={handleOnSubmit}
+                        onComplete={handleOnSubmitOTP}
                         disabled={loading}
                         customStyles={{
                             accent: appearance?.colors?.accent ?? "#04AA6D",
@@ -105,19 +115,21 @@ export function EmailOTPInput({
                     </InputOTP>
                 </div>
 
-                <p className="text-sm leading-tight text-cm-text-secondary text-center">
+                <div className="text-xs leading-tight text-cm-text-secondary text-center">
                     <span style={{ color: appearance?.colors?.textSecondary }}>
-                        Can't find the email? Check spam folder or contact
-                    </span>{" "}
-                    <a
-                        key="resend-email-link"
-                        className="transition-opacity duration-150 text-cm-link hover:opacity-70"
-                        style={{ color: appearance?.colors?.textLink }}
-                        href="mailto:support@crossmint.io"
-                    >
-                        support@crossmint.io
-                    </a>
-                </p>
+                        Can't find the email? Check spam folder.
+                        {"\n"}
+                        Some emails may take several minutes to arrive.
+                    </span>
+                </div>
+
+                <CountdownButton
+                    seconds={30}
+                    appearance={appearance}
+                    countdownText={(seconds) => `Re-send code in ${seconds}s`}
+                    countdownCompleteText="Re-send code"
+                    handleOnClick={handleOnResendCode}
+                />
             </div>
         </div>
     );

--- a/packages/client/ui/react-ui/src/components/auth/methods/email/EmailSignIn.tsx
+++ b/packages/client/ui/react-ui/src/components/auth/methods/email/EmailSignIn.tsx
@@ -8,13 +8,11 @@ import { isEmailValid } from "@crossmint/common-sdk-auth";
 import { useAuthForm } from "@/providers/auth/AuthFormProvider";
 import type { OtpEmailPayload } from "@/types/auth";
 import { useCrossmintAuth } from "@/hooks/useCrossmintAuth";
-import { GoogleIcon } from "@/icons/google";
-import { useOAuthWindowListener } from "@/hooks/useOAuthWindowListener";
+import { ContinueWithGoogle } from "../google/ContinueWithGoogle";
 
 export function EmailSignIn({ setOtpEmailData }: { setOtpEmailData: (data: OtpEmailPayload) => void }) {
     const { crossmintAuth } = useCrossmintAuth();
     const { appearance, setStep, setError } = useAuthForm();
-    const { createPopupAndSetupListeners, isLoading: isLoadingOAuthWindow } = useOAuthWindowListener("google");
 
     const [emailInput, setEmailInput] = useState("");
     const [emailError, setEmailError] = useState("");
@@ -113,39 +111,7 @@ export function EmailSignIn({ setOtpEmailData }: { setOtpEmailData: (data: OtpEm
                                 />
                             )}
                             {showGoogleContinueButton ? (
-                                <button
-                                    type="button"
-                                    className={classNames(
-                                        "flex items-center gap-2 justify-center h-[32px] px-2.5 border border-cm-border rounded-xl bg-cm-background-primary",
-                                        "hover:bg-cm-hover focus:bg-cm-hover outline-none",
-                                        isLoadingOAuthWindow ? "cursor-not-allowed hover:bg-cm-muted-primary" : ""
-                                    )}
-                                    onClick={
-                                        isLoadingOAuthWindow
-                                            ? undefined
-                                            : () => createPopupAndSetupListeners(emailInput.trim().toLowerCase())
-                                    }
-                                    style={{
-                                        backgroundColor: appearance?.colors?.buttonBackground,
-                                        borderRadius: appearance?.borderRadius,
-                                    }}
-                                >
-                                    <GoogleIcon className="max-h-[18px] max-w-[18px] h-[18px] w-[18px]" />
-                                    {isLoadingOAuthWindow ? (
-                                        <Spinner
-                                            style={{
-                                                color: appearance?.colors?.textSecondary,
-                                                fill: appearance?.colors?.textPrimary,
-                                                width: "18px",
-                                                height: "18px",
-                                            }}
-                                        />
-                                    ) : (
-                                        <span className="text-cm-accent" style={{ color: appearance?.colors?.accent }}>
-                                            Continue
-                                        </span>
-                                    )}
-                                </button>
+                                <ContinueWithGoogle emailInput={emailInput} appearance={appearance} />
                             ) : !emailError && !isLoading ? (
                                 <button
                                     type="submit"

--- a/packages/client/ui/react-ui/src/components/auth/methods/email/EmailSignIn.tsx
+++ b/packages/client/ui/react-ui/src/components/auth/methods/email/EmailSignIn.tsx
@@ -20,11 +20,6 @@ export function EmailSignIn({ setOtpEmailData }: { setOtpEmailData: (data: OtpEm
     async function handleOnSubmit(e: FormEvent<HTMLFormElement>) {
         e.preventDefault();
 
-        if (!isEmailValid(emailInput)) {
-            setEmailError("Please enter a valid email address");
-            return;
-        }
-
         setIsLoading(true);
 
         try {
@@ -43,10 +38,16 @@ export function EmailSignIn({ setOtpEmailData }: { setOtpEmailData: (data: OtpEm
         <>
             <div className="flex flex-col items-start justify-start w-full rounded-lg">
                 <div className="w-full">
+                    <label
+                        className="text-cm-text-primary block mb-[5px]"
+                        style={{ color: appearance?.colors?.textPrimary }}
+                    >
+                        Email
+                    </label>
                     <form
                         role="form"
                         className="relative"
-                        onSubmit={handleOnSubmit}
+                        onSubmit={isEmailValid(emailInput) ? handleOnSubmit : undefined}
                         noValidate // we want to handle validation ourselves
                     >
                         <label htmlFor="emailInput" className="sr-only">
@@ -54,9 +55,10 @@ export function EmailSignIn({ setOtpEmailData }: { setOtpEmailData: (data: OtpEm
                         </label>
                         <input
                             className={classNames(
-                                "flex-grow text-cm-text-secondary text-left pl-[16px] pr-[80px] h-[58px] w-full border border-cm-border rounded-xl bg-cm-background-primary placeholder:text-sm placeholder:text-opacity-60",
+                                "flex-grow text-cm-text-primary text-left pl-[16px] pr-[80px] h-[58px] w-full border border-cm-border rounded-xl bg-cm-background-primary placeholder:text-md",
                                 "transition-none duration-200 ease-in-out",
                                 "focus:outline-none focus-ring-custom", // Add focus ring
+                                "placeholder:[color:var(--placeholder-color)]",
                                 emailError ? "border-red-500" : ""
                             )}
                             style={{
@@ -64,13 +66,14 @@ export function EmailSignIn({ setOtpEmailData }: { setOtpEmailData: (data: OtpEm
                                 borderRadius: appearance?.borderRadius,
                                 borderColor: emailError ? appearance?.colors?.danger : appearance?.colors?.border,
                                 backgroundColor: appearance?.colors?.inputBackground,
-                                // @ts-expect-error Add custom ring color to tailwind
+                                // @ts-expect-error Add custom placeholder & ring color to tailwind
+                                "--placeholder-color": appearance?.colors?.textSecondary ?? "#67797F",
                                 "--focus-ring-color": new Color(appearance?.colors?.accent ?? "#04AA6D")
                                     .alpha(0.18)
                                     .toString(),
                             }}
                             type="email"
-                            placeholder="Enter email"
+                            placeholder="your@email.com"
                             value={emailInput}
                             onChange={(e) => {
                                 setEmailInput(e.target.value);
@@ -93,11 +96,14 @@ export function EmailSignIn({ setOtpEmailData }: { setOtpEmailData: (data: OtpEm
                             {!emailError && !isLoading && (
                                 <button
                                     type="submit"
-                                    className={classNames("cursor-pointer font-medium text-cm-accent text-nowrap")}
+                                    className={classNames(
+                                        "font-medium text-cm-accent text-nowrap",
+                                        !isEmailValid(emailInput) ? "!cursor-not-allowed opacity-60" : "cursor-pointer"
+                                    )}
                                     style={{ color: appearance?.colors?.accent }}
-                                    disabled={!emailInput}
+                                    disabled={!isEmailValid(emailInput) || isLoading}
                                 >
-                                    Sign in
+                                    Submit
                                 </button>
                             )}
                         </div>

--- a/packages/client/ui/react-ui/src/components/auth/methods/farcaster/FarcasterSignIn.tsx
+++ b/packages/client/ui/react-ui/src/components/auth/methods/farcaster/FarcasterSignIn.tsx
@@ -27,7 +27,7 @@ export function FarcasterSignIn() {
                         setError(null);
                     }}
                 >
-                    <FarcasterIcon className="h-[25px] w-[25px] absolute left-[18px]" />
+                    <FarcasterIcon className="max-h-[25px] max-w-[25px] h-[25px] w-[25px] absolute left-[18px]" />
                     <span
                         className="font-medium"
                         style={{ margin: "0px 32px", color: appearance?.colors?.textPrimary }}

--- a/packages/client/ui/react-ui/src/components/auth/methods/google/ContinueWithGoogle.tsx
+++ b/packages/client/ui/react-ui/src/components/auth/methods/google/ContinueWithGoogle.tsx
@@ -1,0 +1,43 @@
+import type { UIConfig } from "@crossmint/common-sdk-base";
+import { Spinner } from "@/components/common/Spinner";
+import { useOAuthWindowListener } from "@/hooks/useOAuthWindowListener";
+import { GoogleIcon } from "@/icons/google";
+import { classNames } from "@/utils/classNames";
+
+export function ContinueWithGoogle({ emailInput, appearance }: { emailInput: string; appearance?: UIConfig }) {
+    const { createPopupAndSetupListeners, isLoading: isLoadingOAuthWindow } = useOAuthWindowListener("google");
+
+    return (
+        <button
+            type="button"
+            className={classNames(
+                "flex items-center gap-2 justify-center h-[32px] px-2.5 border border-cm-border rounded-xl bg-cm-background-primary",
+                "hover:bg-cm-hover focus:bg-cm-hover outline-none",
+                isLoadingOAuthWindow ? "cursor-not-allowed hover:bg-cm-muted-primary" : ""
+            )}
+            onClick={
+                isLoadingOAuthWindow ? undefined : () => createPopupAndSetupListeners(emailInput.trim().toLowerCase())
+            }
+            style={{
+                backgroundColor: appearance?.colors?.buttonBackground,
+                borderRadius: appearance?.borderRadius,
+            }}
+        >
+            <GoogleIcon className="max-h-[18px] max-w-[18px] h-[18px] w-[18px]" />
+            {isLoadingOAuthWindow ? (
+                <Spinner
+                    style={{
+                        color: appearance?.colors?.textSecondary,
+                        fill: appearance?.colors?.textPrimary,
+                        width: "18px",
+                        height: "18px",
+                    }}
+                />
+            ) : (
+                <span className="text-cm-accent" style={{ color: appearance?.colors?.accent }}>
+                    Continue
+                </span>
+            )}
+        </button>
+    );
+}

--- a/packages/client/ui/react-ui/src/components/auth/methods/google/GoogleSignIn.tsx
+++ b/packages/client/ui/react-ui/src/components/auth/methods/google/GoogleSignIn.tsx
@@ -30,7 +30,7 @@ export function GoogleSignIn({ ...props }: ButtonHTMLAttributes<HTMLButtonElemen
             {...props}
         >
             <>
-                <GoogleIcon className="h-[25px] w-[25px] absolute left-[18px]" />
+                <GoogleIcon className="max-h-[25px] max-w-[25px] h-[25px] w-[25px] absolute left-[18px]" />
                 {isLoading ? (
                     <Spinner
                         style={{

--- a/packages/client/ui/react-ui/src/components/auth/methods/google/GoogleSignIn.tsx
+++ b/packages/client/ui/react-ui/src/components/auth/methods/google/GoogleSignIn.tsx
@@ -26,7 +26,7 @@ export function GoogleSignIn({ ...props }: ButtonHTMLAttributes<HTMLButtonElemen
                 borderRadius: appearance?.borderRadius,
                 backgroundColor: appearance?.colors?.buttonBackground,
             }}
-            onClick={isLoading ? undefined : createPopupAndSetupListeners}
+            onClick={isLoading ? undefined : () => createPopupAndSetupListeners()}
             {...props}
         >
             <>

--- a/packages/client/ui/react-ui/src/components/auth/methods/twitter/TwitterSignIn.tsx
+++ b/packages/client/ui/react-ui/src/components/auth/methods/twitter/TwitterSignIn.tsx
@@ -26,7 +26,7 @@ export function TwitterSignIn({ ...props }: ButtonHTMLAttributes<HTMLButtonEleme
                 borderRadius: appearance?.borderRadius,
                 backgroundColor: appearance?.colors?.buttonBackground,
             }}
-            onClick={isLoading ? undefined : createPopupAndSetupListeners}
+            onClick={isLoading ? undefined : () => createPopupAndSetupListeners()}
             {...props}
         >
             <>

--- a/packages/client/ui/react-ui/src/components/auth/methods/twitter/TwitterSignIn.tsx
+++ b/packages/client/ui/react-ui/src/components/auth/methods/twitter/TwitterSignIn.tsx
@@ -30,7 +30,7 @@ export function TwitterSignIn({ ...props }: ButtonHTMLAttributes<HTMLButtonEleme
             {...props}
         >
             <>
-                <TwitterIcon className="h-[25px] w-[25px] absolute left-[18px]" />
+                <TwitterIcon className="max-h-[25px] max-w-[25px] h-[25px] w-[25px] absolute left-[18px]" />
 
                 {isLoading ? (
                     <Spinner

--- a/packages/client/ui/react-ui/src/components/common/CountdownButton.tsx
+++ b/packages/client/ui/react-ui/src/components/common/CountdownButton.tsx
@@ -1,0 +1,81 @@
+import { useState, useEffect } from "react";
+import type { UIConfig } from "@crossmint/common-sdk-base";
+import { classNames } from "@/utils/classNames";
+
+type CountdownButtonProps = {
+    seconds: number;
+    appearance?: UIConfig;
+    countdownText: (seconds: number) => string;
+    countdownCompleteText: string;
+    handleOnClick: () => Promise<void>;
+};
+
+export function CountdownButton({
+    seconds: initialSeconds,
+    appearance,
+    countdownText,
+    countdownCompleteText,
+    handleOnClick,
+}: CountdownButtonProps) {
+    const [seconds, setSeconds] = useState(0);
+    const [canResend, setCanResend] = useState(true);
+    const [retryCount, setRetryCount] = useState(0);
+
+    useEffect(() => {
+        let timer: NodeJS.Timeout;
+
+        if (seconds > 0) {
+            setCanResend(false);
+            timer = setInterval(() => {
+                setSeconds((prev) => {
+                    if (prev <= 1) {
+                        setCanResend(true);
+                        return 0;
+                    }
+                    return prev - 1;
+                });
+            }, 1000);
+        }
+
+        return () => {
+            if (timer) {
+                clearInterval(timer);
+            }
+        };
+    }, [seconds]);
+
+    const startCountdown = () => {
+        if (!canResend) {
+            return;
+        }
+
+        const backoffDelay = Math.min(initialSeconds * Math.pow(2, retryCount), 240); // Exponential backoff until 4 minutes
+        setSeconds(backoffDelay);
+        setRetryCount((prev) => prev + 1);
+    };
+
+    const handleClick = async () => {
+        if (canResend) {
+            await handleOnClick();
+            startCountdown();
+        }
+    };
+
+    return (
+        <button
+            onClick={handleClick}
+            disabled={!canResend}
+            className={classNames(
+                "text-sm leading-tight text-center mt-2 transition-opacity",
+                canResend ? "cursor-pointer opacity-100" : "cursor-default opacity-50"
+            )}
+            style={{
+                color: canResend
+                    ? appearance?.colors?.textLink ?? "#1A73E8"
+                    : appearance?.colors?.textSecondary ?? "#67797F",
+            }}
+        >
+            {canResend ? countdownCompleteText : countdownText(seconds)}
+        </button>
+    );
+}

--- a/packages/client/ui/react-ui/src/components/common/CountdownButton.tsx
+++ b/packages/client/ui/react-ui/src/components/common/CountdownButton.tsx
@@ -22,7 +22,7 @@ export function CountdownButton({
     const [retryCount, setRetryCount] = useState(0);
 
     useEffect(() => {
-        let timer: NodeJS.Timeout;
+        let timer: ReturnType<typeof setInterval>;
 
         if (seconds > 0) {
             setCanResend(false);
@@ -38,7 +38,7 @@ export function CountdownButton({
         }
 
         return () => {
-            if (timer) {
+            if (timer != null) {
                 clearInterval(timer);
             }
         };

--- a/packages/client/ui/react-ui/src/components/common/Dialog.tsx
+++ b/packages/client/ui/react-ui/src/components/common/Dialog.tsx
@@ -24,12 +24,12 @@ const DialogContent = React.forwardRef<React.ElementRef<typeof DialogPrimitive.C
                 ref={ref}
                 className={classNames(
                     "fixed z-50 p-6 pb-4 bg-cm-background-primary border border-cm-border shadow-xl transition-none",
-                    // Mobile viewport styles (bottom sheet)
-                    "inset-x-0 bottom-0 w-full border-t rounded-t-xl",
+                    // Mobile viewport styles (bottom sheet) - updated with margins
+                    "inset-x-[9px] bottom-2 w-[calc(100%-18px)] border-t rounded-t-[36px] rounded-b-[50px]",
                     "max-[479px]:data-[state=closed]:animate-slide-out-to-bottom max-[479px]:data-[state=open]:animate-slide-in-from-bottom",
                     // Desktop viewport styles (centered modal)
                     "min-[480px]:inset-auto !min-[480px]:p-10 !min-[480px]:pb-8 min-[480px]:left-[50%] min-[480px]:top-[50%] min-[480px]:translate-x-[-50%] min-[480px]:translate-y-[-52%]",
-                    "min-[480px]:max-w-[448px] min-[480px]:rounded-xl",
+                    "min-[480px]:max-w-[448px] min-[480px]:rounded-3xl",
                     "min-[480px]:data-[state=closed]:animate-fade-out min-[480px]:data-[state=open]:animate-fade-in",
                     className
                 )}
@@ -41,9 +41,9 @@ const DialogContent = React.forwardRef<React.ElementRef<typeof DialogPrimitive.C
                         className={classNames(
                             "absolute rounded-full opacity-70 ring-offset-background transition-opacity hover:opacity-100",
                             "focus:outline-none focus:ring-2 focus:ring-cm-accent focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-text-primary",
-                            "right-4 top-4 !min-[480px]:right-6 !min-[480px]:top-6"
+                            "right-5 top-5 !min-[480px]:right-7 !min-[480px]:top-7"
                         )}
-                        style={{ color: closeButtonColor ?? "#00150D" }}
+                        style={{ color: closeButtonColor ?? "#67797F" }}
                     >
                         <svg
                             xmlns="http://www.w3.org/2000/svg"
@@ -55,7 +55,7 @@ const DialogContent = React.forwardRef<React.ElementRef<typeof DialogPrimitive.C
                             strokeWidth="2"
                             strokeLinecap="round"
                             strokeLinejoin="round"
-                            className="h-6 w-6"
+                            className="h-7 w-7"
                         >
                             <path d="M18 6 6 18" />
                             <path d="m6 6 12 12" />

--- a/packages/client/ui/react-ui/src/components/common/SecuredByCrossmint.tsx
+++ b/packages/client/ui/react-ui/src/components/common/SecuredByCrossmint.tsx
@@ -3,8 +3,8 @@ import { classNames } from "@/utils/classNames";
 
 export function SecuredByCrossmint({ color = "#67797F", className }: { color?: string; className?: string }) {
     return (
-        <p className={classNames("flex", className)}>
+        <div className={classNames("flex", className)}>
             <SecuredByLeaf color={color} />
-        </p>
+        </div>
     );
 }

--- a/packages/client/ui/react-ui/src/hooks/useOAuthWindowListener.ts
+++ b/packages/client/ui/react-ui/src/hooks/useOAuthWindowListener.ts
@@ -34,7 +34,8 @@ export const useOAuthWindowListener = (provider: OAuthProvider) => {
 
         const baseUrl = new URL(oauthUrlMap[provider]);
 
-        // If we have a providerLoginHint, we need to add it to the beginning of the url
+        // The provider_login_hint is a parameter that can be used to pre-fill the email field of the OAuth provider to allow auto-login if session exists.
+        // Stytch Docs: https://stytch.com/docs/api/oauth-google-start#additional-provider-parameters
         if (providerLoginHint != null) {
             // Clear existing params but save them
             const existingParams = Array.from(baseUrl.searchParams.entries());

--- a/packages/client/ui/react-ui/src/hooks/useOAuthWindowListener.ts
+++ b/packages/client/ui/react-ui/src/hooks/useOAuthWindowListener.ts
@@ -25,13 +25,33 @@ export const useOAuthWindowListener = (provider: OAuthProvider) => {
         };
     }, []);
 
-    const createPopupAndSetupListeners = async () => {
+    const createPopupAndSetupListeners = async (providerLoginHint?: string) => {
         if (childRef.current == null) {
             throw new Error("Child window not initialized");
         }
         setIsLoading(true);
         setError(null);
-        const popup = await PopupWindow.init(oauthUrlMap[provider], {
+
+        const baseUrl = new URL(oauthUrlMap[provider]);
+
+        // If we have a providerLoginHint, we need to add it to the beginning of the url
+        if (providerLoginHint != null) {
+            // Clear existing params but save them
+            const existingParams = Array.from(baseUrl.searchParams.entries());
+            baseUrl.search = "";
+
+            // Add provider_login_hint first
+            if (providerLoginHint) {
+                baseUrl.searchParams.append("provider_login_hint", providerLoginHint);
+            }
+
+            // Add all other params after
+            existingParams.forEach(([key, value]) => {
+                baseUrl.searchParams.append(key, value);
+            });
+        }
+
+        const popup = await PopupWindow.init(baseUrl.toString(), {
             awaitToLoad: false,
             crossOrigin: true,
             width: 400,

--- a/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.tsx
@@ -23,6 +23,7 @@ export type LoginMethod = "email" | "google" | "farcaster" | "web3" | "twitter";
 export type CrossmintAuthProviderProps = {
     embeddedWallets?: CrossmintAuthWalletConfig;
     appearance?: UIConfig;
+    termsOfServiceText?: string | ReactNode;
     children: ReactNode;
     loginMethods?: LoginMethod[];
     refreshRoute?: string;
@@ -63,6 +64,7 @@ export function CrossmintAuthProvider({
     embeddedWallets = defaultEmbeddedWallets,
     children,
     appearance,
+    termsOfServiceText,
     loginMethods = ["email", "google"],
     refreshRoute,
     logoutRoute,
@@ -173,6 +175,7 @@ export function CrossmintAuthProvider({
                             appearance,
                             setDialogOpen,
                             loginMethods,
+                            termsOfServiceText,
                             embeddedWallets,
                             baseUrl: crossmintBaseUrl,
                         }}

--- a/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.tsx
@@ -24,6 +24,7 @@ export type CrossmintAuthProviderProps = {
     embeddedWallets?: CrossmintAuthWalletConfig;
     appearance?: UIConfig;
     termsOfServiceText?: string | ReactNode;
+    authModalTitle?: string;
     children: ReactNode;
     loginMethods?: LoginMethod[];
     refreshRoute?: string;
@@ -65,6 +66,7 @@ export function CrossmintAuthProvider({
     children,
     appearance,
     termsOfServiceText,
+    authModalTitle,
     loginMethods = ["email", "google"],
     refreshRoute,
     logoutRoute,
@@ -176,6 +178,7 @@ export function CrossmintAuthProvider({
                             setDialogOpen,
                             loginMethods,
                             termsOfServiceText,
+                            authModalTitle,
                             embeddedWallets,
                             baseUrl: crossmintBaseUrl,
                         }}

--- a/packages/client/ui/react-ui/src/providers/auth/AuthFormProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/auth/AuthFormProvider.tsx
@@ -17,6 +17,7 @@ interface AuthFormContextType {
     error: string | null;
     appearance?: UIConfig;
     termsOfServiceText?: string | ReactNode;
+    authModalTitle?: string;
     loginMethods: LoginMethod[];
     oauthUrlMap: OAuthUrlMap;
     isLoadingOauthUrlMap: boolean;
@@ -29,6 +30,7 @@ interface AuthFormContextType {
 type ContextInitialStateProps = {
     appearance?: UIConfig;
     termsOfServiceText?: string | ReactNode;
+    authModalTitle?: string;
     loginMethods: LoginMethod[];
     baseUrl: string;
     setDialogOpen?: (open: boolean) => void;
@@ -55,7 +57,8 @@ export const AuthFormProvider = ({
     const [oauthUrlMap, setOauthUrlMap] = useState<OAuthUrlMap>(initialOAuthUrlMap);
     const [isLoadingOauthUrlMap, setIsLoadingOauthUrlMap] = useState(true);
 
-    const { loginMethods, baseUrl, setDialogOpen, appearance, embeddedWallets, termsOfServiceText } = initialState;
+    const { loginMethods, baseUrl, setDialogOpen, appearance, embeddedWallets, termsOfServiceText, authModalTitle } =
+        initialState;
 
     if (loginMethods.includes("web3") && embeddedWallets?.createOnLogin === "all-users") {
         throw new Error("Creating wallets on login is not yet supported for web3 login method");
@@ -104,6 +107,7 @@ export const AuthFormProvider = ({
         baseUrl,
         appearance,
         termsOfServiceText,
+        authModalTitle,
         loginMethods,
         oauthUrlMap,
         isLoadingOauthUrlMap,

--- a/packages/client/ui/react-ui/src/providers/auth/AuthFormProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/auth/AuthFormProvider.tsx
@@ -16,6 +16,7 @@ interface AuthFormContextType {
     step: AuthStep;
     error: string | null;
     appearance?: UIConfig;
+    termsOfServiceText?: string | ReactNode;
     loginMethods: LoginMethod[];
     oauthUrlMap: OAuthUrlMap;
     isLoadingOauthUrlMap: boolean;
@@ -27,6 +28,7 @@ interface AuthFormContextType {
 
 type ContextInitialStateProps = {
     appearance?: UIConfig;
+    termsOfServiceText?: string | ReactNode;
     loginMethods: LoginMethod[];
     baseUrl: string;
     setDialogOpen?: (open: boolean) => void;
@@ -53,7 +55,7 @@ export const AuthFormProvider = ({
     const [oauthUrlMap, setOauthUrlMap] = useState<OAuthUrlMap>(initialOAuthUrlMap);
     const [isLoadingOauthUrlMap, setIsLoadingOauthUrlMap] = useState(true);
 
-    const { loginMethods, baseUrl, setDialogOpen, appearance, embeddedWallets } = initialState;
+    const { loginMethods, baseUrl, setDialogOpen, appearance, embeddedWallets, termsOfServiceText } = initialState;
 
     if (loginMethods.includes("web3") && embeddedWallets?.createOnLogin === "all-users") {
         throw new Error("Creating wallets on login is not yet supported for web3 login method");
@@ -101,6 +103,7 @@ export const AuthFormProvider = ({
         error,
         baseUrl,
         appearance,
+        termsOfServiceText,
         loginMethods,
         oauthUrlMap,
         isLoadingOauthUrlMap,

--- a/packages/client/ui/react-ui/src/twind.config.ts
+++ b/packages/client/ui/react-ui/src/twind.config.ts
@@ -93,15 +93,6 @@ export default defineConfig({
     },
     rules: [
         [
-            "cm-responsive-border-radius-auth-dialog",
-            {
-                "@media (max-width: 479px)": {
-                    "border-bottom-left-radius": "0 !important",
-                    "border-bottom-right-radius": "0 !important",
-                },
-            },
-        ],
-        [
             "focus-ring-custom",
             {
                 "&:focus": {

--- a/packages/client/ui/react-ui/src/twind.config.ts
+++ b/packages/client/ui/react-ui/src/twind.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
                 "cm-muted-primary": "#F0F2F4",
                 "cm-hover": "#E9ECF0",
                 "cm-border": "#D9D9D9",
-                "cm-link": "#1A73E8",
+                "cm-link": "#1A74E9",
                 "cm-accent": "#04AA6D",
             },
             keyframes: {


### PR DESCRIPTION
## Description

This pr contains all of the changes from our design UI

![Screenshot 2025-02-13 at 1 25 34 PM](https://github.com/user-attachments/assets/0eafaad6-3f54-4dd4-bcc4-190b06e1e2c0)

![Screenshot 2025-02-13 at 1 25 56 PM](https://github.com/user-attachments/assets/654b9da7-564e-4cd3-ad5a-4fd83f968e92)

![Screenshot 2025-02-13 at 8 13 41 PM](https://github.com/user-attachments/assets/1c6fafd0-358a-40e7-b9c0-03b12e3e1fb2)

### Features

- new feel 
- new prop exposed called `termsOfServiceText` that can pass a string or reactnode with links nested
- new prop exposed: `authModalTitle` that allows the title of the modal to be changed
- email input shows a "Continue" button that logs you in with google if you use a `gmail.com` domain
  - plus, if your already authenticated in the same browser, it'll auto sign in

## Test plan

- built and tested with yalc
- customized appearance object styles
- exhausted a lot of manual testing 

## Package updates

@crossmint/client-sdk-react-ui