### PR TITLE
docs: fix typo in Wallets SDK

### DIFF
--- a/packages/wallets/README.md
+++ b/packages/wallets/README.md
@@ -55,7 +55,7 @@ const wallet = await crossmintWallets.getOrCreateWallet("solana-smart-wallet", {
 });
 ```
 
-#### MCP Wallets
+#### MPC Wallets
 
 ```ts
 const wallet = await crossmintWallets.getOrCreateWallet("solana-mpc-wallet", {


### PR DESCRIPTION
## Description

Fix `MCP Wallets` → `MPC Wallets` typo in README

## Test plan

* CI
* No more typos