### PR TITLE
Solana sendTransaction: Fix signing for keypair

### DIFF
--- a/.changeset/tiny-donuts-arrive.md
+++ b/.changeset/tiny-donuts-arrive.md
@@ -2,4 +2,4 @@
 "@crossmint/wallets-sdk": patch
 ---
 
-fixed admin signer for signing sol txns
+fix signing for solana transactions

--- a/.changeset/tiny-donuts-arrive.md
+++ b/.changeset/tiny-donuts-arrive.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+fixed admin signer for signing sol txns

--- a/packages/wallets/src/solana/services/approvals-service.ts
+++ b/packages/wallets/src/solana/services/approvals-service.ts
@@ -1,4 +1,5 @@
 import bs58 from "bs58";
+import { VersionedMessage, VersionedTransaction } from "@solana/web3.js";
 import type { ApiClient, CreateTransactionSuccessResponse, SolanaWalletLocator } from "@/api";
 import type { SolanaNonCustodialSigner } from "../types/signers";
 import { PendingApprovalsError, InvalidSignerError, TransactionFailedError } from "../../utils/errors";
@@ -24,8 +25,16 @@ export class SolanaApprovalsService {
                         `Signer ${approval.signer} is required for the transaction but was not found in the signer list`
                     );
                 }
+                // Convert the decoded transaction message from server back into a VersionedTransaction
+                const messageBytes = bs58.decode(approval.message);
+                const message = VersionedMessage.deserialize(messageBytes);
+                const transaction = new VersionedTransaction(message);
+                // Sign the transaction (we can't use signMessage on transactions, so we need to sign the transaction directly)
+                const signedTxn = await signer.signTransaction(transaction);
+                // Get the signature from the signed transaction
+                const signature = this.retrieveValidSignature(signedTxn);
                 return {
-                    signature: bs58.encode(await signer.signMessage(bs58.decode(approval.message))),
+                    signature,
                     signer: approval.signer,
                 };
             })
@@ -40,5 +49,22 @@ export class SolanaApprovalsService {
             throw new PendingApprovalsError("Still has pending approvals, please submit all approvals");
         }
         return transaction;
+    }
+
+    private retrieveValidSignature(signedTxn: VersionedTransaction) {
+        let signatureObj = null;
+        for (let i = 0; i < signedTxn.signatures.length; i++) {
+            const sig = signedTxn.signatures[i];
+            // Check if this signature is non-zero
+            if (Object.values(sig).some((byte) => byte !== 0)) {
+                signatureObj = sig;
+                break;
+            }
+        }
+        if (!signatureObj) {
+            throw new Error("No valid signature found in the transaction");
+        }
+        const signatureBytes = new Uint8Array(Object.values(signatureObj));
+        return bs58.encode(signatureBytes);
     }
 }


### PR DESCRIPTION
## Description

Fixed our signing mechanism for signing solana txns.

To provide some context here, according to Claude this is whats happening

> This is a security protection - Phantom (and other Solana wallets) deliberately prevent you from using the signMessage method to sign transaction data. This prevents potential security exploits where users think they're signing a message but are actually signing a transaction.

Therefore, from my understanding the following was necessary:

1. the server sends a serialized transaction message from the transaction
2. then, we need to convert that serialized transaction message back into a transaction and use the signTransaction function from our wallet provider (dynamic in our case i'm not 100 percent confident this will work with other providers but it should based on my research!)

## Test plan

Tested signing with wallet.sendTransaction and works

## Package updates

@crossmint/wallets-sdk