### PR TITLE
NCS: add sign event

### DIFF
--- a/.changeset/warm-spiders-live.md
+++ b/.changeset/warm-spiders-live.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-signers": patch
+---
+
+Add new sign event

--- a/packages/client/signers/src/communications/events.ts
+++ b/packages/client/signers/src/communications/events.ts
@@ -6,16 +6,18 @@ import {
     GetPublicKeyPayloadSchema,
     SendEncryptedOtpPayloadSchema,
     SignMessagePayloadSchema,
+    SignPayloadSchema,
     SignTransactionPayloadSchema,
 } from "./schemas";
 
 export const SIGNER_EVENTS = [
     "create-signer",
     "get-attestation",
-    "sign-message",
-    "sign-transaction",
+    "sign-message", // Deprecated, use sign instead
+    "sign-transaction", // Deprecated, use sign instead
     "send-otp",
     "get-public-key",
+    "sign",
 ] as const;
 export type SignerIFrameEventName = (typeof SIGNER_EVENTS)[number];
 
@@ -26,6 +28,7 @@ export const signerInboundEvents = {
     "request:sign-transaction": SignTransactionPayloadSchema.request,
     "request:send-otp": SendEncryptedOtpPayloadSchema.request,
     "request:get-public-key": GetPublicKeyPayloadSchema.request,
+    "request:sign": SignPayloadSchema.request,
 } as const;
 
 export const signerOutboundEvents = {
@@ -35,6 +38,7 @@ export const signerOutboundEvents = {
     "response:sign-transaction": SignTransactionPayloadSchema.response,
     "response:send-otp": SendEncryptedOtpPayloadSchema.response,
     "response:get-public-key": GetPublicKeyPayloadSchema.response,
+    "response:sign": SignPayloadSchema.response,
 } as const;
 
 export type SignerInputEvent<E extends SignerIFrameEventName> = z.infer<(typeof signerInboundEvents)[`request:${E}`]>;

--- a/packages/client/signers/src/communications/schemas.ts
+++ b/packages/client/signers/src/communications/schemas.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 const SupportedChainLayer = z.enum(["solana", "evm"]);
+const KeyType = z.enum(["secp256k1", "ed25519"]);
 
 const AuthenticatedEventRequest = z.object({
     authData: z.object({
@@ -102,6 +103,22 @@ export const GetPublicKeyPayloadSchema = {
     }),
     response: ResultResponse(
         z.object({
+            publicKey: z.string(),
+        })
+    ),
+};
+
+export const SignPayloadSchema = {
+    request: AuthenticatedEventRequest.extend({
+        data: z.object({
+            keyType: KeyType,
+            bytes: z.string(),
+            encoding: z.enum(["base58"]).optional().default("base58"),
+        }),
+    }),
+    response: ResultResponse(
+        z.object({
+            signature: z.string(),
             publicKey: z.string(),
         })
     ),


### PR DESCRIPTION
## Description

Just adding a generic sign event that will eventually replace chain-specific signMessage and signTransaction logic 

## Test plan

Nothing to be tested

## Package updates

<!-- 
  List any package updates and ensure you've added the necessary changesets, running `pnpm change:add` to do so.
-->