### PR TITLE
Fix `CrossmintErrors` not exposed

### DIFF
--- a/.changeset/strong-berries-tease.md
+++ b/.changeset/strong-berries-tease.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-base": patch
+---
+
+Fix CrossmintErrors not exported

--- a/packages/client/base/src/error/index.ts
+++ b/packages/client/base/src/error/index.ts
@@ -1,4 +1,10 @@
-import { CrossmintSDKError, CrossmintErrors } from "@crossmint/common-sdk-base";
+import {
+    CrossmintSDKError,
+    PaymentErrors,
+    SmartWalletErrorCode,
+    WalletErrorCode,
+    CrossmintErrors,
+} from "@crossmint/common-sdk-base";
 
 export class CrossmintServiceError extends CrossmintSDKError {
     public status?: number;
@@ -61,3 +67,5 @@ export class OutOfCreditsError extends CrossmintSDKError {
         );
     }
 }
+
+export { CrossmintSDKError, PaymentErrors, SmartWalletErrorCode, WalletErrorCode, CrossmintErrors };


### PR DESCRIPTION
## Description

Exports `CrossmintErrors` in `@crossmint/client-sdk-base` to fix the `crossbit-main` build.

Also exports `CrossmintSDKError, PaymentErrors, SmartWalletErrorCode, WalletErrorCode` that were also previously exported to keep backwards compatibility.

Those were moved to `@crossmint/client-sdk-base` in a larger refactor, but haven't been reexported.

## Test plan

* CI
* exports

## Package updates

```
"@crossmint/client-sdk-base": patch
```