### PR TITLE
auth: allow local jwks

### DIFF
--- a/.changeset/lucky-trains-rush.md
+++ b/.changeset/lucky-trains-rush.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/server-sdk": patch
+---
+
+auth: allow local jwks

--- a/packages/server/src/auth/CrossmintAuthServer.ts
+++ b/packages/server/src/auth/CrossmintAuthServer.ts
@@ -21,6 +21,7 @@ import {
 } from "./types/request";
 import { getAuthCookies, setAuthCookies } from "./utils/cookies";
 import { verifyCrossmintJwt } from "./utils/jwt";
+import type { JSONWebKeySet } from "jose";
 
 export type CrossmintAuthServerOptions = CrossmintAuthOptions & {
     cookieOptions?: CookieOptions;
@@ -126,7 +127,10 @@ export class CrossmintAuthServer extends CrossmintAuth {
         }
     }
 
-    public verifyCrossmintJwt(token: string) {
+    public verifyCrossmintJwt(token: string, jwks?: JSONWebKeySet) {
+        if (jwks != null) {
+            return verifyCrossmintJwt(token, jwks);
+        }
         return verifyCrossmintJwt(token, this.getJwksUri());
     }
 


### PR DESCRIPTION
## Description

allow local jwks, to skip remote fetch

## Test plan

<!--
  Example:
   * Unit tests which cover functionality X, Y, Z
   * V was tested via UI tests
   * W was tested manually
-->

## Package updates

<!-- 
  List any package updates and ensure you've added the necessary changesets, running `pnpm change:add` to do so.
-->