### PR TITLE
pay w crypto: switch to default chain if not supported

### DIFF
--- a/.changeset/weak-lemons-roll.md
+++ b/.changeset/weak-lemons-roll.md
@@ -1,0 +1,6 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+"@crossmint/client-sdk-base": patch
+---
+
+embed: crypto default switch + pirate currency


### PR DESCRIPTION
## Description
If the user's wallet is on a chain we don't support (this should only happen for EVM):
- Switch to the default chain
- If that fails, return an error explaining user must switch to a supported chain

## Test plan

pretty straight forward