### PR TITLE
Smart Wallet React SDK: fix wallet persistence & passkey prompts

### DIFF
--- a/.changeset/smooth-chairs-wash.md
+++ b/.changeset/smooth-chairs-wash.md
@@ -1,0 +1,6 @@
+---
+"@crossmint/client-sdk-smart-wallet": minor
+"@crossmint/client-sdk-react-ui": patch
+---
+
+fixed passkey prompts and wallet persistence

--- a/packages/client/ui/react-ui/package.json
+++ b/packages/client/ui/react-ui/package.json
@@ -42,6 +42,7 @@
         "color": "4.2.3",
         "input-otp": "1.2.4",
         "lodash.isequal": "4.5.0",
+        "ox": "0.6.9",
         "react-jss": "10.10.0",
         "tailwind-merge": "2.4.0",
         "tailwindcss": "3.4.10",
@@ -49,12 +50,12 @@
         "zod": "3.22.4"
     },
     "devDependencies": {
-        "pino-pretty": "^7.6.0",
         "@testing-library/react": "^16.0.1",
         "@types/color": "4.2.0",
         "@types/lodash.isequal": "4.5.6",
         "@types/react": "^18.3.0",
         "@types/react-dom": "^18.3.0",
+        "pino-pretty": "^7.6.0",
         "react": "^18.3.0",
         "react-dom": "^18.3.0"
     },

--- a/packages/client/ui/react-ui/src/hooks/index.ts
+++ b/packages/client/ui/react-ui/src/hooks/index.ts
@@ -2,3 +2,4 @@ export * from "./useCrossmint";
 export * from "./useCrossmintCheckout";
 export * from "./useWallet";
 export * from "./useAuth";
+export * from "./useWalletCache";

--- a/packages/client/ui/react-ui/src/hooks/useWalletCache.ts
+++ b/packages/client/ui/react-ui/src/hooks/useWalletCache.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import type { Address } from "viem";
 import type { WebAuthnP256 } from "ox";
 import type { PasskeySigner } from "@crossmint/client-sdk-smart-wallet";
@@ -42,10 +42,6 @@ export function useWalletCache(userId: string | undefined) {
         [userId]
     );
 
