### PR TITLE
Wallets SDK: fix code gen script

### DIFF
--- a/.changeset/shy-trains-leave.md
+++ b/.changeset/shy-trains-leave.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+fixed codegen script

--- a/packages/wallets/package.json
+++ b/packages/wallets/package.json
@@ -15,7 +15,7 @@
     "types": "./dist/index.d.ts",
     "files": ["dist", "LICENSE"],
     "scripts": {
-        "build": "tsup && pnpm generate",
+        "build": "pnpm generate && tsup",
         "dev": "tsup --watch",
         "test:vitest": "vitest run",
         "openapi-ts": "openapi-ts",

--- a/packages/wallets/package.json
+++ b/packages/wallets/package.json
@@ -15,11 +15,11 @@
     "types": "./dist/index.d.ts",
     "files": ["dist", "LICENSE"],
     "scripts": {
-        "build": "tsup",
+        "build": "tsup && pnpm generate",
         "dev": "tsup --watch",
         "test:vitest": "vitest run",
-        "generate": "pnpm dlx @hey-api/openapi-ts",
-        "postinstall": "pnpm generate"
+        "openapi-ts": "openapi-ts",
+        "generate": "pnpm run openapi-ts"
     },
     "dependencies": {
         "@crossmint/common-sdk-auth": "workspace:*",


### PR DESCRIPTION
## Description

Fix our build script to run the code generation stuff rather than postinstall (which gets triggered in ANY subsequent projects using the sdk)

Error from attempting to run `pnpm i` in our smarter wallets demo repo
![Screenshot 2025-03-20 at 2 12 08 PM](https://github.com/user-attachments/assets/50b16b9c-7872-41cd-bfba-af53b78cbfcd)

## Test plan

ensure original intent of generating codegen still works and that this doesn't cause side effects

## Package updates

@crossmint/wallets-sdk