### PR TITLE
Auth: Prevent /start calls when logged in

### DIFF
--- a/.changeset/eleven-sloths-carry.md
+++ b/.changeset/eleven-sloths-carry.md
@@ -2,4 +2,4 @@
 "@crossmint/client-sdk-react-ui": patch
 ---
 
-Prevent unecessary calls to API when user logged in
+Prevent unnecessary calls to API when user is logged in

--- a/.changeset/eleven-sloths-carry.md
+++ b/.changeset/eleven-sloths-carry.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+---
+
+Prevent unecessary calls to API when user logged in

--- a/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.test.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.test.tsx
@@ -61,15 +61,15 @@ function renderAuthProvider({
 function TestComponent() {
     const { setJwt } = useCrossmint();
     const { wallet, status: walletStatus, error } = useWallet();
-    const { status: authStatus } = useAuth();
+    const { status: authStatus, jwt } = useAuth();
     return (
         <div>
             <div data-testid="error">{error?.message ?? "No Error"}</div>
             <div data-testid="wallet-status">{walletStatus}</div>
             <div data-testid="auth-status">{authStatus}</div>
             <div data-testid="wallet">{wallet ? "Wallet Loaded" : "No Wallet"}</div>
-
-            <button data-testid="jwt-input" onClick={() => setJwt("mock-jwt")}>
+            <div data-testid="auth-jwt">{jwt}</div>
+            <button data-testid="auth-jwt-input" onClick={() => setJwt("mock-jwt")}>
                 Set JWT
             </button>
             <button data-testid="clear-jwt-button" onClick={() => setJwt(undefined)}>
@@ -140,6 +140,23 @@ describe("CrossmintAuthProvider", () => {
         vi.spyOn(CrossmintAuthClient, "from").mockReturnValue(mockCrossmintAuth);
     });
 
+    it("When user is logged out", async () => {
+        const { getByTestId } = renderAuthProvider({
+            children: <TestComponent />,
+            embeddedWallets,
+        });
+
+        expect(getByTestId("auth-status").textContent).toBe("logged-out");
+        expect(getByTestId("auth-jwt").textContent).toBe("");
+        await waitFor(() => {
+            expect(getByTestId("auth-status").textContent).toBe("logged-out");
+        });
+
+        expect(handleRefreshAuthMaterialSpy).toHaveBeenCalled();
+        expect(getOAuthUrlSpy).toHaveBeenCalled();
+        expect(vi.mocked(mockSDK.getOrCreateWallet)).not.toHaveBeenCalled();
+    });
+
     it("Happy path", async () => {
         await act(() => {
             document.cookie = `${REFRESH_TOKEN_PREFIX}=mock-refresh-token; path=/; SameSite=Lax;`;
@@ -163,8 +180,8 @@ describe("CrossmintAuthProvider", () => {
             expect(getByTestId("error").textContent).toBe("No Error");
         });
 
-        expect(handleRefreshAuthMaterialSpy).toHaveBeenCalledOnce();
-        expect(getOAuthUrlSpy).toHaveBeenCalled();
+        expect(handleRefreshAuthMaterialSpy).not.toHaveBeenCalled();
+        expect(getOAuthUrlSpy).not.toHaveBeenCalled();
         expect(vi.mocked(mockSDK.getOrCreateWallet)).toHaveBeenCalledOnce();
     });
 
@@ -236,7 +253,7 @@ describe("CrossmintAuthProvider", () => {
             expect(getByTestId("auth-status").textContent).toBe("logged-out");
         });
 
-        fireEvent.click(getByTestId("jwt-input"));
+        fireEvent.click(getByTestId("auth-jwt-input"));
 
         await waitFor(() => {
             expect(getByTestId("auth-status").textContent).toBe("logged-in");

--- a/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.tsx
@@ -173,6 +173,7 @@ export function CrossmintAuthProvider({
                     appearance={appearance}
                 >
                     <AuthFormProvider
+                        preFetchOAuthUrls={getAuthStatus() === "logged-out"}
                         initialState={{
                             appearance,
                             setDialogOpen,

--- a/packages/client/ui/react-ui/src/providers/auth/AuthFormProvider.test.tsx
+++ b/packages/client/ui/react-ui/src/providers/auth/AuthFormProvider.test.tsx
@@ -61,7 +61,7 @@ describe("AuthFormProvider", () => {
 
     it("provides initial context values and fetches OAuth URLs", async () => {
         const { getByTestId } = render(
-            <AuthFormProvider initialState={mockInitialState}>
+            <AuthFormProvider initialState={mockInitialState} preFetchOAuthUrls={true}>
                 <TestComponent />
             </AuthFormProvider>
         );
@@ -81,7 +81,7 @@ describe("AuthFormProvider", () => {
 
     it("updates step", () => {
         const { getByTestId } = render(
-            <AuthFormProvider initialState={mockInitialState}>
+            <AuthFormProvider initialState={mockInitialState} preFetchOAuthUrls={true}>
                 <TestComponent />
             </AuthFormProvider>
         );
@@ -92,7 +92,7 @@ describe("AuthFormProvider", () => {
 
     it("calls setDialogOpen", () => {
         const { getByTestId } = render(
-            <AuthFormProvider initialState={mockInitialState}>
+            <AuthFormProvider initialState={mockInitialState} preFetchOAuthUrls={true}>
                 <TestComponent />
             </AuthFormProvider>
         );
@@ -105,7 +105,7 @@ describe("AuthFormProvider", () => {
         vi.mocked(mockedGetOAuthUrl).mockRejectedValue(new Error("Fetch failed"));
 
         const { getByTestId } = render(
-            <AuthFormProvider initialState={mockInitialState}>
+            <AuthFormProvider initialState={mockInitialState} preFetchOAuthUrls={true}>
                 <TestComponent />
             </AuthFormProvider>
         );
@@ -129,7 +129,7 @@ describe("AuthFormProvider", () => {
 
         expect(() =>
             render(
-                <AuthFormProvider initialState={invalidState}>
+                <AuthFormProvider initialState={invalidState} preFetchOAuthUrls={true}>
                     <TestComponent />
                 </AuthFormProvider>
             )

--- a/packages/client/ui/react-ui/src/providers/auth/AuthFormProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/auth/AuthFormProvider.tsx
@@ -37,6 +37,12 @@ type ContextInitialStateProps = {
     embeddedWallets: CrossmintAuthWalletConfig;
 };
 
+type AuthFormProviderProps = {
+    preFetchOAuthUrls: boolean;
+    initialState: ContextInitialStateProps;
+    children: ReactNode;
+};
+
 const AuthFormContext = createContext<AuthFormContextType | undefined>(undefined);
 
 export const useAuthForm = () => {
@@ -47,10 +53,7 @@ export const useAuthForm = () => {
     return context;
 };
 
-export const AuthFormProvider = ({
-    children,
-    initialState,
-}: { children: ReactNode; initialState: ContextInitialStateProps }) => {
+export const AuthFormProvider = ({ preFetchOAuthUrls, initialState, children }: AuthFormProviderProps) => {
     const { crossmintAuth } = useCrossmintAuth();
     const [step, setStep] = useState<AuthStep>("initial");
     const [error, setError] = useState<string | null>(null);
@@ -90,8 +93,11 @@ export const AuthFormProvider = ({
     }, [loginMethods, crossmintAuth]);
 
     useEffect(() => {
-        preFetchAndSetOauthUrl();
-    }, [preFetchAndSetOauthUrl]);
+        // Only pre-fetch oauth urls if the user is not logged in
+        if (preFetchOAuthUrls) {
+            preFetchAndSetOauthUrl();
+        }
+    }, [preFetchAndSetOauthUrl, preFetchOAuthUrls]);
 
     const handleToggleDialog = (open: boolean) => {
         setDialogOpen?.(open);


### PR DESCRIPTION
## Description

Changes prevent /start endpoint to be called unless they are logged out

## Test plan

Tested and /start calls weren't made when user was logged in or logging in. 

## Package updates

@crossmint/client-sdk-react-ui