### PR TITLE
Use Public RPCs for `client-sdk-smart-wallet`

### DIFF
--- a/.changeset/giant-hats-appear.md
+++ b/.changeset/giant-hats-appear.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-smart-wallet": patch
+---
+
+Use public RPCs

--- a/packages/client/wallets/smart-wallet/src/evm/rpc.ts
+++ b/packages/client/wallets/smart-wallet/src/evm/rpc.ts
@@ -1,5 +1,0 @@
-import { viemNetworks, type SmartWalletChain } from "./chains";
-
-export function getRPC(chain: SmartWalletChain): string {
-    return viemNetworks[chain].rpcUrls.default.http[0];
-}

--- a/packages/client/wallets/smart-wallet/src/evm/rpc.ts
+++ b/packages/client/wallets/smart-wallet/src/evm/rpc.ts
@@ -1,33 +1,5 @@
-import { blockchainToChainId } from "@crossmint/common-sdk-base";
-
 import { viemNetworks, type SmartWalletChain } from "./chains";
 
-const ALCHEMY_API_KEY = "-7M6vRDBDknwvMxnqah_jbcieWg0qad9";
-const PIMLICO_API_KEY = "pim_9dKmQPxiTCvtbUNF7XFBbA";
-
-export const ALCHEMY_RPC_SUBDOMAIN: Partial<Record<SmartWalletChain, string>> = {
-    polygon: "polygon-mainnet",
-    "polygon-amoy": "polygon-amoy",
-    base: "base-mainnet",
-    "base-sepolia": "base-sepolia",
-    optimism: "opt-mainnet",
-    "optimism-sepolia": "opt-sepolia",
-    arbitrum: "arb-mainnet",
-    "arbitrum-sepolia": "arb-sepolia",
-};
-
-export function getAlchemyRPC(chain: SmartWalletChain): string {
-    return `https://${ALCHEMY_RPC_SUBDOMAIN[chain]}.g.alchemy.com/v2/${ALCHEMY_API_KEY}`;
-}
-
 export function getRPC(chain: SmartWalletChain): string {
-    if (chain === "story-testnet" || chain === "story") {
-        // Story is not supported by Alchemy yet
-        return viemNetworks[chain].rpcUrls.default.http[0];
-    }
-    return getAlchemyRPC(chain);
-}
-
-export function getPimlicoBundlerRPC(chain: SmartWalletChain): string {
-    return `https://api.pimlico.io/v2/${blockchainToChainId(chain)}/rpc?apikey=${PIMLICO_API_KEY}`;
+    return viemNetworks[chain].rpcUrls.default.http[0];
 }

--- a/packages/client/wallets/smart-wallet/src/evm/wallet.ts
+++ b/packages/client/wallets/smart-wallet/src/evm/wallet.ts
@@ -27,11 +27,11 @@ export class EVMSmartWallet {
             /**
              * An interface to interact with the smart wallet, execute transactions, sign messages, etc.
              */
-            public: PublicClient<HttpTransport>;
+            wallet: SmartWalletClient;
             /**
              * An interface to read onchain data, fetch transactions, retrieve account balances, etc. Corresponds to public [JSON-RPC API](https://ethereum.org/en/developers/docs/apis/json-rpc/) methods.
              */
-            wallet: SmartWalletClient;
+            public: PublicClient<HttpTransport>;
         },
         public readonly chain: SmartWalletChain,
         private readonly apiService: CrossmintApiService

--- a/packages/client/wallets/smart-wallet/src/smartWalletService.ts
+++ b/packages/client/wallets/smart-wallet/src/smartWalletService.ts
@@ -21,10 +21,9 @@ import { WebAuthnP256 } from "ox";
 import entryPointAbi from "./abi/entryPoint";
 import type { CrossmintApiService } from "./apiService";
 import type { CreateWalletResponse, TransactionResponse, Signer, SignatureResponse } from "./types/api";
-import type { SmartWalletChain } from "./evm/chains";
+import { viemNetworks, type SmartWalletChain } from "./evm/chains";
 import type { SmartWalletClient } from "./evm/smartWalletClient";
 import { EVMSmartWallet } from "./evm/wallet";
