### PR TITLE
Wallets SDK: Standardize wallet return type

### DIFF
--- a/.changeset/few-mice-care.md
+++ b/.changeset/few-mice-care.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": major
+---
+
+Fixed wallet return types

--- a/apps/wallets/smart-wallet/next/src/app/wallet/page.tsx
+++ b/apps/wallets/smart-wallet/next/src/app/wallet/page.tsx
@@ -67,9 +67,9 @@ export default function Index() {
         queryKey: ["smart-wallet"],
         queryFn: async () => {
             if (type === "evm-smart-wallet") {
-                return (await wallet?.nfts(11, 1, wallet.chain, wallet.getAddress())) as NFT[];
+                return (await wallet?.getNfts(11, 1, wallet.chain, wallet.getAddress())) as NFT[];
             } else if (type === "solana-smart-wallet") {
-                return (await wallet?.nfts(11, 1, wallet?.getAddress())) as NFT[];
+                return (await wallet?.getNfts(11, 1, wallet?.getAddress())) as NFT[];
             }
             return [];
         },

--- a/packages/wallets/src/api/client.ts
+++ b/packages/wallets/src/api/client.ts
@@ -173,6 +173,15 @@ class ApiClient extends CrossmintApiClient {
         return response.json();
     }
 
+    async getSigners(walletLocator: WalletLocator): Promise<GetSignerResponse[]> {
+        const walletResponse = await this.get(`${this.apiPrefix}/${walletLocator}`, {
+            headers: this.headers,
+        });
+        const wallet = await walletResponse.json();
+        const signers = wallet.config?.delegatedSigners ?? [];
+        return signers;
+    }
+
     public get isServerSide() {
         return this.parsedAPIKey.usageOrigin === APIKeyUsageOrigin.SERVER;
     }

--- a/packages/wallets/src/api/client.ts
+++ b/packages/wallets/src/api/client.ts
@@ -173,7 +173,7 @@ class ApiClient extends CrossmintApiClient {
         return response.json();
     }
 
-    async getSigners(walletLocator: WalletLocator): Promise<GetSignerResponse[]> {
+    async getDelegatedSigners(walletLocator: WalletLocator): Promise<GetSignerResponse[]> {
         const walletResponse = await this.get(`${this.apiPrefix}/${walletLocator}`, {
             headers: this.headers,
         });

--- a/packages/wallets/src/evm/index.ts
+++ b/packages/wallets/src/evm/index.ts
@@ -1,4 +1,5 @@
 export * from "./wallet";
 export * from "./chains";
-
+export type { EVMSmartWallet } from "./types/wallet";
+export type { EVMSignerInput, EVMSigner } from "./types/signers";
 export type { EVMSmartWalletChain } from "./chains";

--- a/packages/wallets/src/evm/index.ts
+++ b/packages/wallets/src/evm/index.ts
@@ -1,5 +1,5 @@
 export * from "./wallet";
 export * from "./chains";
-export type { EVMSmartWallet } from "./types/wallet";
+export type { EVMSmartWallet, TransactionInput } from "./types/wallet";
 export type { EVMSignerInput, EVMSigner } from "./types/signers";
 export type { EVMSmartWalletChain } from "./chains";

--- a/packages/wallets/src/evm/types/signers.ts
+++ b/packages/wallets/src/evm/types/signers.ts
@@ -1,0 +1,40 @@
+import type { WebAuthnP256 } from "ox";
+import type { Account, Hex, EIP1193Provider } from "viem";
+
+export type PasskeySigningCallback = (
+    message: string
+) => Promise<{ signature: Hex; metadata: WebAuthnP256.SignMetadata }>;
+export type PasskeyCreationCallback = (name: string) => Promise<{ id: string; publicKey: { x: string; y: string } }>;
+
+export type EVMSignerInput =
+    | {
+          type: "evm-keypair";
+          address: string;
+          signer:
+              | {
+                    type: "provider";
+                    provider: EIP1193Provider;
+                }
+              | {
+                    type: "viem_v2";
+                    account: Account;
+                };
+      }
+    | {
+          type: "evm-passkey";
+          name?: string;
+          signingCallback?: PasskeySigningCallback;
+          creationCallback?: PasskeyCreationCallback;
+      };
+
+export type EVMSigner = EVMSignerInput & {
+    locator: string;
+} & (
+        | {
+              type: "evm-passkey";
+              id: string;
+          }
+        | {
+              type: "evm-keypair";
+          }
+    );

--- a/packages/wallets/src/evm/types/wallet.ts
+++ b/packages/wallets/src/evm/types/wallet.ts
@@ -1,0 +1,12 @@
+import type { Address, HttpTransport, PublicClient } from "viem";
+import type { GetBalanceResponse, GetNftsResponse, GetTransactionsResponse } from "@/api";
+import type { ViemWallet } from "../wallet";
+import type { EVMSmartWalletChain } from "../chains";
+
+export interface EVMSmartWallet extends ViemWallet {
+    getBalances(tokens: Address[]): Promise<GetBalanceResponse>;
+    getTransactions(): Promise<GetTransactionsResponse>;
+    getNfts(perPage: number, page: number, chain: string, locator?: string): Promise<GetNftsResponse>;
+    chain: EVMSmartWalletChain;
+    publicClient: PublicClient<HttpTransport>;
+}

--- a/packages/wallets/src/evm/types/wallet.ts
+++ b/packages/wallets/src/evm/types/wallet.ts
@@ -1,6 +1,5 @@
-import type { Address, HttpTransport, PublicClient } from "viem";
+import type { Address, Hex, SignableMessage, PublicClient, HttpTransport, TypedData, TypedDataDefinition } from "viem";
 import type { GetBalanceResponse, GetNftsResponse, GetTransactionsResponse } from "@/api";
-import type { ViemWallet } from "../wallet";
 import type { EVMSmartWalletChain } from "../chains";
 
 export interface EVMSmartWallet extends ViemWallet {
@@ -9,4 +8,51 @@ export interface EVMSmartWallet extends ViemWallet {
     getNfts(perPage: number, page: number, chain: string, locator?: string): Promise<GetNftsResponse>;
     chain: EVMSmartWalletChain;
     publicClient: PublicClient<HttpTransport>;
+}
+
+export interface TransactionInput {
+    to: Address;
+    data?: Hex;
+    value?: bigint;
+}
+
+export interface ViemWallet {
+    /**
+     * Get the wallet address
+     * @returns The wallet address
+     */
+    getAddress: () => Address;
+
+    /**
+     * Get the wallet nonce
+     * @param parameters - The parameters
+     * @returns The nonce
+     */
+    getNonce?: ((parameters?: { key?: bigint | undefined } | undefined) => Promise<bigint>) | undefined;
+
+    /**
+     * Sign a message
+     * @param parameters - The parameters
+     * @returns The signature
+     */
+    signMessage: (parameters: { message: SignableMessage }) => Promise<Hex>;
+
+    /**
+     * Sign a typed data
+     * @param parameters - The parameters
+     * @returns The signature
+     */
+    signTypedData: <
+        const typedData extends TypedData | Record<string, unknown>,
+        primaryType extends keyof typedData | "EIP712Domain" = keyof typedData,
+    >(
+        parameters: TypedDataDefinition<typedData, primaryType>
+    ) => Promise<Hex>;
+
+    /**
+     * Sign and submit a transaction
+     * @param parameters - The transaction parameters
+     * @returns The transaction hash
+     */
+    sendTransaction: (parameters: TransactionInput) => Promise<Hex>;
 }

--- a/packages/wallets/src/evm/utils.ts
+++ b/packages/wallets/src/evm/utils.ts
@@ -1,6 +1,6 @@
 import { WebAuthnP256 } from "ox";
 import type { CreateWalletResponse } from "../api";
-import type { EVMSigner, EVMSignerInput, PasskeyCreationCallback } from "./wallet";
+import type { EVMSigner, EVMSignerInput, PasskeyCreationCallback } from "./types/signers";
 import { SignerTypeMismatchError } from "../utils/errors";
 
 export function getEvmAdminSigner(

--- a/packages/wallets/src/evm/wallet.ts
+++ b/packages/wallets/src/evm/wallet.ts
@@ -44,57 +44,11 @@ import {
 import entryPointAbi from "./abi/entryPoint";
 import { toViemChain, type EVMSmartWalletChain } from "./chains";
 import type { EVMSigner } from "./types/signers";
-
-export interface TransactionInput {
-    to: Address;
-    data?: Hex;
-    value?: bigint;
-}
-
-export interface ViemWallet {
-    /**
-     * Get the wallet address
-     * @returns The wallet address
-     */
-    getAddress: () => Address;
-
-    /**
-     * Get the wallet nonce
-     * @param parameters - The parameters
-     * @returns The nonce
-     */
-    getNonce?: ((parameters?: { key?: bigint | undefined } | undefined) => Promise<bigint>) | undefined;
-
-    /**
-     * Sign a message
-     * @param parameters - The parameters
-     * @returns The signature
-     */
-    signMessage: (parameters: { message: SignableMessage }) => Promise<Hex>;
-
-    /**
-     * Sign a typed data
-     * @param parameters - The parameters
-     * @returns The signature
-     */
-    signTypedData: <
-        const typedData extends TypedData | Record<string, unknown>,
-        primaryType extends keyof typedData | "EIP712Domain" = keyof typedData,
-    >(
-        parameters: TypedDataDefinition<typedData, primaryType>
-    ) => Promise<Hex>;
-
-    /**
-     * Sign and submit a transaction
-     * @param parameters - The transaction parameters
-     * @returns The transaction hash
-     */
-    sendTransaction: (parameters: TransactionInput) => Promise<Hex>;
-}
+import type { TransactionInput, ViemWallet } from "./types/wallet";
 
 type PendingApproval = NonNullable<NonNullable<CreateTransactionSuccessResponse["approvals"]>["pending"]>[number];
 
-export class IEVMSmartWallet implements ViemWallet {
+export class EVMSmartWalletImpl implements ViemWallet {
     public readonly publicClient: PublicClient<HttpTransport>;
 
     constructor(

--- a/packages/wallets/src/index.ts
+++ b/packages/wallets/src/index.ts
@@ -1,9 +1,6 @@
 export * from "./sdk";
 export * from "./utils/errors";
 export type { Callbacks } from "./utils/options";
-export { SolanaSmartWallet, SolanaMPCWallet } from "./solana/wallet";
-export { EVMSmartWallet } from "./evm/wallet";
-
-export type { EVMSignerInput, EVMSigner, EVMSmartWalletChain } from "./evm";
-export type { SolanaSignerInput } from "./solana";
+export type { SolanaSmartWallet, SolanaMPCWallet, SolanaSignerInput } from "./solana";
+export type { EVMSmartWallet, EVMSignerInput, EVMSigner, EVMSmartWalletChain } from "./evm";
 export type { WalletTypeToArgs } from "./services/types";

--- a/packages/wallets/src/services/types.ts
+++ b/packages/wallets/src/services/types.ts
@@ -1,7 +1,8 @@
-import type { EVMSmartWallet, EVMSignerInput } from "@/evm/wallet";
-import type { SolanaSmartWallet, SolanaMPCWallet } from "@/solana/wallet";
+import type { EVMSignerInput } from "@/evm/types/signers";
+import type { EVMSmartWallet } from "@/evm/types/wallet";
 import type { EVMSmartWalletChain } from "@/evm/chains";
 import type { SolanaSignerInput } from "@/solana/types/signers";
+import type { SolanaSmartWallet, SolanaMPCWallet } from "@/solana/types/wallet";
 
 export type EvmWalletType = "evm-smart-wallet";
 export type SolanaWalletType = "solana-smart-wallet" | "solana-mpc-wallet";

--- a/packages/wallets/src/services/wallet-factory.test.ts
+++ b/packages/wallets/src/services/wallet-factory.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, vi, expectTypeOf } from "vitest";
 import { mock } from "vitest-mock-extended";
+import { Keypair } from "@solana/web3.js";
 import type { ApiClient } from "../api";
 import { WalletFactory } from "./wallet-factory";
-import { Keypair } from "@solana/web3.js";
-import { SolanaSmartWallet } from "../solana";
+import type { EVMSmartWallet } from "../evm";
+import type { SolanaSmartWallet } from "../solana";
 
 describe("WalletSDK", () => {
     let factory: WalletFactory;
@@ -15,6 +16,38 @@ describe("WalletSDK", () => {
             environment: "development",
         });
         factory = new WalletFactory(apiClient);
+    });
+
+    it("should create a EVM wallet with a keypair admin signer", async () => {
+        const adminSigner = {
+            type: "evm-keypair",
+            address: "mock-address",
+        };
+        apiClient.createWallet.mockResolvedValueOnce({
+            type: "evm-smart-wallet",
+            address: "mock-address",
+            config: {
+                adminSigner,
+            },
+        });
+        const wallet = await factory.getOrCreateWallet("evm-smart-wallet", {
+            chain: "base",
+            adminSigner,
+        });
+
+        expectTypeOf(wallet).toMatchTypeOf<EVMSmartWallet>();
+        expect(typeof wallet.sendTransaction).toBe("function");
+        expect(typeof wallet.getBalances).toBe("function");
+        expect(typeof wallet.getTransactions).toBe("function");
+        expect(typeof wallet.getNfts).toBe("function");
+        expect(typeof wallet.getAddress).toBe("function");
+        expect(typeof wallet.getNonce).toBe("function");
+        expect(typeof wallet.signMessage).toBe("function");
+        expect(typeof wallet.signTypedData).toBe("function");
+        expect(typeof wallet.chain).toBe("string");
+        expect(typeof wallet.publicClient).toBe("object");
+        expect(wallet.getAddress()).toBe("mock-address");
+        expect(wallet.chain).toBe("base");
     });
 
     it("should create a SSW with a keypair admin signer", async () => {
@@ -40,7 +73,16 @@ describe("WalletSDK", () => {
         });
 
         // Wallet Checks
-        expect(wallet).toBeInstanceOf(SolanaSmartWallet);
+        expectTypeOf(wallet).toMatchTypeOf<SolanaSmartWallet>();
+        expect(typeof wallet.sendTransaction).toBe("function");
+        expect(typeof wallet.getBalances).toBe("function");
+        expect(typeof wallet.getTransactions).toBe("function");
+        expect(typeof wallet.getNfts).toBe("function");
+        expect(typeof wallet.addDelegatedSigner).toBe("function");
+        expect(typeof wallet.getDelegatedSigners).toBe("function");
+        expect(typeof wallet.adminSigner).toBe("object");
+        expect(typeof wallet.getPublicKey).toBe("function");
+        expect(typeof wallet.getAddress).toBe("function");
         expect(wallet.getPublicKey().toBase58()).toBe(walletAddress);
         expect(wallet.adminSigner.type).toBe("solana-keypair");
         expect(wallet.adminSigner.address).toBe(adminSigner.address);
@@ -86,7 +128,7 @@ describe("WalletSDK", () => {
         });
 
         // Wallet Checks
-        expect(wallet).toBeInstanceOf(SolanaSmartWallet);
+        expectTypeOf(wallet).toMatchTypeOf<SolanaSmartWallet>();
         expect(wallet.getPublicKey().toBase58()).toBe(walletAddress);
         expect(wallet.adminSigner.type).toBe("solana-keypair");
         expect(wallet.adminSigner.address).toBe(adminSigner.address);
@@ -127,7 +169,7 @@ describe("WalletSDK", () => {
         });
 
         // Wallet Checks
-        expect(wallet).toBeInstanceOf(SolanaSmartWallet);
+        expectTypeOf(wallet).toMatchTypeOf<SolanaSmartWallet>();
         expect(wallet.getPublicKey().toBase58()).toBe(walletAddress);
         expect(wallet.adminSigner.type).toBe("solana-fireblocks-custodial");
         expect(wallet.getAddress()).toBe(walletAddress);

--- a/packages/wallets/src/services/wallet-factory.ts
+++ b/packages/wallets/src/services/wallet-factory.ts
@@ -4,8 +4,8 @@ import type { Address } from "viem";
 import type { EvmWalletType, SolanaWalletType, WalletTypeToArgs, WalletTypeToWallet } from "./types";
 import type { ApiClient, CreateWalletResponse, GetWalletSuccessResponse } from "../api";
 import { createPasskeySigner, getEvmAdminSigner } from "../evm/utils";
-import { ISolanaMPCWallet, ISolanaSmartWallet, type SolanaMPCWallet, type SolanaSmartWallet } from "../solana";
-import { IEVMSmartWallet, type EVMSmartWallet } from "../evm";
+import { SolanaMPCWalletImpl, SolanaSmartWalletImpl, type SolanaMPCWallet, type SolanaSmartWallet } from "../solana";
+import { EVMSmartWalletImpl, type EVMSmartWallet } from "../evm";
 import { parseSolanaSignerInput } from "../solana/types/signers";
 import { getConnectionFromEnvironment } from "../solana/utils";
 import type { WalletOptions } from "../utils/options";
@@ -143,7 +143,7 @@ export class WalletFactory {
             case "evm-smart-wallet": {
                 const { chain, adminSigner: adminSignerInput } = args as WalletTypeToArgs["evm-smart-wallet"];
                 const evmResponse = walletResponse as Extract<CreateWalletResponse, { type: "evm-smart-wallet" }>;
-                const wallet = new IEVMSmartWallet(
+                const wallet = new EVMSmartWalletImpl(
                     chain,
                     this.apiClient,
                     evmResponse.address as Address,
@@ -161,7 +161,7 @@ export class WalletFactory {
                     sendTransaction: wallet.sendTransaction.bind(wallet),
                     chain: wallet.chain,
                     publicClient: wallet.publicClient,
-                } as EVMSmartWallet;
+                } satisfies EVMSmartWallet;
             }
         }
     }
@@ -176,7 +176,7 @@ export class WalletFactory {
         switch (type) {
             case "solana-smart-wallet": {
                 const { adminSigner: adminSignerInput } = args as WalletTypeToArgs["solana-smart-wallet"];
-                const wallet = new ISolanaSmartWallet(
+                const wallet = new SolanaSmartWalletImpl(
                     this.apiClient,
                     new PublicKey(solanaResponse.address),
                     adminSignerInput ?? {
@@ -195,10 +195,10 @@ export class WalletFactory {
                     getNfts: wallet.getNfts.bind(wallet),
                     sendTransaction: wallet.sendTransaction.bind(wallet),
                     getTransactions: wallet.getTransactions.bind(wallet),
-                } as SolanaSmartWallet;
+                } satisfies SolanaSmartWallet;
             }
             case "solana-mpc-wallet": {
-                const wallet = new ISolanaMPCWallet(
+                const wallet = new SolanaMPCWalletImpl(
                     this.apiClient,
                     new PublicKey(solanaResponse.address),
                     getConnectionFromEnvironment(this.apiClient.environment),
@@ -211,7 +211,7 @@ export class WalletFactory {
                     getPublicKey: wallet.getPublicKey.bind(wallet),
                     getNfts: wallet.getNfts.bind(wallet),
                     getTransactions: wallet.getTransactions.bind(wallet),
-                } as SolanaMPCWallet;
+                } satisfies SolanaMPCWallet;
             }
         }
     }

--- a/packages/wallets/src/services/wallet-factory.ts
+++ b/packages/wallets/src/services/wallet-factory.ts
@@ -1,12 +1,11 @@
 import { PublicKey } from "@solana/web3.js";
 import type { Address } from "viem";
 
-import { SolanaMPCWallet } from "../solana";
 import type { EvmWalletType, SolanaWalletType, WalletTypeToArgs, WalletTypeToWallet } from "./types";
 import type { ApiClient, CreateWalletResponse, GetWalletSuccessResponse } from "../api";
-import { EVMSmartWallet } from "../evm";
 import { createPasskeySigner, getEvmAdminSigner } from "../evm/utils";
-import { SolanaSmartWallet } from "../solana";
+import { ISolanaMPCWallet, ISolanaSmartWallet, type SolanaMPCWallet, type SolanaSmartWallet } from "../solana";
+import { IEVMSmartWallet, type EVMSmartWallet } from "../evm";
 import { parseSolanaSignerInput } from "../solana/types/signers";
 import { getConnectionFromEnvironment } from "../solana/utils";
 import type { WalletOptions } from "../utils/options";
@@ -144,13 +143,25 @@ export class WalletFactory {
             case "evm-smart-wallet": {
                 const { chain, adminSigner: adminSignerInput } = args as WalletTypeToArgs["evm-smart-wallet"];
                 const evmResponse = walletResponse as Extract<CreateWalletResponse, { type: "evm-smart-wallet" }>;
-                return new EVMSmartWallet(
+                const wallet = new IEVMSmartWallet(
                     chain,
                     this.apiClient,
                     evmResponse.address as Address,
                     getEvmAdminSigner(adminSignerInput, evmResponse),
                     options?.experimental_callbacks ?? {}
-                ) as WalletTypeToWallet[WalletType];
+                );
+                return {
+                    getBalances: wallet.getBalances.bind(wallet),
+                    getTransactions: wallet.getTransactions.bind(wallet),
+                    getNfts: wallet.getNfts.bind(wallet),
+                    getAddress: wallet.getAddress.bind(wallet),
+                    getNonce: wallet.getNonce.bind(wallet),
+                    signMessage: wallet.signMessage.bind(wallet),
+                    signTypedData: wallet.signTypedData.bind(wallet),
+                    sendTransaction: wallet.sendTransaction.bind(wallet),
+                    chain: wallet.chain,
+                    publicClient: wallet.publicClient,
+                } as EVMSmartWallet;
             }
         }
     }
@@ -165,7 +176,7 @@ export class WalletFactory {
         switch (type) {
             case "solana-smart-wallet": {
                 const { adminSigner: adminSignerInput } = args as WalletTypeToArgs["solana-smart-wallet"];
-                return new SolanaSmartWallet(
+                const wallet = new ISolanaSmartWallet(
                     this.apiClient,
                     new PublicKey(solanaResponse.address),
                     adminSignerInput ?? {
@@ -173,15 +184,34 @@ export class WalletFactory {
                     },
                     getConnectionFromEnvironment(this.apiClient.environment),
                     options?.experimental_callbacks ?? {}
-                ) as WalletTypeToWallet[WalletType];
+                );
+                return {
+                    getDelegatedSigners: wallet.getDelegatedSigners.bind(wallet),
+                    addDelegatedSigner: wallet.addDelegatedSigner.bind(wallet),
+                    adminSigner: wallet.adminSigner,
+                    getBalances: wallet.getBalances.bind(wallet),
+                    getAddress: wallet.getAddress.bind(wallet),
+                    getPublicKey: wallet.getPublicKey.bind(wallet),
+                    getNfts: wallet.getNfts.bind(wallet),
+                    sendTransaction: wallet.sendTransaction.bind(wallet),
+                    getTransactions: wallet.getTransactions.bind(wallet),
+                } as SolanaSmartWallet;
             }
             case "solana-mpc-wallet": {
-                return new SolanaMPCWallet(
+                const wallet = new ISolanaMPCWallet(
                     this.apiClient,
                     new PublicKey(solanaResponse.address),
                     getConnectionFromEnvironment(this.apiClient.environment),
                     options?.experimental_callbacks ?? {}
-                ) as WalletTypeToWallet[WalletType];
+                );
+                return {
+                    sendTransaction: wallet.sendTransaction.bind(wallet),
+                    getBalances: wallet.getBalances.bind(wallet),
+                    getAddress: wallet.getAddress.bind(wallet),
+                    getPublicKey: wallet.getPublicKey.bind(wallet),
+                    getNfts: wallet.getNfts.bind(wallet),
+                    getTransactions: wallet.getTransactions.bind(wallet),
+                } as SolanaMPCWallet;
             }
         }
     }

--- a/packages/wallets/src/solana/index.ts
+++ b/packages/wallets/src/solana/index.ts
@@ -1,3 +1,5 @@
 export * from "./wallet";
 export * from "./tokens";
 export * from "./types/signers";
+
+export type { SolanaSmartWallet, SolanaMPCWallet } from "./types/wallet";

--- a/packages/wallets/src/solana/services/delegated-signers-service.ts
+++ b/packages/wallets/src/solana/services/delegated-signers-service.ts
@@ -28,7 +28,7 @@ export class SolanaDelegatedSignerService {
     }
 
     public async getDelegatedSigners() {
-        const response = await this.apiClient.getSigners(this.walletLocator);
+        const response = await this.apiClient.getDelegatedSigners(this.walletLocator);
         return response;
     }
 }

--- a/packages/wallets/src/solana/services/delegated-signers-service.ts
+++ b/packages/wallets/src/solana/services/delegated-signers-service.ts
@@ -26,4 +26,9 @@ export class SolanaDelegatedSignerService {
         const response = await this.apiClient.getSigner(this.walletLocator, signer);
         return response;
     }
+
+    public async getDelegatedSigners() {
+        const response = await this.apiClient.getSigners(this.walletLocator);
+        return response;
+    }
 }

--- a/packages/wallets/src/solana/types/wallet.ts
+++ b/packages/wallets/src/solana/types/wallet.ts
@@ -1,0 +1,24 @@
+import type { GetSignerResponse } from "@/api";
+import type { SolanaNonCustodialSignerInput, SolanaSigner } from "./signers";
+import type { VersionedTransaction } from "@solana/web3.js";
+import type { SolanaWallet } from "../wallet";
+
+export interface SolanaSmartWallet extends SolanaWallet {
+    addDelegatedSigner(signer: string): Promise<GetSignerResponse>;
+    getDelegatedSigners(): Promise<GetSignerResponse[]>;
+    adminSigner: SolanaSigner;
+    sendTransaction(parameters: SmartWalletTransactionParams): Promise<string>;
+}
+
+export interface SolanaMPCWallet extends SolanaWallet {
+    sendTransaction(parameters: {
+        transaction: VersionedTransaction;
+        additionalSigners?: SolanaNonCustodialSignerInput[];
+    }): Promise<string>;
+}
+
+export interface SmartWalletTransactionParams {
+    transaction: VersionedTransaction;
+    additionalSigners?: SolanaNonCustodialSignerInput[];
+    delegatedSigner?: SolanaNonCustodialSignerInput;
+}

--- a/packages/wallets/src/solana/types/wallet.ts
+++ b/packages/wallets/src/solana/types/wallet.ts
@@ -1,16 +1,58 @@
-import type { GetSignerResponse } from "@/api";
+import type {
+    GetBalanceResponse,
+    GetNftsResponse,
+    GetSignerResponse,
+    GetTransactionsResponse,
+    SolanaWalletLocator,
+} from "@/api";
 import type { SolanaNonCustodialSignerInput, SolanaSigner } from "./signers";
-import type { VersionedTransaction } from "@solana/web3.js";
-import type { SolanaWallet } from "../wallet";
+import type { PublicKey, VersionedTransaction } from "@solana/web3.js";
+import type { SolanaSupportedToken } from "../tokens";
 
-export interface SolanaSmartWallet extends SolanaWallet {
+export interface BaseSolanaWallet {
+    /**
+     * Get the wallet public key
+     * @returns The wallet public key
+     */
+    getPublicKey(): PublicKey;
+
+    /**
+     * Get the wallet address
+     * @returns The wallet address
+     */
+    getAddress(): string;
+
+    /**
+     * Get the wallet balances
+     * @param tokens - The tokens
+     * @returns The balances
+     */
+    getBalances(tokens: SolanaSupportedToken[]): Promise<GetBalanceResponse>;
+
+    /**
+     * Get the wallet transactions
+     * @returns The transactions
+     */
+    getTransactions(): Promise<GetTransactionsResponse>;
+
+    /**
+     * Get the wallet NFTs
+     * @param perPage - The number of NFTs per page
+     * @param page - The page number
+     * @param locator - The wallet locator
+     * @returns The NFTs
+     */
+    getNfts(perPage: number, page: number, locator?: SolanaWalletLocator): Promise<GetNftsResponse>;
+}
+
+export interface SolanaSmartWallet extends BaseSolanaWallet {
     addDelegatedSigner(signer: string): Promise<GetSignerResponse>;
     getDelegatedSigners(): Promise<GetSignerResponse[]>;
     adminSigner: SolanaSigner;
     sendTransaction(parameters: SmartWalletTransactionParams): Promise<string>;
 }
 
-export interface SolanaMPCWallet extends SolanaWallet {
+export interface SolanaMPCWallet extends BaseSolanaWallet {
     sendTransaction(parameters: {
         transaction: VersionedTransaction;
         additionalSigners?: SolanaNonCustodialSignerInput[];

--- a/packages/wallets/src/solana/wallet.ts
+++ b/packages/wallets/src/solana/wallet.ts
@@ -4,6 +4,7 @@ import type {
     ApiClient,
     GetBalanceResponse,
     GetNftsResponse,
+    GetSignerResponse,
     GetTransactionsResponse,
     SolanaWalletLocator,
 } from "../api";
@@ -20,6 +21,7 @@ import {
 } from "./types/signers";
 import { SolanaTransactionsService } from "./services/transactions-service";
 import { SolanaDelegatedSignerService } from "./services/delegated-signers-service";
+import type { SolanaSmartWallet, SmartWalletTransactionParams, SolanaMPCWallet } from "./types/wallet";
 
 export type Transaction = VersionedTransaction;
 
@@ -28,13 +30,7 @@ interface MPCTransactionParams {
     additionalSigners?: SolanaNonCustodialSignerInput[];
 }
 
-interface SmartWalletTransactionParams {
-    transaction: VersionedTransaction;
-    additionalSigners?: SolanaNonCustodialSignerInput[];
-    delegatedSigner?: SolanaNonCustodialSignerInput;
-}
-
-abstract class SolanaWallet {
+export abstract class SolanaWallet {
     protected readonly transactionsService: SolanaTransactionsService;
     protected readonly delegatedSignerService: SolanaDelegatedSignerService;
     constructor(
@@ -72,7 +68,7 @@ abstract class SolanaWallet {
      * @param tokens - The tokens
      * @returns The balances
      */
-    public async balances(tokens: SolanaSupportedToken[]): Promise<GetBalanceResponse> {
+    public async getBalances(tokens: SolanaSupportedToken[]): Promise<GetBalanceResponse> {
         return await this.apiClient.getBalance(this.getAddress(), {
             tokens,
         });
@@ -82,7 +78,7 @@ abstract class SolanaWallet {
      * Get the wallet transactions
      * @returns The transactions
      */
-    public async transactions(): Promise<GetTransactionsResponse> {
+    public async getTransactions(): Promise<GetTransactionsResponse> {
         return await this.transactionsService.getTransactions();
     }
 
@@ -93,7 +89,7 @@ abstract class SolanaWallet {
      * @param locator - The wallet locator
      * @returns The NFTs
      */
-    public async nfts(perPage: number, page: number, locator?: SolanaWalletLocator): Promise<GetNftsResponse> {
+    public async getNfts(perPage: number, page: number, locator?: SolanaWalletLocator): Promise<GetNftsResponse> {
         return await this.apiClient.getNfts("solana", locator ?? this.walletLocator, perPage, page);
     }
 
@@ -106,7 +102,7 @@ abstract class SolanaWallet {
     }
 }
 
-export class SolanaSmartWallet extends SolanaWallet {
+export class ISolanaSmartWallet extends SolanaWallet implements SolanaSmartWallet {
     public readonly adminSigner: SolanaSigner;
     constructor(
         apiClient: ApiClient,
@@ -146,6 +142,14 @@ export class SolanaSmartWallet extends SolanaWallet {
         );
     }
 
+    /**
+     * Gets delegated signers for the wallet
+     * @returns The delegated signers
+     */
+    public async getDelegatedSigners(): Promise<GetSignerResponse[]> {
+        return await this.delegatedSignerService.getDelegatedSigners();
+    }
+
     private getEffectiveTransactionSigner(
         signer: SolanaNonCustodialSignerInput | undefined
     ): SolanaNonCustodialSigner | undefined {
@@ -159,7 +163,7 @@ export class SolanaSmartWallet extends SolanaWallet {
     }
 }
 
-export class SolanaMPCWallet extends SolanaWallet {
+export class ISolanaMPCWallet extends SolanaWallet implements SolanaMPCWallet {
     /**
      * Sign and submit a transaction
      * @param parameters - The transaction parameters

--- a/packages/wallets/src/solana/wallet.ts
+++ b/packages/wallets/src/solana/wallet.ts
@@ -21,7 +21,12 @@ import {
 } from "./types/signers";
 import { SolanaTransactionsService } from "./services/transactions-service";
 import { SolanaDelegatedSignerService } from "./services/delegated-signers-service";
-import type { SolanaSmartWallet, SmartWalletTransactionParams, SolanaMPCWallet } from "./types/wallet";
+import type {
+    SolanaSmartWallet,
+    SmartWalletTransactionParams,
+    SolanaMPCWallet,
+    BaseSolanaWallet,
+} from "./types/wallet";
 
 export type Transaction = VersionedTransaction;
 
@@ -30,7 +35,7 @@ interface MPCTransactionParams {
     additionalSigners?: SolanaNonCustodialSignerInput[];
 }
 
-export abstract class SolanaWallet {
+export abstract class SolanaWallet implements BaseSolanaWallet {
     protected readonly transactionsService: SolanaTransactionsService;
     protected readonly delegatedSignerService: SolanaDelegatedSignerService;
     constructor(
@@ -102,7 +107,7 @@ export abstract class SolanaWallet {
     }
 }
 
-export class ISolanaSmartWallet extends SolanaWallet implements SolanaSmartWallet {
+export class SolanaSmartWalletImpl extends SolanaWallet implements SolanaSmartWallet {
     public readonly adminSigner: SolanaSigner;
     constructor(
         apiClient: ApiClient,
@@ -163,7 +168,7 @@ export class ISolanaSmartWallet extends SolanaWallet implements SolanaSmartWalle
     }
 }
 
-export class ISolanaMPCWallet extends SolanaWallet implements SolanaMPCWallet {
+export class SolanaMPCWalletImpl extends SolanaWallet implements SolanaMPCWallet {
     /**
      * Sign and submit a transaction
      * @param parameters - The transaction parameters


### PR DESCRIPTION
## Description

• Standardizes return value from getOrCreateWallet method, this ensures the return type matches the actual returned wallet instance
• Adds `get` prefix to all getter methods for consistency
• Adds getDelegatedSigners method to solana-smart-wallet

additional context: 

what we currently **have**: (similar applies to evm)
![Screenshot 2025-04-07 at 12 20 20 PM](https://github.com/user-attachments/assets/c44bdda2-a041-4337-a253-4408e7465df3)


what we **want**:
![Screenshot 2025-04-07 at 2 05 50 PM](https://github.com/user-attachments/assets/67b65312-3e6e-4e0c-91e8-c28adbabf15d)


## Test plan

Added additional automated test cases for evm and existing sol, manually tested wallets object, and type remain the same but return value is now correct.

## Package updates

@crossmint/wallets-sdk