### PR TITLE
Tailwind styles: Disable preflight fix style override

### DIFF
--- a/.changeset/big-bulldogs-prove.md
+++ b/.changeset/big-bulldogs-prove.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+---
+
+Tailwind styles: Disable preflight fix style override

--- a/packages/client/ui/react-ui/src/components/common/Dialog.tsx
+++ b/packages/client/ui/react-ui/src/components/common/Dialog.tsx
@@ -28,8 +28,9 @@ const DialogContent = React.forwardRef<React.ElementRef<typeof DialogPrimitive.C
                     "inset-x-[9px] bottom-2 w-[calc(100%-18px)] border-t rounded-t-[36px] rounded-b-[50px]",
                     "max-[479px]:data-[state=closed]:animate-slide-out-to-bottom max-[479px]:data-[state=open]:animate-slide-in-from-bottom",
                     // Desktop viewport styles (centered modal)
-                    "min-[480px]:inset-auto !min-[480px]:p-10 !min-[480px]:pb-8 min-[480px]:left-[50%] min-[480px]:top-[50%] min-[480px]:translate-x-[-50%] min-[480px]:translate-y-[-52%]",
-                    "min-[480px]:max-w-[448px] min-[480px]:rounded-3xl",
+                    "min-[480px]:inset-auto min-[480px]:left-[50%] min-[480px]:top-[50%]",
+                    "min-[480px]:[transform:translate(-50%,-50%)]",
+                    "min-[480px]:max-w-[448px] min-[480px]:rounded-3xl !min-[480px]:p-10 !min-[480px]:pb-8",
                     "min-[480px]:data-[state=closed]:animate-fade-out min-[480px]:data-[state=open]:animate-fade-in",
                     className
                 )}

--- a/packages/client/ui/react-ui/src/twind.config.ts
+++ b/packages/client/ui/react-ui/src/twind.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "@twind/core";
 import presetTailwind from "@twind/preset-tailwind";
 
 export default defineConfig({
-    presets: [presetTailwind()],
+    presets: [presetTailwind({ disablePreflight: true })],
     theme: {
         extend: {
             colors: {


### PR DESCRIPTION
## Description

Disabled preflight in CSS to prevent style conflicts with client apps. Updated dialog transform property to use direct value instead of shorthand to avoid any ui bugs/interference.

This should've probably already been disabled but we can at least catch it now to minimize any further disruption in client apps using the react sdk. 

Changes:
- Set disablePreflight: true
- Fixed side-effect in dialog component just using the translate(-50%, -50%)  

## Test plan

- tested against a completely separate app built using yalc and styling override was no longer happening and all styles /ui elements worked and looked as expected (from the sdk)
- tested on Safari, google chrome, and ofc in smart wallet demo

## Package updates

@crossmint/client-sdk-react-ui