### PR TITLE
SSW: fix signature error in some browser wallets

### DIFF
--- a/packages/wallets/src/solana/services/approvals-service.test.ts
+++ b/packages/wallets/src/solana/services/approvals-service.test.ts
@@ -56,13 +56,10 @@ describe("SolanaApprovalsService", () => {
 
     describe("approve", () => {
         it("should successfully approve a transaction with single signer", async () => {
-            const transactionBase58 =
-                "jbvfjrXhwBBfLh5GiWf7owJQUkvokFFp1wxsnPhEciZqE87GMdN";
+            const transactionBase58 = "jbvfjrXhwBBfLh5GiWf7owJQUkvokFFp1wxsnPhEciZqE87GMdN";
             const mockSignedTxn = {
                 message: {
-                    staticAccountKeys: [
-                        { equals: vi.fn().mockReturnValue(true) },
-                    ],
+                    staticAccountKeys: [{ equals: vi.fn().mockReturnValue(true) }],
                 },
                 signatures: [new Uint8Array([1, 2, 3])],
             };
@@ -93,11 +90,7 @@ describe("SolanaApprovalsService", () => {
                 id: "mock-approval-id",
             });
 
-            const result = await approvalsService.approve(
-                mockTransaction,
-                pendingApprovals,
-                [signer]
-            );
+            const result = await approvalsService.approve(mockTransaction, pendingApprovals, [signer]);
 
             // Verify signTransaction was called with a VersionedTransaction
             expect(signer.signTransaction).toHaveBeenCalled();
@@ -105,24 +98,19 @@ describe("SolanaApprovalsService", () => {
             expect(txnArg).toBeInstanceOf(VersionedTransaction);
 
             // Verify API call
-            expect(apiClient.approveTransaction).toHaveBeenCalledWith(
-                walletLocator,
-                "mock-tx-id",
-                {
-                    approvals: [
-                        {
-                            signer: "mock-address",
-                            signature: expect.any(String),
-                        },
-                    ],
-                }
-            );
+            expect(apiClient.approveTransaction).toHaveBeenCalledWith(walletLocator, "mock-tx-id", {
+                approvals: [
+                    {
+                        signer: "mock-address",
+                        signature: expect.any(String),
+                    },
+                ],
+            });
             expect(result).toEqual({ id: "mock-approval-id" });
         });
 
         it("should successfully approve a transaction with multiple signers", async () => {
-            const transactionBase58 =
-                "jbvfjrXhwBBfLh5GiWf7owJQUkvokFFp1wxsnPhEciZqE87GMdN";
+            const transactionBase58 = "jbvfjrXhwBBfLh5GiWf7owJQUkvokFFp1wxsnPhEciZqE87GMdN";
 
             // Create mock transactions
             const mockSignedTxn = new VersionedTransaction(
@@ -163,11 +151,7 @@ describe("SolanaApprovalsService", () => {
                 id: "mock-tx-id",
             });
 
-            const result = await approvalsService.approve(
-                mockTransaction,
-                pendingApprovals,
-                [signer1, signer2]
-            );
+            const result = await approvalsService.approve(mockTransaction, pendingApprovals, [signer1, signer2]);
 
             // Verify signTransaction was called for both signers
             expect(signer1.signTransaction).toHaveBeenCalled();
@@ -175,22 +159,18 @@ describe("SolanaApprovalsService", () => {
 
             // Verify API call
             expect(apiClient.approveTransaction).toHaveBeenCalledTimes(1);
-            expect(apiClient.approveTransaction).toHaveBeenCalledWith(
-                walletLocator,
-                "mock-tx-id",
-                {
-                    approvals: [
-                        {
-                            signer: "mock-address-1",
-                            signature: expect.any(String),
-                        },
-                        {
-                            signer: "mock-address-2",
-                            signature: expect.any(String),
-                        },
-                    ],
-                }
-            );
+            expect(apiClient.approveTransaction).toHaveBeenCalledWith(walletLocator, "mock-tx-id", {
+                approvals: [
+                    {
+                        signer: "mock-address-1",
+                        signature: expect.any(String),
+                    },
+                    {
+                        signer: "mock-address-2",
+                        signature: expect.any(String),
+                    },
+                ],
+            });
             expect(result).toEqual({ id: "mock-tx-id" });
         });
 
@@ -202,8 +182,7 @@ describe("SolanaApprovalsService", () => {
             const pendingApprovals = [
                 {
                     signer: "different-address",
-                    message:
-                        "jbvfjrXhwBBfLh5GiWf7owJQUkvokFFp1wxsnPhEciZqE87GMdN",
+                    message: "jbvfjrXhwBBfLh5GiWf7owJQUkvokFFp1wxsnPhEciZqE87GMdN",
                 },
             ];
 
@@ -211,17 +190,12 @@ describe("SolanaApprovalsService", () => {
                 id: "mock-tx-id",
                 walletType: "solana-smart-wallet",
                 onChain: {
-                    transaction:
-                        "jbvfjrXhwBBfLh5GiWf7owJQUkvokFFp1wxsnPhEciZqE87GMdN",
+                    transaction: "jbvfjrXhwBBfLh5GiWf7owJQUkvokFFp1wxsnPhEciZqE87GMdN",
                 },
                 status: "awaiting-approval",
             };
 
-            await expect(
-                approvalsService.approve(mockTransaction, pendingApprovals, [
-                    signer,
-                ])
-            ).rejects.toThrow(
+            await expect(approvalsService.approve(mockTransaction, pendingApprovals, [signer])).rejects.toThrow(
                 "Signer different-address is required for the transaction but was not found in the signer list"
             );
         });
@@ -234,8 +208,7 @@ describe("SolanaApprovalsService", () => {
             const pendingApprovals = [
                 {
                     signer: "mock-address",
-                    message:
-                        "jbvfjrXhwBBfLh5GiWf7owJQUkvokFFp1wxsnPhEciZqE87GMdN",
+                    message: "jbvfjrXhwBBfLh5GiWf7owJQUkvokFFp1wxsnPhEciZqE87GMdN",
                 },
             ];
 
@@ -243,17 +216,14 @@ describe("SolanaApprovalsService", () => {
                 id: "mock-tx-id",
                 walletType: "unsupported-wallet",
                 onChain: {
-                    transaction:
-                        "jbvfjrXhwBBfLh5GiWf7owJQUkvokFFp1wxsnPhEciZqE87GMdN",
+                    transaction: "jbvfjrXhwBBfLh5GiWf7owJQUkvokFFp1wxsnPhEciZqE87GMdN",
                 },
                 status: "awaiting-approval",
             };
 
-            await expect(
-                approvalsService.approve(mockTransaction, pendingApprovals, [
-                    signer,
-                ])
-            ).rejects.toThrow("Unsupported wallet type: unsupported-wallet");
+            await expect(approvalsService.approve(mockTransaction, pendingApprovals, [signer])).rejects.toThrow(
+                "Unsupported wallet type: unsupported-wallet"
+            );
         });
     });
 });

--- a/packages/wallets/src/solana/services/approvals-service.test.ts
+++ b/packages/wallets/src/solana/services/approvals-service.test.ts
@@ -5,6 +5,7 @@ import { mock } from "vitest-mock-extended";
 import type { SolanaNonCustodialSigner } from "../types/signers";
 import base58 from "bs58";
 import { VersionedMessage, VersionedTransaction } from "@solana/web3.js";
+import type { WalletsV1Alpha2TransactionResponseDto } from "@/api/gen";
 
 vi.mock("@solana/web3.js", () => {
     return {
@@ -32,6 +33,9 @@ vi.mock("@solana/web3.js", () => {
                 this.message = { staticAccountKeys: [{ equals: () => true }] };
                 this.signatures = [new Uint8Array([1, 2, 3])];
             }
+            static deserialize() {
+                return new this();
+            }
         },
     };
 });
@@ -52,10 +56,13 @@ describe("SolanaApprovalsService", () => {
 
     describe("approve", () => {
         it("should successfully approve a transaction with single signer", async () => {
-            const messageBase58 = "jbvfjrXhwBBfLh5GiWf7owJQUkvokFFp1wxsnPhEciZqE87GMdN";
+            const transactionBase58 =
+                "jbvfjrXhwBBfLh5GiWf7owJQUkvokFFp1wxsnPhEciZqE87GMdN";
             const mockSignedTxn = {
                 message: {
-                    staticAccountKeys: [{ equals: vi.fn().mockReturnValue(true) }],
+                    staticAccountKeys: [
+                        { equals: vi.fn().mockReturnValue(true) },
+                    ],
                 },
                 signatures: [new Uint8Array([1, 2, 3])],
             };
@@ -69,15 +76,28 @@ describe("SolanaApprovalsService", () => {
             const pendingApprovals = [
                 {
                     signer: "mock-address",
-                    message: messageBase58,
+                    message: transactionBase58,
                 },
             ];
+
+            const mockTransaction: WalletsV1Alpha2TransactionResponseDto = {
+                id: "mock-tx-id",
+                walletType: "solana-smart-wallet",
+                onChain: {
+                    transaction: transactionBase58,
+                },
+                status: "awaiting-approval",
+            };
 
             apiClient.approveTransaction.mockResolvedValueOnce({
                 id: "mock-approval-id",
             });
 
-            const result = await approvalsService.approve("mock-tx-id", pendingApprovals, [signer]);
+            const result = await approvalsService.approve(
+                mockTransaction,
+                pendingApprovals,
+                [signer]
+            );
 
             // Verify signTransaction was called with a VersionedTransaction
             expect(signer.signTransaction).toHaveBeenCalled();
@@ -85,23 +105,29 @@ describe("SolanaApprovalsService", () => {
             expect(txnArg).toBeInstanceOf(VersionedTransaction);
 
             // Verify API call
-            expect(apiClient.approveTransaction).toHaveBeenCalledWith(walletLocator, "mock-tx-id", {
-                approvals: [
-                    {
-                        signer: "mock-address",
-                        signature: expect.any(String),
-                    },
-                ],
-            });
+            expect(apiClient.approveTransaction).toHaveBeenCalledWith(
+                walletLocator,
+                "mock-tx-id",
+                {
+                    approvals: [
+                        {
+                            signer: "mock-address",
+                            signature: expect.any(String),
+                        },
+                    ],
+                }
+            );
             expect(result).toEqual({ id: "mock-approval-id" });
         });
 
         it("should successfully approve a transaction with multiple signers", async () => {
-            const messageBase58 = "jbvfjrXhwBBfLh5GiWf7owJQUkvokFFp1wxsnPhEciZqE87GMdN";
-            const messageBytes = base58.decode(messageBase58);
+            const transactionBase58 =
+                "jbvfjrXhwBBfLh5GiWf7owJQUkvokFFp1wxsnPhEciZqE87GMdN";
 
             // Create mock transactions
-            const mockSignedTxn = new VersionedTransaction(VersionedMessage.deserialize(messageBytes));
+            const mockSignedTxn = new VersionedTransaction(
+                VersionedMessage.deserialize(base58.decode(transactionBase58))
+            );
 
             const signer1 = mock<SolanaNonCustodialSigner>({
                 address: "mock-address-1",
@@ -116,19 +142,32 @@ describe("SolanaApprovalsService", () => {
             const pendingApprovals = [
                 {
                     signer: "mock-address-1",
-                    message: messageBase58,
+                    message: transactionBase58,
                 },
                 {
                     signer: "mock-address-2",
-                    message: messageBase58,
+                    message: transactionBase58,
                 },
             ];
+
+            const mockTransaction: WalletsV1Alpha2TransactionResponseDto = {
+                id: "mock-tx-id",
+                walletType: "solana-smart-wallet",
+                onChain: {
+                    transaction: transactionBase58,
+                },
+                status: "awaiting-approval",
+            };
 
             apiClient.approveTransaction.mockResolvedValueOnce({
                 id: "mock-tx-id",
             });
 
-            const result = await approvalsService.approve("mock-tx-id", pendingApprovals, [signer1, signer2]);
+            const result = await approvalsService.approve(
+                mockTransaction,
+                pendingApprovals,
+                [signer1, signer2]
+            );
 
             // Verify signTransaction was called for both signers
             expect(signer1.signTransaction).toHaveBeenCalled();
@@ -136,18 +175,22 @@ describe("SolanaApprovalsService", () => {
 
             // Verify API call
             expect(apiClient.approveTransaction).toHaveBeenCalledTimes(1);
-            expect(apiClient.approveTransaction).toHaveBeenCalledWith(walletLocator, "mock-tx-id", {
-                approvals: [
-                    {
-                        signer: "mock-address-1",
-                        signature: expect.any(String),
-                    },
-                    {
-                        signer: "mock-address-2",
-                        signature: expect.any(String),
-                    },
-                ],
-            });
+            expect(apiClient.approveTransaction).toHaveBeenCalledWith(
+                walletLocator,
+                "mock-tx-id",
+                {
+                    approvals: [
+                        {
+                            signer: "mock-address-1",
+                            signature: expect.any(String),
+                        },
+                        {
+                            signer: "mock-address-2",
+                            signature: expect.any(String),
+                        },
+                    ],
+                }
+            );
             expect(result).toEqual({ id: "mock-tx-id" });
         });
 
@@ -159,13 +202,58 @@ describe("SolanaApprovalsService", () => {
             const pendingApprovals = [
                 {
                     signer: "different-address",
-                    message: "jbvfjrXhwBBfLh5GiWf7owJQUkvokFFp1wxsnPhEciZqE87GMdN",
+                    message:
+                        "jbvfjrXhwBBfLh5GiWf7owJQUkvokFFp1wxsnPhEciZqE87GMdN",
                 },
             ];
 
-            await expect(approvalsService.approve("mock-tx-id", pendingApprovals, [signer])).rejects.toThrow(
+            const mockTransaction: WalletsV1Alpha2TransactionResponseDto = {
+                id: "mock-tx-id",
+                walletType: "solana-smart-wallet",
+                onChain: {
+                    transaction:
+                        "jbvfjrXhwBBfLh5GiWf7owJQUkvokFFp1wxsnPhEciZqE87GMdN",
+                },
+                status: "awaiting-approval",
+            };
+
+            await expect(
+                approvalsService.approve(mockTransaction, pendingApprovals, [
+                    signer,
+                ])
+            ).rejects.toThrow(
                 "Signer different-address is required for the transaction but was not found in the signer list"
             );
+        });
+
+        it("should throw error for unsupported wallet type", async () => {
+            const signer = mock<SolanaNonCustodialSigner>({
+                address: "mock-address",
+            });
+
+            const pendingApprovals = [
+                {
+                    signer: "mock-address",
+                    message:
+                        "jbvfjrXhwBBfLh5GiWf7owJQUkvokFFp1wxsnPhEciZqE87GMdN",
+                },
+            ];
+
+            const mockTransaction: WalletsV1Alpha2TransactionResponseDto = {
+                id: "mock-tx-id",
+                walletType: "unsupported-wallet",
+                onChain: {
+                    transaction:
+                        "jbvfjrXhwBBfLh5GiWf7owJQUkvokFFp1wxsnPhEciZqE87GMdN",
+                },
+                status: "awaiting-approval",
+            };
+
+            await expect(
+                approvalsService.approve(mockTransaction, pendingApprovals, [
+                    signer,
+                ])
+            ).rejects.toThrow("Unsupported wallet type: unsupported-wallet");
         });
     });
 });

--- a/packages/wallets/src/solana/services/approvals-service.ts
+++ b/packages/wallets/src/solana/services/approvals-service.ts
@@ -37,7 +37,6 @@ export class SolanaApprovalsService {
                 const walletPublicKey = new PublicKey(signer.address);
 
                 const signature = this.retrieveValidSignature(signedTxn, walletPublicKey);
-                console.log("Signature from tx", signature);
                 return {
                     signature,
                     signer: approval.signer,

--- a/packages/wallets/src/solana/services/approvals-service.ts
+++ b/packages/wallets/src/solana/services/approvals-service.ts
@@ -1,26 +1,11 @@
 import bs58 from "bs58";
-import {
-    PublicKey,
-    Transaction,
-    VersionedMessage,
-    VersionedTransaction,
-} from "@solana/web3.js";
-import type {
-    ApiClient,
-    CreateTransactionSuccessResponse,
-    SolanaWalletLocator,
-} from "@/api";
+import { PublicKey, VersionedTransaction } from "@solana/web3.js";
+import type { ApiClient, CreateTransactionSuccessResponse, SolanaWalletLocator } from "@/api";
 import type { SolanaNonCustodialSigner } from "../types/signers";
-import {
-    PendingApprovalsError,
-    InvalidSignerError,
-    TransactionFailedError,
-} from "../../utils/errors";
+import { PendingApprovalsError, InvalidSignerError, TransactionFailedError } from "../../utils/errors";
 import type { WalletsV1Alpha2TransactionResponseDto } from "@/api/gen";
 
-type PendingApproval = NonNullable<
-    NonNullable<CreateTransactionSuccessResponse["approvals"]>["pending"]
->[number];
+type PendingApproval = NonNullable<NonNullable<CreateTransactionSuccessResponse["approvals"]>["pending"]>[number];
 
 export class SolanaApprovalsService {
     constructor(
@@ -33,40 +18,25 @@ export class SolanaApprovalsService {
         pendingApprovals: Array<PendingApproval>,
         signers: Array<SolanaNonCustodialSigner>
     ) {
-        if (
-            transaction.walletType !== "solana-smart-wallet" &&
-            transaction.walletType !== "solana-mpc-wallet"
-        ) {
-            throw new Error(
-                `Unsupported wallet type: ${transaction.walletType}`
-            );
+        if (transaction.walletType !== "solana-smart-wallet" && transaction.walletType !== "solana-mpc-wallet") {
+            throw new Error(`Unsupported wallet type: ${transaction.walletType}`);
         }
         const approvals = await Promise.all(
             pendingApprovals.map(async (approval) => {
-                const signer = signers.find((s) =>
-                    approval.signer.includes(s.address)
-                );
+                const signer = signers.find((s) => approval.signer.includes(s.address));
                 if (signer == null) {
                     throw new InvalidSignerError(
                         `Signer ${approval.signer} is required for the transaction but was not found in the signer list`
                     );
                 }
-                const transactionBytes = bs58.decode(
-                    transaction.onChain.transaction
-                );
-                const deserializedTransaction =
-                    VersionedTransaction.deserialize(transactionBytes);
+                const transactionBytes = bs58.decode(transaction.onChain.transaction);
+                const deserializedTransaction = VersionedTransaction.deserialize(transactionBytes);
                 // Sign the transaction (we can't use signMessage on transactions, so we need to sign the transaction directly)
-                const signedTxn = await signer.signTransaction(
-                    deserializedTransaction
-                );
+                const signedTxn = await signer.signTransaction(deserializedTransaction);
                 // Get the signature from the signed transaction
                 const walletPublicKey = new PublicKey(signer.address);
 
-                const signature = this.retrieveValidSignature(
-                    signedTxn,
-                    walletPublicKey
-                );
+                const signature = this.retrieveValidSignature(signedTxn, walletPublicKey);
                 console.log("Signature from tx", signature);
                 return {
                     signature,
@@ -74,43 +44,26 @@ export class SolanaApprovalsService {
                 };
             })
         );
-        const approvedTransaction = await this.apiClient.approveTransaction(
-            this.walletLocator,
-            transaction.id,
-            {
-                approvals,
-            }
-        );
+        const approvedTransaction = await this.apiClient.approveTransaction(this.walletLocator, transaction.id, {
+            approvals,
+        });
         if (approvedTransaction.error) {
-            throw new TransactionFailedError(
-                JSON.stringify(approvedTransaction)
-            );
+            throw new TransactionFailedError(JSON.stringify(approvedTransaction));
         }
         if (approvedTransaction.status === "awaiting-approval") {
-            throw new PendingApprovalsError(
-                "Still has pending approvals, please submit all approvals"
-            );
+            throw new PendingApprovalsError("Still has pending approvals, please submit all approvals");
         }
         return approvedTransaction;
     }
 
-    private retrieveValidSignature(
-        signedTxn: VersionedTransaction,
-        signerPublicKey: PublicKey
-    ) {
-        const signerIndex = signedTxn.message.staticAccountKeys.findIndex(
-            (key) => key.equals(signerPublicKey)
-        );
+    private retrieveValidSignature(signedTxn: VersionedTransaction, signerPublicKey: PublicKey) {
+        const signerIndex = signedTxn.message.staticAccountKeys.findIndex((key) => key.equals(signerPublicKey));
         if (signerIndex === -1) {
-            throw new TransactionFailedError(
-                "Wallet public key not found in transaction signers"
-            );
+            throw new TransactionFailedError("Wallet public key not found in transaction signers");
         }
         const signature = signedTxn.signatures[signerIndex];
         if (signature == null) {
-            throw new TransactionFailedError(
-                "No valid signature found in the transaction"
-            );
+            throw new TransactionFailedError("No valid signature found in the transaction");
         }
         const signatureBytes = new Uint8Array(Object.values(signature));
         return bs58.encode(signatureBytes);

--- a/packages/wallets/src/solana/services/approvals-service.ts
+++ b/packages/wallets/src/solana/services/approvals-service.ts
@@ -1,10 +1,26 @@
 import bs58 from "bs58";
-import { PublicKey, VersionedMessage, VersionedTransaction } from "@solana/web3.js";
-import type { ApiClient, CreateTransactionSuccessResponse, SolanaWalletLocator } from "@/api";
+import {
+    PublicKey,
+    Transaction,
+    VersionedMessage,
+    VersionedTransaction,
+} from "@solana/web3.js";
+import type {
+    ApiClient,
+    CreateTransactionSuccessResponse,
+    SolanaWalletLocator,
+} from "@/api";
 import type { SolanaNonCustodialSigner } from "../types/signers";
-import { PendingApprovalsError, InvalidSignerError, TransactionFailedError } from "../../utils/errors";
+import {
+    PendingApprovalsError,
+    InvalidSignerError,
+    TransactionFailedError,
+} from "../../utils/errors";
+import type { WalletsV1Alpha2TransactionResponseDto } from "@/api/gen";
 
-type PendingApproval = NonNullable<NonNullable<CreateTransactionSuccessResponse["approvals"]>["pending"]>[number];
+type PendingApproval = NonNullable<
+    NonNullable<CreateTransactionSuccessResponse["approvals"]>["pending"]
+>[number];
 
 export class SolanaApprovalsService {
     constructor(
@@ -13,53 +29,88 @@ export class SolanaApprovalsService {
     ) {}
 
     public async approve(
-        transactionId: string,
+        transaction: WalletsV1Alpha2TransactionResponseDto,
         pendingApprovals: Array<PendingApproval>,
         signers: Array<SolanaNonCustodialSigner>
     ) {
+        if (
+            transaction.walletType !== "solana-smart-wallet" &&
+            transaction.walletType !== "solana-mpc-wallet"
+        ) {
+            throw new Error(
+                `Unsupported wallet type: ${transaction.walletType}`
+            );
+        }
         const approvals = await Promise.all(
             pendingApprovals.map(async (approval) => {
-                const signer = signers.find((s) => approval.signer.includes(s.address));
+                const signer = signers.find((s) =>
+                    approval.signer.includes(s.address)
+                );
                 if (signer == null) {
                     throw new InvalidSignerError(
                         `Signer ${approval.signer} is required for the transaction but was not found in the signer list`
                     );
                 }
-                // Convert the decoded transaction message from server back into a VersionedTransaction
-                const messageBytes = bs58.decode(approval.message);
-                const message = VersionedMessage.deserialize(messageBytes);
-                const transaction = new VersionedTransaction(message);
+                const transactionBytes = bs58.decode(
+                    transaction.onChain.transaction
+                );
+                const deserializedTransaction =
+                    VersionedTransaction.deserialize(transactionBytes);
                 // Sign the transaction (we can't use signMessage on transactions, so we need to sign the transaction directly)
-                const signedTxn = await signer.signTransaction(transaction);
+                const signedTxn = await signer.signTransaction(
+                    deserializedTransaction
+                );
                 // Get the signature from the signed transaction
                 const walletPublicKey = new PublicKey(signer.address);
-                const signature = this.retrieveValidSignature(signedTxn, walletPublicKey);
+
+                const signature = this.retrieveValidSignature(
+                    signedTxn,
+                    walletPublicKey
+                );
+                console.log("Signature from tx", signature);
                 return {
                     signature,
                     signer: approval.signer,
                 };
             })
         );
-        const transaction = await this.apiClient.approveTransaction(this.walletLocator, transactionId, {
-            approvals,
-        });
-        if (transaction.error) {
-            throw new TransactionFailedError(JSON.stringify(transaction));
+        const approvedTransaction = await this.apiClient.approveTransaction(
+            this.walletLocator,
+            transaction.id,
+            {
+                approvals,
+            }
+        );
+        if (approvedTransaction.error) {
+            throw new TransactionFailedError(
+                JSON.stringify(approvedTransaction)
+            );
         }
-        if (transaction.status === "awaiting-approval") {
-            throw new PendingApprovalsError("Still has pending approvals, please submit all approvals");
+        if (approvedTransaction.status === "awaiting-approval") {
+            throw new PendingApprovalsError(
+                "Still has pending approvals, please submit all approvals"
+            );
         }
-        return transaction;
+        return approvedTransaction;
     }
 
-    private retrieveValidSignature(signedTxn: VersionedTransaction, signerPublicKey: PublicKey) {
-        const signerIndex = signedTxn.message.staticAccountKeys.findIndex((key) => key.equals(signerPublicKey));
+    private retrieveValidSignature(
+        signedTxn: VersionedTransaction,
+        signerPublicKey: PublicKey
+    ) {
+        const signerIndex = signedTxn.message.staticAccountKeys.findIndex(
+            (key) => key.equals(signerPublicKey)
+        );
         if (signerIndex === -1) {
-            throw new TransactionFailedError("Wallet public key not found in transaction signers");
+            throw new TransactionFailedError(
+                "Wallet public key not found in transaction signers"
+            );
         }
         const signature = signedTxn.signatures[signerIndex];
         if (signature == null) {
-            throw new TransactionFailedError("No valid signature found in the transaction");
+            throw new TransactionFailedError(
+                "No valid signature found in the transaction"
+            );
         }
         const signatureBytes = new Uint8Array(Object.values(signature));
         return bs58.encode(signatureBytes);

--- a/packages/wallets/src/solana/services/transaction-service.test.ts
+++ b/packages/wallets/src/solana/services/transaction-service.test.ts
@@ -19,11 +19,7 @@ describe("SolanaTransactionsService", () => {
     let transactionsService: SolanaTransactionsService;
     beforeEach(() => {
         vi.resetAllMocks();
-        transactionsService = new SolanaTransactionsService(
-            walletLocator,
-            apiClient,
-            approvalsService
-        );
+        transactionsService = new SolanaTransactionsService(walletLocator, apiClient, approvalsService);
     });
     it("transaction creation complete flow -- happy path", async () => {
         const signer = mock<SolanaNonCustodialSigner>({
@@ -37,8 +33,7 @@ describe("SolanaTransactionsService", () => {
             },
         ];
 
-        const serializedTransactionString =
-            "jbvfjrXhwBBfLh5GiWf7owJQUkvokFFp1wxsnPhEciZqE87GMdN";
+        const serializedTransactionString = "jbvfjrXhwBBfLh5GiWf7owJQUkvokFFp1wxsnPhEciZqE87GMdN";
         const serializedTransaction = bs58.decode(serializedTransactionString);
         transaction.serialize.mockReturnValueOnce(serializedTransaction);
         apiClient.createTransaction.mockResolvedValueOnce({
@@ -88,26 +83,16 @@ describe("SolanaTransactionsService", () => {
 
         expect(transaction.serialize).toHaveBeenCalledTimes(1);
         expect(apiClient.createTransaction).toHaveBeenCalledTimes(1);
-        expect(apiClient.createTransaction).toHaveBeenCalledWith(
-            walletLocator,
-            {
-                params: {
-                    signer: "mock-address",
-                    transaction: serializedTransactionString,
-                    additionalSigners: [],
-                },
-            }
-        );
+        expect(apiClient.createTransaction).toHaveBeenCalledWith(walletLocator, {
+            params: {
+                signer: "mock-address",
+                transaction: serializedTransactionString,
+                additionalSigners: [],
+            },
+        });
         expect(approvalsService.approve).toHaveBeenCalledTimes(1);
-        expect(approvalsService.approve).toHaveBeenCalledWith(
-            mockTransaction,
-            pendingApprovals,
-            [signer]
-        );
+        expect(approvalsService.approve).toHaveBeenCalledWith(mockTransaction, pendingApprovals, [signer]);
         expect(apiClient.getTransaction).toHaveBeenCalledTimes(4);
-        expect(apiClient.getTransaction).toHaveBeenCalledWith(
-            walletLocator,
-            "mock-tx-id"
-        );
+        expect(apiClient.getTransaction).toHaveBeenCalledWith(walletLocator, "mock-tx-id");
     });
 });

--- a/packages/wallets/src/solana/services/transactions-service.ts
+++ b/packages/wallets/src/solana/services/transactions-service.ts
@@ -46,23 +46,13 @@ export class SolanaTransactionsService {
         return await this.apiClient.getTransactions(this.walletLocator);
     }
 
-    async approveTransaction(
-        transactionId: string,
-        signers: SolanaNonCustodialSigner[]
-    ) {
-        const transaction = await this.apiClient.getTransaction(
-            this.walletLocator,
-            transactionId
-        );
+    async approveTransaction(transactionId: string, signers: SolanaNonCustodialSigner[]) {
+        const transaction = await this.apiClient.getTransaction(this.walletLocator, transactionId);
         if (transaction.error) {
             throw new TransactionNotAvailableError(JSON.stringify(transaction));
         }
         if (transaction.status === "awaiting-approval") {
-            await this.approvalsService.approve(
-                transaction,
-                transaction.approvals?.pending || [],
-                signers
-            );
+            await this.approvalsService.approve(transaction, transaction.approvals?.pending || [], signers);
         }
     }
 
@@ -77,58 +67,41 @@ export class SolanaTransactionsService {
             ...(signer ? { signer: signer.address } : {}),
             ...(additionalSigners
                 ? {
-                      additionalSigners: additionalSigners.map(
-                          (s) => s.address
-                      ),
+                      additionalSigners: additionalSigners.map((s) => s.address),
                   }
                 : {}),
         };
 
-        const transactionCreationResponse =
-            await this.apiClient.createTransaction(this.walletLocator, {
-                params: transactionParams,
-            });
+        const transactionCreationResponse = await this.apiClient.createTransaction(this.walletLocator, {
+            params: transactionParams,
+        });
         if (transactionCreationResponse.error) {
-            throw new TransactionNotCreatedError(
-                JSON.stringify(transactionCreationResponse)
-            );
+            throw new TransactionNotCreatedError(JSON.stringify(transactionCreationResponse));
         }
         return transactionCreationResponse;
     }
 
-    async waitForTransaction(
-        transactionId: string,
-        timeoutMs = 60000
-    ): Promise<string> {
+    async waitForTransaction(transactionId: string, timeoutMs = 60000): Promise<string> {
         const startTime = Date.now();
         let transactionResponse;
 
         do {
             if (Date.now() - startTime > timeoutMs) {
-                const error = new TransactionConfirmationTimeoutError(
-                    "Transaction confirmation timeout"
-                );
+                const error = new TransactionConfirmationTimeoutError("Transaction confirmation timeout");
                 await this.callbacks.onTransactionFail?.(error);
                 throw error;
             }
 
-            transactionResponse = await this.apiClient.getTransaction(
-                this.walletLocator,
-                transactionId
-            );
+            transactionResponse = await this.apiClient.getTransaction(this.walletLocator, transactionId);
             if (transactionResponse.error) {
-                throw new TransactionNotAvailableError(
-                    JSON.stringify(transactionResponse)
-                );
+                throw new TransactionNotAvailableError(JSON.stringify(transactionResponse));
             }
             await sleep(STATUS_POLLING_INTERVAL_MS);
         } while (transactionResponse.status === "pending");
 
         if (transactionResponse.status === "failed") {
             const error = new TransactionSendingFailedError(
-                `Transaction sending failed: ${JSON.stringify(
-                    transactionResponse.error
-                )}`
+                `Transaction sending failed: ${JSON.stringify(transactionResponse.error)}`
             );
             await this.callbacks.onTransactionFail?.(error);
             throw error;
@@ -144,9 +117,7 @@ export class SolanaTransactionsService {
 
         const transactionHash = transactionResponse.onChain.txId;
         if (transactionHash == null) {
-            const error = new TransactionHashNotFoundError(
-                "Transaction hash not found on transaction response"
-            );
+            const error = new TransactionHashNotFoundError("Transaction hash not found on transaction response");
             await this.callbacks.onTransactionFail?.(error);
             throw error;
         }

--- a/packages/wallets/src/solana/services/transactions-service.ts
+++ b/packages/wallets/src/solana/services/transactions-service.ts
@@ -46,13 +46,23 @@ export class SolanaTransactionsService {
         return await this.apiClient.getTransactions(this.walletLocator);
     }
 
-    async approveTransaction(transactionId: string, signers: SolanaNonCustodialSigner[]) {
-        const transaction = await this.apiClient.getTransaction(this.walletLocator, transactionId);
+    async approveTransaction(
+        transactionId: string,
+        signers: SolanaNonCustodialSigner[]
+    ) {
+        const transaction = await this.apiClient.getTransaction(
+            this.walletLocator,
+            transactionId
+        );
         if (transaction.error) {
             throw new TransactionNotAvailableError(JSON.stringify(transaction));
         }
         if (transaction.status === "awaiting-approval") {
-            await this.approvalsService.approve(transaction.id, transaction.approvals?.pending || [], signers);
+            await this.approvalsService.approve(
+                transaction,
+                transaction.approvals?.pending || [],
+                signers
+            );
         }
     }
 
@@ -67,41 +77,58 @@ export class SolanaTransactionsService {
             ...(signer ? { signer: signer.address } : {}),
             ...(additionalSigners
                 ? {
-                      additionalSigners: additionalSigners.map((s) => s.address),
+                      additionalSigners: additionalSigners.map(
+                          (s) => s.address
+                      ),
                   }
                 : {}),
         };
 
-        const transactionCreationResponse = await this.apiClient.createTransaction(this.walletLocator, {
-            params: transactionParams,
-        });
+        const transactionCreationResponse =
+            await this.apiClient.createTransaction(this.walletLocator, {
+                params: transactionParams,
+            });
         if (transactionCreationResponse.error) {
-            throw new TransactionNotCreatedError(JSON.stringify(transactionCreationResponse));
+            throw new TransactionNotCreatedError(
+                JSON.stringify(transactionCreationResponse)
+            );
         }
         return transactionCreationResponse;
     }
 
-    async waitForTransaction(transactionId: string, timeoutMs = 60000): Promise<string> {
+    async waitForTransaction(
+        transactionId: string,
+        timeoutMs = 60000
+    ): Promise<string> {
         const startTime = Date.now();
         let transactionResponse;
 
         do {
             if (Date.now() - startTime > timeoutMs) {
-                const error = new TransactionConfirmationTimeoutError("Transaction confirmation timeout");
+                const error = new TransactionConfirmationTimeoutError(
+                    "Transaction confirmation timeout"
+                );
                 await this.callbacks.onTransactionFail?.(error);
                 throw error;
             }
 
-            transactionResponse = await this.apiClient.getTransaction(this.walletLocator, transactionId);
+            transactionResponse = await this.apiClient.getTransaction(
+                this.walletLocator,
+                transactionId
+            );
             if (transactionResponse.error) {
-                throw new TransactionNotAvailableError(JSON.stringify(transactionResponse));
+                throw new TransactionNotAvailableError(
+                    JSON.stringify(transactionResponse)
+                );
             }
             await sleep(STATUS_POLLING_INTERVAL_MS);
         } while (transactionResponse.status === "pending");
 
         if (transactionResponse.status === "failed") {
             const error = new TransactionSendingFailedError(
-                `Transaction sending failed: ${JSON.stringify(transactionResponse.error)}`
+                `Transaction sending failed: ${JSON.stringify(
+                    transactionResponse.error
+                )}`
             );
             await this.callbacks.onTransactionFail?.(error);
             throw error;
@@ -117,7 +144,9 @@ export class SolanaTransactionsService {
 
         const transactionHash = transactionResponse.onChain.txId;
         if (transactionHash == null) {
-            const error = new TransactionHashNotFoundError("Transaction hash not found on transaction response");
+            const error = new TransactionHashNotFoundError(
+                "Transaction hash not found on transaction response"
+            );
             await this.callbacks.onTransactionFail?.(error);
             throw error;
         }


### PR DESCRIPTION
## Description

This was popping up in the backpack wallet, the transaction was tampered with in the browser (maybe due to lacking a proper blockhash or signer) and the signature it returned was not the one we expected, which made the transaction fail

## Test plan

Tested by using it in the SSW quickstart, tested backwards compatibility with phantom

## Package updates

Wallets SDK
<!-- 
  List any package updates and ensure you've added the necessary changesets, running `pnpm change:add` to do so.
-->