### PR TITLE
Wallets SDK: fix balance token query param

### DIFF
--- a/packages/wallets/src/api/client.ts
+++ b/packages/wallets/src/api/client.ts
@@ -194,7 +194,7 @@ class ApiClient extends CrossmintApiClient {
         if (params.chains) {
             params.chains.forEach((chain) => queryParams.append("chains", chain));
         }
-        params.tokens.forEach((token) => queryParams.append("tokens", token));
+        queryParams.append("tokens", params.tokens.join(","));
         const response = await this.get(`api/v1-alpha2/wallets/${walletLocator}/balances?${queryParams.toString()}`, {
             headers: {
                 "Content-Type": "application/json",

--- a/packages/wallets/src/evm/wallet.ts
+++ b/packages/wallets/src/evm/wallet.ts
@@ -129,7 +129,7 @@ export class EVMSmartWallet implements ViemWallet {
      * @returns The balances
      */
     public async balances(tokens: Address[]) {
-        return await this.apiClient.getBalance(this.walletLocator, {
+        return await this.apiClient.getBalance(this.getAddress(), {
             chains: [this.chain],
             tokens,
         });

--- a/packages/wallets/src/solana/tokens.ts
+++ b/packages/wallets/src/solana/tokens.ts
@@ -1,1 +1,1 @@
-export type SolanaSupportedToken = "usdc" | "usdt" | "sol";
+export type SolanaSupportedToken = "usdc" | "sol";

--- a/packages/wallets/src/solana/wallet.ts
+++ b/packages/wallets/src/solana/wallet.ts
@@ -73,7 +73,7 @@ abstract class SolanaWallet {
      * @returns The balances
      */
     public async balances(tokens: SolanaSupportedToken[]): Promise<GetBalanceResponse> {
-        return await this.apiClient.getBalance(this.walletLocator, {
+        return await this.apiClient.getBalance(this.getAddress(), {
             tokens,
         });
     }


### PR DESCRIPTION
## Description

Fixes /balances request by using a comma separated list for tokens as well as using locator instead of me:locator, also removed `usdt` as our api doesn't support that currency 

## Test plan

tested endpoint with both wallets and multiple and single item list 

## Package updates

@crossmint/wallets-sdk