### PR TITLE
Bugs: Exports types from react native + fixes rpcs in web3auth

### DIFF
--- a/.changeset/late-news-guess.md
+++ b/.changeset/late-news-guess.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-smart-wallet-web3auth-adapter": patch
+---
+
+Uses non-ankr rpc urls, uses defaults from viem

--- a/.changeset/tasty-turtles-count.md
+++ b/.changeset/tasty-turtles-count.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-native-ui": patch
+---
+
+Exports types from wallet and fixes exporting CrossmintAuthProvider

--- a/packages/client/ui/react-native/src/index.ts
+++ b/packages/client/ui/react-native/src/index.ts
@@ -1,7 +1,7 @@
 export * from "./hooks";
 export * from "./providers";
 
-export type { EVMSmartWallet, SolanaSmartWallet } from "@crossmint/wallets-sdk";
+export type { EVMSmartWallet, SolanaSmartWallet, DelegatedSigner, WalletBalance } from "@crossmint/wallets-sdk";
 export type { CrossmintEvent, CrossmintEventMap } from "@crossmint/client-sdk-base";
 
 export type { SDKExternalUser, OAuthProvider } from "@crossmint/common-sdk-auth";

--- a/packages/client/ui/react-native/src/providers/CrossmintAuthProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintAuthProvider.tsx
@@ -99,7 +99,6 @@ export function CrossmintAuthProvider({
         if (crossmint.jwt == null) {
             storageProvider?.get("jwt").then((jwt) => {
                 if (jwt != null) {
-                    console.log("[CrossmintAuthProvider] jwt", jwt);
                     setJwt(jwt);
                 }
             });

--- a/packages/client/ui/react-native/src/providers/index.ts
+++ b/packages/client/ui/react-native/src/providers/index.ts
@@ -1,2 +1,3 @@
 export { CrossmintProvider } from "./CrossmintProvider";
+export { CrossmintAuthProvider } from "./CrossmintAuthProvider";
 export { CrossmintWalletProvider } from "@crossmint/client-sdk-react-base";

--- a/packages/client/wallets/web3auth-adapter/src/networks.ts
+++ b/packages/client/wallets/web3auth-adapter/src/networks.ts
@@ -3,10 +3,10 @@ import type { EVMBlockchainIncludingTestnet } from "@crossmint/common-sdk-base";
 export function getUrlProviderByBlockchain(chain: EVMBlockchainIncludingTestnet) {
     const url = new Map<EVMBlockchainIncludingTestnet, string | null>([
         ["ethereum", "https://eth.llamarpc.com"],
-        ["polygon", "https://rpc.ankr.com/polygon"],
+        ["polygon", "https://polygon-rpc.com"],
         ["bsc", "https://binance.llamarpc.com"],
-        ["optimism", "https://rpc.ankr.com/optimism"],
-        ["arbitrum", "https://rpc.ankr.com/arbitrum"],
+        ["optimism", "https://mainnet.optimism.io"],
+        ["arbitrum", "https://arb1.arbitrum.io/rpc"],
         ["ethereum-sepolia", "https://ethereum-sepolia.publicnode.com"],
         ["polygon-amoy", "https://rpc-amoy.polygon.technology"],
         ["zkatana", "https://rpc.startale.com/zkatana"],


### PR DESCRIPTION
## Description

Mixed in a couple of fixes:

- export new types from wallet-sdk in react native
- fixed exporting CrossmintAuthProvider
- Move away from non-functioning rpcs in web3auth-adapter

## Test plan

Tested with expo

## Package updates

react-native: patch
web3auth-adapter: patch