### PR TITLE
EmbeddedAuthForm: fix Google icon size on initial page load

### DIFF
--- a/.changeset/late-moons-study.md
+++ b/.changeset/late-moons-study.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+---
+
+EmbeddedAuthForm: Fix google icon size initial render

--- a/packages/client/ui/react-ui/src/icons/google.tsx
+++ b/packages/client/ui/react-ui/src/icons/google.tsx
@@ -1,12 +1,12 @@
 export function GoogleIcon({ className }: { className?: string }) {
     return (
         <svg
-            xmlns="http://www.w3.org/2000/svg"
+            width="25"
+            height="25"
             x="0px"
             y="0px"
-            width="100"
-            height="100"
             viewBox="0 0 48 48"
+            xmlns="http://www.w3.org/2000/svg"
             className={className}
         >
             <path


### PR DESCRIPTION
## Description

the initial render of the embedded auth form creates a massively jarring experience 

closes issue: https://linear.app/crossmint/issue/WAL-3702/visual-bug-initial-rendering-icon-size-embeddedauthform

## Test plan

built pckg/app and tested, icon was regular size on initial render

## Package updates

@crossmint/client-sdk-react-ui