-import { getRPC } from "./evm/rpc";
 import { sleep } from "./utils";
 import { ENTRY_POINT_ADDRESS, STATUS_POLLING_INTERVAL_MS } from "./utils/constants";
 import {
@@ -85,16 +84,16 @@ export class SmartWalletService {
         callbacks?: Callbacks
     ): Promise<EVMSmartWallet> {
         this.callbacks = callbacks;
-        const publicClient = createPublicClient({
-            transport: http(getRPC(chain)),
-        });
         const { signer } = walletParams;
         const walletResponse = await this.createWallet(user, signer);
         const address = walletResponse.address;
         return new EVMSmartWallet(
             {
                 wallet: this.smartAccountClient(user, signer, chain, address),
-                public: publicClient,
+                public: createPublicClient({
+                    chain: viemNetworks[chain],
+                    transport: http(),
+                }),
             },
             chain,
             this.crossmintApiService
@@ -113,10 +112,10 @@ export class SmartWalletService {
             },
 
             getNonce: async (params?: { key?: bigint }) => {
-                const publicClient = createPublicClient({
-                    transport: http(getRPC(chain)),
-                });
-                const nonce = await publicClient.readContract({
+                const nonce = await createPublicClient({
+                    chain: viemNetworks[chain],
+                    transport: http(),
+                }).readContract({
                     abi: entryPointAbi,
                     address: ENTRY_POINT_ADDRESS,
                     functionName: "getNonce",

--- a/packages/client/wallets/smart-wallet/src/smartWalletService.ts
+++ b/packages/client/wallets/smart-wallet/src/smartWalletService.ts
@@ -24,7 +24,7 @@ import type { CreateWalletResponse, TransactionResponse, Signer, SignatureRespon
 import type { SmartWalletChain } from "./evm/chains";
 import type { SmartWalletClient } from "./evm/smartWalletClient";
 import { EVMSmartWallet } from "./evm/wallet";
-import { getAlchemyRPC } from "./evm/rpc";
+import { getRPC } from "./evm/rpc";
 import { sleep } from "./utils";
 import { ENTRY_POINT_ADDRESS, STATUS_POLLING_INTERVAL_MS } from "./utils/constants";
 import {
@@ -86,7 +86,7 @@ export class SmartWalletService {
     ): Promise<EVMSmartWallet> {
         this.callbacks = callbacks;
         const publicClient = createPublicClient({
-            transport: http(getAlchemyRPC(chain)),
+            transport: http(getRPC(chain)),
         });
         const { signer } = walletParams;
         const walletResponse = await this.createWallet(user, signer);
@@ -114,7 +114,7 @@ export class SmartWalletService {
 
             getNonce: async (params?: { key?: bigint }) => {
                 const publicClient = createPublicClient({
-                    transport: http(getAlchemyRPC(chain)),
+                    transport: http(getRPC(chain)),
                 });
                 const nonce = await publicClient.readContract({
                     abi: entryPointAbi,


### PR DESCRIPTION
## Description

We have some RPCs hardcoded we're treating as public that are remnants of an old architecture. Now that everything is routed through our APIs, the remaining places we do use public PRCs:
- To implement a `viem` interface and support `getNonce`, which calls a smart contract.
- Exposed as `wallet.client.public` from our `EVMSmartWallet` object
Expect little enough usage for default public RPCs from viem.

This is also what we do in our latest package `@crossmint/wallets-sdk`

<img width="412" alt="Screenshot 2025-04-14 at 8 25 52 PM" src="https://github.com/user-attachments/assets/69656388-8848-4d99-9326-a1aa40226223" />

## Test plan

Didn't test because this PR only:
- deletes unused code
- changes the inputs to `createPublicClient` from our own RPCs to default public RPCs from `viem`. I copied the code populate `createPublicClient` with default RPCs from `@crossmint/wallets-sdk`.

## Package updates

patch `client-sdk-smart-wallet`