### PR TITLE
Wallets SDK: Small Fixes

### DIFF
--- a/.changeset/shaggy-garlics-decide.md
+++ b/.changeset/shaggy-garlics-decide.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+general bug fixes

--- a/packages/wallets/src/api/client.ts
+++ b/packages/wallets/src/api/client.ts
@@ -168,8 +168,8 @@ class ApiClient extends CrossmintApiClient {
     async getNfts(
         chain: string,
         walletLocator: WalletLocator,
-        page: number,
-        perPage: number
+        perPage: number,
+        page: number
     ): Promise<GetNftsResponse> {
         const queryParams = new URLSearchParams();
         queryParams.append("page", page.toString());

--- a/packages/wallets/src/evm/utils.ts
+++ b/packages/wallets/src/evm/utils.ts
@@ -23,7 +23,7 @@ export function getEvmAdminSigner(
             return {
                 type: "evm-passkey",
                 id: responseSigner.id,
-                name: input.name,
+                name: input?.name ?? responseSigner.name,
                 locator: responseSigner.locator,
             };
     }

--- a/packages/wallets/src/solana/wallet.ts
+++ b/packages/wallets/src/solana/wallet.ts
@@ -67,8 +67,13 @@ abstract class SolanaWallet {
     public async transactions(): Promise<GetTransactionsResponse> {
         return await this.transactionsService.getTransactions();
     }
-    public async nfts(perPage: number, page: number, chain: string): Promise<GetNftsResponse> {
-        return await this.apiClient.getNfts(chain, this.walletLocator, perPage, page);
+    public async nfts(
+        perPage: number,
+        page: number,
+        chain?: string,
+        locator?: SolanaWalletLocator
+    ): Promise<GetNftsResponse> {
+        return await this.apiClient.getNfts(chain ?? "solana", locator ?? this.walletLocator, perPage, page);
     }
 
     protected get walletLocator(): SolanaWalletLocator {

--- a/packages/wallets/src/solana/wallet.ts
+++ b/packages/wallets/src/solana/wallet.ts
@@ -67,13 +67,8 @@ abstract class SolanaWallet {
     public async transactions(): Promise<GetTransactionsResponse> {
         return await this.transactionsService.getTransactions();
     }
-    public async nfts(
-        perPage: number,
-        page: number,
-        chain?: string,
-        locator?: SolanaWalletLocator
-    ): Promise<GetNftsResponse> {
-        return await this.apiClient.getNfts(chain ?? "solana", locator ?? this.walletLocator, perPage, page);
+    public async nfts(perPage: number, page: number, locator?: SolanaWalletLocator): Promise<GetNftsResponse> {
+        return await this.apiClient.getNfts("solana", locator ?? this.walletLocator, perPage, page);
     }
 
     protected get walletLocator(): SolanaWalletLocator {


### PR DESCRIPTION
## Description

PR fixes the following: 
- passing the adminSigner.name or fallback to existing
- nfts method - the pagination params order was incorrect
- fixes nfts method for solana
- renamed `createWallet` to `getOrCreateWalletInternal`
- only call onWalletCreationStart callback when actually creating a wallet

## Test plan

wallets-sdk works as expected without errors regarding signing, wallet.nfts(...), or wallet creation passkey prompts

## Package updates

@crossmint/wallets-sdk