### PR TITLE
NCS: support non-happy-path responses on events

### DIFF
--- a/.changeset/two-ligers-shake.md
+++ b/.changeset/two-ligers-shake.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-signers": patch
+---
+
+Adapting events

--- a/packages/client/signers/src/communications/schemas.ts
+++ b/packages/client/signers/src/communications/schemas.ts
@@ -9,13 +9,28 @@ const AuthenticatedEventRequest = z.object({
     }),
 });
 
+const ErrorResponse = z.object({
+    error: z.string(),
+    code: z.string().optional(),
+    data: z.any().optional(),
+});
+
+const ResultResponse = <T extends z.ZodRawShape>(schema: z.ZodObject<T>) =>
+    ErrorResponse.or(
+        schema.extend({
+            status: z.literal("success"),
+        })
+    );
+
 export const GetAttestationPayloadSchema = {
     request: z.object({
         challenge: z.string(),
     }),
-    response: z.object({
-        attestationDocument: z.record(z.string(), z.any()), // TODO: Refine this type
-    }),
+    response: ResultResponse(
+        z.object({
+            attestationDocument: z.record(z.string(), z.any()), // TODO: Refine this type
+        })
+    ),
 };
 
 export const SignMessagePayloadSchema = {
@@ -26,10 +41,12 @@ export const SignMessagePayloadSchema = {
             encoding: z.enum(["base58"]).optional().default("base58"),
         }),
     }),
-    response: z.object({
-        signature: z.string(),
-        publicKey: z.string(),
-    }),
+    response: ResultResponse(
+        z.object({
+            signature: z.string(),
+            publicKey: z.string(),
+        })
+    ),
 };
 
 export const SignTransactionPayloadSchema = {
@@ -40,19 +57,26 @@ export const SignTransactionPayloadSchema = {
             encoding: z.enum(["base58"]).optional().default("base58"),
         }),
     }),
-    response: z.object({
-        signature: z.string(),
-        publicKey: z.string(),
-    }),
+    response: ResultResponse(
+        z.object({
+            signature: z.string(),
+            publicKey: z.string(),
+        })
+    ),
 };
 
 export const CreateSignerPayloadSchema = {
     request: AuthenticatedEventRequest.extend({
         data: z.object({
             authId: z.string(),
+            chainLayer: SupportedChainLayer,
         }),
     }),
-    response: z.object({}),
+    response: ResultResponse(
+        z.object({
+            address: z.string(),
+        })
+    ),
 };
 
 export const SendEncryptedOtpPayloadSchema = {
@@ -62,9 +86,11 @@ export const SendEncryptedOtpPayloadSchema = {
             chainLayer: SupportedChainLayer,
         }),
     }),
-    response: z.object({
-        address: z.string(),
-    }),
+    response: ResultResponse(
+        z.object({
+            address: z.string(),
+        })
+    ),
 };
 
 export const GetPublicKeyPayloadSchema = {
@@ -73,7 +99,9 @@ export const GetPublicKeyPayloadSchema = {
             chainLayer: SupportedChainLayer,
         }),
     }),
-    response: z.object({
-        publicKey: z.string(),
-    }),
+    response: ResultResponse(
+        z.object({
+            publicKey: z.string(),
+        })
+    ),
 };

--- a/packages/client/signers/src/communications/schemas.ts
+++ b/packages/client/signers/src/communications/schemas.ts
@@ -10,6 +10,7 @@ const AuthenticatedEventRequest = z.object({
 });
 
 const ErrorResponse = z.object({
+    status: z.literal("error"),
     error: z.string(),
     code: z.string().optional(),
     data: z.any().optional(),


### PR DESCRIPTION
## Description

We support sending an error in the response.

Also, we allow the create signer response to already contain the address of the signer, not needing to send the OTP and so on.

## Test plan

Will integrate now in the demo

## Package updates

<!-- 
  List any package updates and ensure you've added the necessary changesets, running `pnpm change:add` to do so.
-->