-    const getWalletAddress = useCallback((): Address | undefined => {
-        return getCache()?.wallet?.address;
-    }, [getCache]);
-
     const setWalletAddress = useCallback(
         (address: Address) => {
             const currentCache = getCache() || {};
@@ -60,7 +56,7 @@ export function useWalletCache(userId: string | undefined) {
         [getCache, setCache]
     );
 
-    const isWalletInitialized = useCallback((): boolean => {
+    const isWalletInitialized = useMemo((): boolean => {
         const cache = getCache();
         if (cache == null) {
             return false;
@@ -85,7 +81,7 @@ export function useWalletCache(userId: string | undefined) {
         [getCache, setCache]
     );
 
-    const getPasskey = useCallback((): PasskeySigner | undefined => {
+    const passkey = useMemo(() => {
         const cache = getCache();
         if (cache === null || cache.passkey === undefined) {
             return undefined;
@@ -122,11 +118,10 @@ export function useWalletCache(userId: string | undefined) {
     );
 
     return {
-        getWalletAddress,
         setWalletAddress,
         isWalletInitialized,
         setWalletInitialized,
-        getPasskey,
+        passkey,
         setPasskey,
     };
 }

--- a/packages/client/ui/react-ui/src/hooks/useWalletCache.ts
+++ b/packages/client/ui/react-ui/src/hooks/useWalletCache.ts
@@ -1,0 +1,132 @@
+import { useCallback } from "react";
+import type { Address } from "viem";
+import type { WebAuthnP256 } from "ox";
+import type { PasskeySigner } from "@crossmint/client-sdk-smart-wallet";
+
+type WalletCache = {
+    wallet?: {
+        address: Address;
+        initialized?: boolean;
+    };
+    passkey?: {
+        authenticatorId: string;
+        domain: string;
+        passkeyName: string;
+        pubKeyPrefix: number;
+        pubKeyX: string;
+        pubKeyY: string;
+    };
+};
+
+export function useWalletCache(userId: string | undefined) {
+    const getCache = useCallback((): WalletCache | null => {
+        if (userId == undefined) {
+            return null;
+        }
+        const key = `smart-wallet-${userId}`;
+        const cache = localStorage.getItem(key);
+        if (cache == null) {
+            return null;
+        }
+        return JSON.parse(cache) as WalletCache;
+    }, [userId]);
+
+    const setCache = useCallback(
+        (newCache: WalletCache) => {
+            if (userId == undefined) {
+                return;
+            }
+            const key = `smart-wallet-${userId}`;
+            localStorage.setItem(key, JSON.stringify(newCache));
+        },
+        [userId]
+    );
+
+    const getWalletAddress = useCallback((): Address | undefined => {
+        return getCache()?.wallet?.address;
+    }, [getCache]);
+
+    const setWalletAddress = useCallback(
+        (address: Address) => {
+            const currentCache = getCache() || {};
+            setCache({
+                ...currentCache,
+                wallet: {
+                    ...currentCache.wallet,
+                    address,
+                },
+            });
+        },
+        [getCache, setCache]
+    );
+
+    const isWalletInitialized = useCallback((): boolean => {
+        const cache = getCache();
+        if (cache == null) {
+            return false;
+        }
+        return cache.wallet?.initialized ?? false;
+    }, [getCache]);
+
+    const setWalletInitialized = useCallback(
+        (initialized: boolean) => {
+            const currentCache = getCache();
+            if (currentCache === null || currentCache.wallet === undefined) {
+                return;
+            }
+            setCache({
+                ...currentCache,
+                wallet: {
+                    ...currentCache.wallet,
+                    initialized,
+                },
+            });
+        },
+        [getCache, setCache]
+    );
+
+    const getPasskey = useCallback((): PasskeySigner | undefined => {
+        const cache = getCache();
+        if (cache === null || cache.passkey === undefined) {
+            return undefined;
+        }
+        return {
+            type: "PASSKEY",
+            credential: {
+                id: cache.passkey.authenticatorId,
+                publicKey: {
+                    prefix: cache.passkey.pubKeyPrefix,
+                    x: BigInt(cache.passkey.pubKeyX),
+                    y: BigInt(cache.passkey.pubKeyY),
+                },
+            } as WebAuthnP256.P256Credential,
+        } as PasskeySigner;
+    }, [getCache]);
+
+    const setPasskey = useCallback(
+        (passkeySigner: PasskeySigner) => {
+            const currentCache = getCache() || {};
+            setCache({
+                ...currentCache,
+                passkey: {
+                    authenticatorId: passkeySigner.credential.id,
+                    domain: "localhost",
+                    passkeyName: "Crossmint Wallet",
+                    pubKeyPrefix: passkeySigner.credential.publicKey.prefix,
+                    pubKeyX: passkeySigner.credential.publicKey.x.toString(),
+                    pubKeyY: passkeySigner.credential.publicKey.y.toString(),
+                },
+            });
+        },
+        [getCache, setCache]
+    );
+
+    return {
+        getWalletAddress,
+        setWalletAddress,
+        isWalletInitialized,
+        setWalletInitialized,
+        getPasskey,
+        setPasskey,
+    };
+}

--- a/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.test.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.test.tsx
@@ -197,7 +197,7 @@ describe("CrossmintAuthProvider", () => {
             expect(getByTestId("error").textContent).toBe("No Error");
         });
 
-        // expect(handleRefreshAuthMaterialSpy).not.toHaveBeenCalled();
+        expect(handleRefreshAuthMaterialSpy).not.toHaveBeenCalled();
         expect(getOAuthUrlSpy).not.toHaveBeenCalled();
         expect(vi.mocked(mockSDK.getOrCreateWallet)).toHaveBeenCalledOnce();
     });

--- a/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.test.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.test.tsx
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, vi, it, type MockInstance } from "vitest"
 import { mock } from "vitest-mock-extended";
 
 import { CrossmintAuth as CrossmintAuthClient, getJWTExpiration, deleteCookie } from "@crossmint/client-sdk-auth";
-import { type EVMSmartWallet, SmartWalletSDK } from "@crossmint/client-sdk-smart-wallet";
+import { type EVMSmartWallet, type PasskeySigner, SmartWalletSDK } from "@crossmint/client-sdk-smart-wallet";
 import { createCrossmint } from "@crossmint/common-sdk-base";
 
 import { useAuth, useWallet } from "../hooks";
@@ -82,6 +82,7 @@ function TestComponent() {
 describe("CrossmintAuthProvider", () => {
     let mockSDK: SmartWalletSDK;
     let mockWallet: EVMSmartWallet;
+    let mockPasskeySigner: PasskeySigner;
     let embeddedWallets: CrossmintAuthWalletConfig;
     let handleRefreshAuthMaterialSpy: MockInstance;
     let getOAuthUrlSpy: MockInstance;
@@ -113,14 +114,27 @@ describe("CrossmintAuthProvider", () => {
 
         mockSDK = mock<SmartWalletSDK>();
         mockWallet = mock<EVMSmartWallet>();
+        mockPasskeySigner = mock<PasskeySigner>({
+            type: "PASSKEY",
+            credential: {
+                id: "mock-credential-id",
+                publicKey: {
+                    prefix: 1,
+                    x: BigInt(1),
+                    y: BigInt(2),
+                },
+            },
+        });
         vi.mocked(SmartWalletSDK.init).mockReturnValue(mockSDK);
         vi.mocked(mockSDK.getOrCreateWallet).mockResolvedValue(mockWallet);
+        vi.mocked(mockSDK.createPasskeySigner).mockResolvedValue(mockPasskeySigner);
         vi.mocked(getJWTExpiration).mockReturnValue(1000);
 
         embeddedWallets = {
             defaultChain: "polygon",
             createOnLogin: "all-users",
             type: "evm-smart-wallet",
+            showPasskeyHelpers: false,
         };
 
         deleteCookie(REFRESH_TOKEN_PREFIX);

--- a/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.test.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.test.tsx
@@ -3,7 +3,12 @@ import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import { type EVMSmartWallet, SmartWalletError, SmartWalletSDK } from "@crossmint/client-sdk-smart-wallet";
+import {
+    type EVMSmartWallet,
+    type PasskeySigner,
+    SmartWalletError,
+    SmartWalletSDK,
+} from "@crossmint/client-sdk-smart-wallet";
 import { createCrossmint } from "@crossmint/common-sdk-base";
 
 import { CrossmintProvider, useCrossmint } from "../hooks/useCrossmint";
@@ -40,7 +45,9 @@ vi.mock("../hooks/useCrossmint", async () => {
 function renderWalletProvider({ children }: { children: ReactNode }) {
     return render(
         <CrossmintProvider apiKey={MOCK_API_KEY}>
-            <CrossmintWalletProvider defaultChain="polygon-amoy">{children}</CrossmintWalletProvider>
+            <CrossmintWalletProvider defaultChain="polygon-amoy" showPasskeyHelpers={false}>
+                {children}
+            </CrossmintWalletProvider>
         </CrossmintProvider>
     );
 }
@@ -66,7 +73,7 @@ function TestComponent() {
 describe("CrossmintWalletProvider", () => {
     let mockSDK: SmartWalletSDK;
     let mockWallet: EVMSmartWallet;
-
+    let mockPasskeySigner: PasskeySigner;
     beforeEach(() => {
         vi.resetAllMocks();
         vi.mocked(createCrossmint).mockImplementation(() => ({}) as any);
@@ -80,8 +87,20 @@ describe("CrossmintWalletProvider", () => {
 
         mockSDK = mock<SmartWalletSDK>();
         mockWallet = mock<EVMSmartWallet>();
+        mockPasskeySigner = mock<PasskeySigner>({
+            type: "PASSKEY",
+            credential: {
+                id: "mock-credential-id",
+                publicKey: {
+                    prefix: 1,
+                    x: BigInt(1),
+                    y: BigInt(2),
+                },
+            },
+        });
         vi.mocked(SmartWalletSDK.init).mockReturnValue(mockSDK);
         vi.mocked(mockSDK.getOrCreateWallet).mockResolvedValue(mockWallet);
+        vi.mocked(mockSDK.createPasskeySigner).mockResolvedValue(mockPasskeySigner);
     });
 
     describe("getOrCreateWallet", () => {

--- a/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
@@ -76,13 +76,11 @@ export function CrossmintWalletProvider({
     const [walletState, setWalletState] = useState<ValidWalletState>({
         status: "not-loaded",
     });
-    const [passkeySigner, setPasskeySigner] = useState<PasskeySigner | undefined>(undefined);
     const [passkeyPromptState, setPasskeyPromptState] = useState<PasskeyPromptState>({ open: false });
 
     const createPasskeySigner = async (name: string) => {
         await createPasskeyPrompt("create-wallet")();
         const signer = await smartWalletSDK.createPasskeySigner(name);
-        setPasskeySigner(signer);
         walletCache.setPasskey(signer);
         return signer;
     };
@@ -177,7 +175,6 @@ export function CrossmintWalletProvider({
                 ...walletState,
                 getOrCreateWallet,
                 createPasskeySigner,
-                passkeySigner,
                 clearWallet,
             }}
         >

--- a/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
@@ -77,6 +77,7 @@ export type WalletConfig = WalletParams & { type: "evm-smart-wallet" };
 export function CrossmintWalletProvider({
     children,
     defaultChain,
+    showPasskeyHelpers = true,
     appearance,
 }: {
     children: ReactNode;
@@ -102,6 +103,7 @@ export function CrossmintWalletProvider({
     };
 
     const getOrCreateWallet = async (config?: WalletConfig) => {
+        console.log("getOrCreateWallet 1", config);
         if (walletState.status == "in-progress") {
             console.log("Wallet already loading");
             return {
@@ -156,6 +158,10 @@ export function CrossmintWalletProvider({
 
     const createPasskeyPrompt = (type: ValidPasskeyPromptType) => () =>
         new Promise<void>((resolve) => {
+            if (!showPasskeyHelpers) {
+                resolve();
+                return;
+            }
             setPasskeyPromptState({
                 type,
                 open: true,

--- a/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
@@ -113,7 +113,7 @@ export function CrossmintWalletProvider({
                 {
                     onWalletCreationFailed: createPasskeyPrompt("create-wallet-error"),
                     onTransactionSigningStarted: () => {
-                        if (walletCache.isWalletInitialized()) {
+                        if (walletCache.isWalletInitialized) {
                             return Promise.resolve();
                         }
                         return createPasskeyPrompt("transaction")();
@@ -159,7 +159,7 @@ export function CrossmintWalletProvider({
     };
 
     const getPasskeySigner = async () => {
-        const cachedPasskey = walletCache.getPasskey();
+        const cachedPasskey = walletCache.passkey;
         if (cachedPasskey === undefined) {
             // Create a new passkey
             const passkeyName = "Crossmint Wallet";

--- a/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
@@ -103,7 +103,6 @@ export function CrossmintWalletProvider({
     };
 
     const getOrCreateWallet = async (config?: WalletConfig) => {
-        console.log("getOrCreateWallet 1", config);
         if (walletState.status == "in-progress") {
             console.log("Wallet already loading");
             return {

--- a/packages/client/wallets/smart-wallet/src/evm/smartWalletClient.ts
+++ b/packages/client/wallets/smart-wallet/src/evm/smartWalletClient.ts
@@ -27,6 +27,12 @@ import type {
     TransactionNotFoundError,
 } from "@/error";
 
+export interface Transaction {
+    to: Address;
+    data?: Hex;
+    value?: bigint;
+}
+
 export interface SmartWalletClient {
     /**
      * Retrieves the address of the smart wallet.

--- a/packages/client/wallets/smart-wallet/src/index.ts
+++ b/packages/client/wallets/smart-wallet/src/index.ts
@@ -4,6 +4,7 @@ export {
 } from "@crossmint/common-sdk-base";
 
 // Types
+export type { Transaction } from "./evm/smartWalletClient";
 export type {
     Callbacks,
     ViemAccount,

--- a/packages/client/wallets/smart-wallet/src/index.ts
+++ b/packages/client/wallets/smart-wallet/src/index.ts
@@ -5,6 +5,7 @@ export {
 
 // Types
 export type {
+    Callbacks,
     ViemAccount,
     PasskeySigner,
     ExternalSigner,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -640,6 +640,9 @@ importers:
       lodash.isequal:
         specifier: 4.5.0
         version: 4.5.0
+      ox:
+        specifier: 0.6.9
+        version: 0.6.9(typescript@5.5.3)(zod@3.22.4)
       react-jss:
         specifier: 10.10.0
         version: 10.10.0(react@18.3.1)


### PR DESCRIPTION
## Description

Fixes `@crossmint/client-sdk-react-ui` by storing the wallet state in LocalStorage. Also uses newly added wallet action callbacks from `@crossmint/client-sdk-smart-wallet` to render passkey prompts.

Passkey callbacks and wallet persistence were removed from `@crossmint/client-sdk-smart-wallet` in #966 to reduce its scope. Removing that from the TS SDK was intentional, but this broke some of the functionality in React SDK.

This PR ports that functionality into the React SDK. This makes the passkey prompts being rendered again, and persists the wallet state across browser sessions.

## Test plan

* CI passes
* Lack of breaking changes
* Using React SDK should persist the wallet state and render the prompt
  * Can test by running the `apps/wallets/smart-wallet/next` playground app

## Package updates

```
"@crossmint/client-sdk-smart-wallet": minor
"@crossmint/client-sdk-react-ui": patch
```