### PR TITLE
SDK: Send App id header in all requests from mobile

### DIFF
--- a/.changeset/angry-carpets-rest.md
+++ b/.changeset/angry-carpets-rest.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/common-sdk-base": minor
+---
+
+Support app id header in crossmint requests

--- a/.changeset/dry-hats-admire.md
+++ b/.changeset/dry-hats-admire.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-base": minor
+---
+
+Add app id to crossmint object

--- a/packages/client/react-base/src/hooks/useCrossmint.tsx
+++ b/packages/client/react-base/src/hooks/useCrossmint.tsx
@@ -12,6 +12,7 @@ const CrossmintContext = createContext<CrossmintContext | null>(null);
 export function CrossmintProvider({
     children,
     apiKey,
+    appId,
     overrideBaseUrl,
 }: Omit<Crossmint, "jwt"> & {
     children: ReactNode;
@@ -19,7 +20,7 @@ export function CrossmintProvider({
     const [version, setVersion] = useState(0);
 
     const crossmintRef = useRef<Crossmint>(
-        new Proxy<Crossmint>(createCrossmint({ apiKey, overrideBaseUrl }), {
+        new Proxy<Crossmint>(createCrossmint({ apiKey, overrideBaseUrl, appId }), {
             set(target, prop, value) {
                 if (prop === "jwt" && target.jwt !== value) {
                     setVersion((v) => v + 1);

--- a/packages/common/base/src/apiClient/CrossmintApiClient.ts
+++ b/packages/common/base/src/apiClient/CrossmintApiClient.ts
@@ -45,6 +45,7 @@ export class CrossmintApiClient extends ApiClient {
     get authHeaders() {
         return {
             "x-api-key": this.crossmint.apiKey,
+            ...(this.crossmint.appId ? { "x-app-identifier": this.crossmint.appId } : {}),
             ...(this.crossmint.jwt ? { Authorization: `Bearer ${this.crossmint.jwt}` } : {}),
         };
     }

--- a/packages/common/base/src/types/Crossmint.ts
+++ b/packages/common/base/src/types/Crossmint.ts
@@ -4,10 +4,11 @@ export type Crossmint = {
     apiKey: string;
     jwt?: string;
     overrideBaseUrl?: string;
+    appId?: string;
 };
 
 export function createCrossmint(config: Crossmint, apiKeyExpectations?: ValidateAPIKeyPrefixExpectations): Crossmint {
-    const { apiKey, jwt, overrideBaseUrl } = config;
+    const { apiKey, jwt, overrideBaseUrl, appId } = config;
     const apiKeyValidationResult = validateAPIKey(apiKey, apiKeyExpectations);
     if (!apiKeyValidationResult.isValid) {
         throw new Error(apiKeyValidationResult.message);
@@ -16,5 +17,6 @@ export function createCrossmint(config: Crossmint, apiKeyExpectations?: Validate
         apiKey,
         jwt,
         overrideBaseUrl,
+        appId,
     };
 }


### PR DESCRIPTION
## Description

We verify requests from mobile with this header, now we'll support it in our base sdks and api client.

## Test plan

Tested with expo app

## Package updates

react-base: minor
common-base: minor