### PR TITLE
Common sdk auth: Updated twitter metadata type

### DIFF
--- a/.changeset/metal-crabs-drop.md
+++ b/.changeset/metal-crabs-drop.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/common-sdk-auth": patch
+---
+
+Added TwitterMetadata type

--- a/packages/common/auth/src/types/user.ts
+++ b/packages/common/auth/src/types/user.ts
@@ -8,10 +8,14 @@ export type FarcasterMetadata = {
     verifications: string[];
 };
 
+export type TwitterMetadata = {
+    username: string;
+};
+
 export type SDKExternalUser = {
     id: string;
     email?: string;
     phoneNumber?: string;
     farcaster?: FarcasterMetadata;
-    twitter?: string;
+    twitter?: TwitterMetadata;
 };


### PR DESCRIPTION
## Description

Since we now expose the twitter username in oauth login method, we needed to update the types.

## Test plan

na

## Package updates

@crossmint/common-sdk-auth