### PR TITLE
Jonathan/fix continue with google btn

### DIFF
--- a/.changeset/early-ghosts-flow.md
+++ b/.changeset/early-ghosts-flow.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+---
+
+Fix dont show continue with google btn if contains plus

--- a/packages/client/ui/react-ui/src/components/auth/methods/email/EmailSignIn.tsx
+++ b/packages/client/ui/react-ui/src/components/auth/methods/email/EmailSignIn.tsx
@@ -18,8 +18,16 @@ export function EmailSignIn({ setOtpEmailData }: { setOtpEmailData: (data: OtpEm
     const [emailError, setEmailError] = useState("");
     const [isLoading, setIsLoading] = useState(false);
 
+    /** Continue with google button will only show under the following conditions:
+     * 1. Email is a gmail address
+     * 2. Email DOES NOT contain a "+" character
+     * 3. Email is valid
+     */
     const showGoogleContinueButton =
-        emailInput.toLowerCase().includes("@gmail.com") && isEmailValid(emailInput) && !isLoading;
+        emailInput.toLowerCase().includes("@gmail.com") &&
+        !emailInput.toLowerCase().includes("+") &&
+        isEmailValid(emailInput) &&
+        !isLoading;
 
     async function handleOnSubmit(e: FormEvent<HTMLFormElement>) {
         e.preventDefault();


### PR DESCRIPTION
## Description

update logic to show "Continue" google button.

addendum to logic for not showing google button if email contains a plus
 
## Test plan

tested manually and worked as expected

## Package updates

@crossmint/client-sdk-react-ui