### PR TITLE
NCS: use raw Ed25519 signing for NCSs

### DIFF
--- a/.changeset/chilled-weeks-occur.md
+++ b/.changeset/chilled-weeks-occur.md
@@ -1,0 +1,7 @@
+---
+"@crossmint/client-sdk-react-native-ui": minor
+"@crossmint/client-sdk-react-ui": minor
+"@crossmint/client-signers": patch
+---
+
+Unifying Solana NCS signatures

--- a/.changeset/chilled-weeks-occur.md
+++ b/.changeset/chilled-weeks-occur.md
@@ -1,6 +1,6 @@
 ---
-"@crossmint/client-sdk-react-native-ui": minor
-"@crossmint/client-sdk-react-ui": minor
+"@crossmint/client-sdk-react-native-ui": patch
+"@crossmint/client-sdk-react-ui": patch
 "@crossmint/client-signers": patch
 ---
 

--- a/packages/client/signers/src/communications/events.ts
+++ b/packages/client/signers/src/communications/events.ts
@@ -5,27 +5,15 @@ import {
     GetAttestationPayloadSchema,
     GetPublicKeyPayloadSchema,
     SendEncryptedOtpPayloadSchema,
-    SignMessagePayloadSchema,
     SignPayloadSchema,
-    SignTransactionPayloadSchema,
 } from "./schemas";
 
-export const SIGNER_EVENTS = [
-    "create-signer",
-    "get-attestation",
-    "sign-message", // Deprecated, use sign instead
-    "sign-transaction", // Deprecated, use sign instead
-    "send-otp",
-    "get-public-key",
-    "sign",
-] as const;
+export const SIGNER_EVENTS = ["create-signer", "get-attestation", "send-otp", "get-public-key", "sign"] as const;
 export type SignerIFrameEventName = (typeof SIGNER_EVENTS)[number];
 
 export const signerInboundEvents = {
     "request:create-signer": CreateSignerPayloadSchema.request,
     "request:get-attestation": GetAttestationPayloadSchema.request,
-    "request:sign-message": SignMessagePayloadSchema.request,
-    "request:sign-transaction": SignTransactionPayloadSchema.request,
     "request:send-otp": SendEncryptedOtpPayloadSchema.request,
     "request:get-public-key": GetPublicKeyPayloadSchema.request,
     "request:sign": SignPayloadSchema.request,
@@ -34,8 +22,6 @@ export const signerInboundEvents = {
 export const signerOutboundEvents = {
     "response:create-signer": CreateSignerPayloadSchema.response,
     "response:get-attestation": GetAttestationPayloadSchema.response,
-    "response:sign-message": SignMessagePayloadSchema.response,
-    "response:sign-transaction": SignTransactionPayloadSchema.response,
     "response:send-otp": SendEncryptedOtpPayloadSchema.response,
     "response:get-public-key": GetPublicKeyPayloadSchema.response,
     "response:sign": SignPayloadSchema.response,

--- a/packages/client/signers/src/communications/schemas.ts
+++ b/packages/client/signers/src/communications/schemas.ts
@@ -35,38 +35,6 @@ export const GetAttestationPayloadSchema = {
     ),
 };
 
-export const SignMessagePayloadSchema = {
-    request: AuthenticatedEventRequest.extend({
-        data: z.object({
-            chainLayer: SupportedChainLayer,
-            message: z.string(),
-            encoding: z.enum(["base58"]).optional().default("base58"),
-        }),
-    }),
-    response: ResultResponse(
-        z.object({
-            signature: z.string(),
-            publicKey: z.string(),
-        })
-    ),
-};
-
-export const SignTransactionPayloadSchema = {
-    request: AuthenticatedEventRequest.extend({
-        data: z.object({
-            transaction: z.string(),
-            chainLayer: SupportedChainLayer,
-            encoding: z.enum(["base58"]).optional().default("base58"),
-        }),
-    }),
-    response: ResultResponse(
-        z.object({
-            signature: z.string(),
-            publicKey: z.string(),
-        })
-    ),
-};
-
 export const CreateSignerPayloadSchema = {
     request: AuthenticatedEventRequest.extend({
         data: z.object({

--- a/packages/client/ui/react-native/src/providers/CrossmintRecoveryKeyProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintRecoveryKeyProvider.tsx
@@ -161,7 +161,11 @@ export function CrossmintRecoveryKeyProvider({
                                 responseEvent: "response:sign-message",
                                 data: {
                                     authData: { jwt, apiKey },
-                                    data: { message: bs58.encode(message), chainLayer: "solana", encoding: "base58" },
+                                    data: {
+                                        bytes: bs58.encode(message),
+                                        keyType: "ed25519",
+                                        encoding: "base58",
+                                    },
                                 },
                                 options: defaultEventOptions,
                             });
@@ -175,14 +179,15 @@ export function CrossmintRecoveryKeyProvider({
                     },
                     signTransaction: async (transaction: VersionedTransaction): Promise<VersionedTransaction> => {
                         try {
+                            const messageData = transaction.message.serialize();
                             const response = await parent.sendAction({
-                                event: "request:sign-transaction",
-                                responseEvent: "response:sign-transaction",
+                                event: "request:sign",
+                                responseEvent: "response:sign",
                                 data: {
                                     authData: { jwt, apiKey },
                                     data: {
-                                        transaction: bs58.encode(transaction.serialize()),
-                                        chainLayer: "solana",
+                                        bytes: bs58.encode(messageData),
+                                        keyType: "ed25519",
                                         encoding: "base58",
                                     },
                                 },
@@ -304,7 +309,14 @@ export function CrossmintRecoveryKeyProvider({
     return (
         <CrossmintRecoveryKeyContext.Provider value={contextValue}>
             {children}
-            <View style={{ position: "absolute", width: 0, height: 0, overflow: "hidden" }}>
+            <View
+                style={{
+                    position: "absolute",
+                    width: 0,
+                    height: 0,
+                    overflow: "hidden",
+                }}
+            >
                 <RNWebView
                     ref={webviewRef}
                     source={{ uri: experimental_secureEndpointUrl }}

--- a/packages/client/ui/react-native/src/providers/CrossmintRecoveryKeyProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintRecoveryKeyProvider.tsx
@@ -1,21 +1,10 @@
-import React, {
-    type ReactNode,
-    useCallback,
-    useContext,
-    useEffect,
-    useRef,
-    useState,
-    useMemo,
-} from "react";
+import React, { type ReactNode, useCallback, useContext, useEffect, useRef, useState, useMemo } from "react";
 import bs58 from "bs58";
 import { PublicKey, type VersionedTransaction } from "@solana/web3.js";
 import type { WebView, WebViewMessageEvent } from "react-native-webview";
 import { RNWebView } from "@crossmint/client-sdk-rn-window";
 import { WebViewParent } from "@crossmint/client-sdk-rn-window";
-import {
-    signerInboundEvents,
-    signerOutboundEvents,
-} from "@crossmint/client-signers";
+import { signerInboundEvents, signerOutboundEvents } from "@crossmint/client-signers";
 import { useCrossmint } from "../hooks";
 import { View } from "react-native";
 
@@ -24,38 +13,25 @@ export interface RecoverySigner {
     address: string;
     signer: {
         signMessage: (message: Uint8Array) => Promise<Uint8Array>;
-        signTransaction: (
-            transaction: VersionedTransaction
-        ) => Promise<VersionedTransaction>;
+        signTransaction: (transaction: VersionedTransaction) => Promise<VersionedTransaction>;
     };
 }
 
-type RecoveryKeyStatus =
-    | "not-loaded"
-    | "frame-loaded"
-    | "awaiting-otp-validation"
-    | "loaded";
+type RecoveryKeyStatus = "not-loaded" | "frame-loaded" | "awaiting-otp-validation" | "loaded";
 
 export interface CrossmintRecoveryKeyContextState {
     experimental_recoveryKeyStatus: RecoveryKeyStatus;
     experimental_recoverySigner: RecoverySigner | null;
-    experimental_createRecoveryKeySigner: (
-        authId: string
-    ) => Promise<RecoverySigner | null>;
-    experimental_validateEmailOtp: (
-        encryptedOtp: string
-    ) => Promise<string | null>;
+    experimental_createRecoveryKeySigner: (authId: string) => Promise<RecoverySigner | null>;
+    experimental_validateEmailOtp: (encryptedOtp: string) => Promise<string | null>;
 }
 
-export const CrossmintRecoveryKeyContext =
-    React.createContext<CrossmintRecoveryKeyContextState | null>(null);
+export const CrossmintRecoveryKeyContext = React.createContext<CrossmintRecoveryKeyContextState | null>(null);
 
 export function useCrossmintRecoveryKey() {
     const context = useContext(CrossmintRecoveryKeyContext);
     if (context == null) {
-        throw new Error(
-            "useCrossmintRecoveryKey must be used within a CrossmintRecoveryKeyProvider"
-        );
+        throw new Error("useCrossmintRecoveryKey must be used within a CrossmintRecoveryKeyProvider");
     }
     return context;
 }
@@ -70,8 +46,7 @@ const defaultEventOptions = {
     intervalMs: 5_000,
 };
 
-const DEFAULT_SECURE_ENDPOINT_URL =
-    "https://crossmint-signer-frames.onrender.com";
+const DEFAULT_SECURE_ENDPOINT_URL = "https://crossmint-signer-frames.onrender.com";
 
 export function CrossmintRecoveryKeyProvider({
     children,
@@ -82,15 +57,12 @@ export function CrossmintRecoveryKeyProvider({
     } = useCrossmint();
 
     const webviewRef = useRef<WebView>(null);
-    const webViewParentRef = useRef<WebViewParent<
-        typeof signerOutboundEvents,
-        typeof signerInboundEvents
-    > | null>(null);
-    const [experimental_recoverySigner, setRecoverySigner] =
-        useState<RecoverySigner | null>(null);
+    const webViewParentRef = useRef<WebViewParent<typeof signerOutboundEvents, typeof signerInboundEvents> | null>(
+        null
+    );
+    const [experimental_recoverySigner, setRecoverySigner] = useState<RecoverySigner | null>(null);
     const [isWebViewReady, setIsWebViewReady] = useState(false);
-    const [experimental_recoveryKeyStatus, setRecoveryKeyStatus] =
-        useState<RecoveryKeyStatus>("not-loaded");
+    const [experimental_recoveryKeyStatus, setRecoveryKeyStatus] = useState<RecoveryKeyStatus>("not-loaded");
 
     const injectedGlobalsScript = useMemo(() => {
         if (appId != null) {
@@ -130,11 +102,7 @@ export function CrossmintRecoveryKeyProvider({
 
         try {
             const messageData = JSON.parse(event.nativeEvent.data);
-            if (
-                messageData &&
-                typeof messageData.type === "string" &&
-                messageData.type.startsWith("console.")
-            ) {
+            if (messageData && typeof messageData.type === "string" && messageData.type.startsWith("console.")) {
                 const consoleMethod = messageData.type.split(".")[1];
                 const args = (messageData.data || []).map((argStr: string) => {
                     try {
@@ -166,10 +134,7 @@ export function CrossmintRecoveryKeyProvider({
                         console.info(prefix, ...args);
                         break;
                     default:
-                        console.log(
-                            `[WebView Unknown:${consoleMethod}]`,
-                            ...args
-                        );
+                        console.log(`[WebView Unknown:${consoleMethod}]`, ...args);
                 }
                 return;
             }
@@ -182,18 +147,14 @@ export function CrossmintRecoveryKeyProvider({
         (address: string): RecoverySigner => {
             const parent = webViewParentRef.current;
             if (parent == null || jwt == null || apiKey == null) {
-                throw new Error(
-                    "Cannot build signer: Missing prerequisites (parent, jwt, apiKey)."
-                );
+                throw new Error("Cannot build signer: Missing prerequisites (parent, jwt, apiKey).");
             }
 
             return {
                 type: "solana-keypair",
                 address,
                 signer: {
-                    signMessage: async (
-                        message: Uint8Array
-                    ): Promise<Uint8Array> => {
+                    signMessage: async (message: Uint8Array): Promise<Uint8Array> => {
                         try {
                             const response = await parent.sendAction({
                                 event: "request:sign",
@@ -208,11 +169,7 @@ export function CrossmintRecoveryKeyProvider({
                                 },
                                 options: defaultEventOptions,
                             });
-                            if (
-                                response == null ||
-                                response.status === "error" ||
-                                response.signature == null
-                            ) {
+                            if (response == null || response.status === "error" || response.signature == null) {
                                 throw new Error("Failed to sign message");
                             }
                             return bs58.decode(response.signature);
@@ -220,9 +177,7 @@ export function CrossmintRecoveryKeyProvider({
                             throw err;
                         }
                     },
-                    signTransaction: async (
-                        transaction: VersionedTransaction
-                    ): Promise<VersionedTransaction> => {
+                    signTransaction: async (transaction: VersionedTransaction): Promise<VersionedTransaction> => {
                         try {
                             const messageData = transaction.message.serialize();
                             const response = await parent.sendAction({
@@ -238,19 +193,10 @@ export function CrossmintRecoveryKeyProvider({
                                 },
                                 options: defaultEventOptions,
                             });
-                            if (
-                                response == null ||
-                                response.status === "error" ||
-                                response.signature == null
-                            ) {
-                                throw new Error(
-                                    "Failed to sign transaction: No signature returned"
-                                );
+                            if (response == null || response.status === "error" || response.signature == null) {
+                                throw new Error("Failed to sign transaction: No signature returned");
                             }
-                            transaction.addSignature(
-                                new PublicKey(address),
-                                bs58.decode(response.signature)
-                            );
+                            transaction.addSignature(new PublicKey(address), bs58.decode(response.signature));
                             return transaction;
                         } catch (err) {
                             throw err;
@@ -266,19 +212,15 @@ export function CrossmintRecoveryKeyProvider({
         async (authId: string): Promise<RecoverySigner | null> => {
             const parent = webViewParentRef.current;
             if (parent == null || !isWebViewReady) {
-                const message =
-                    "WebViewParent not ready or handshake incomplete.";
+                const message = "WebViewParent not ready or handshake incomplete.";
                 throw new Error(message);
             }
             if (jwt == null || apiKey == null) {
-                const message =
-                    "Missing authentication credentials (JWT or API Key).";
+                const message = "Missing authentication credentials (JWT or API Key).";
                 throw new Error(message);
             }
 
-            const prefixedAuthId = authId.startsWith("email:")
-                ? authId
-                : `email:${authId}`;
+            const prefixedAuthId = authId.startsWith("email:") ? authId : `email:${authId}`;
 
             try {
                 const response = await parent.sendAction({
@@ -314,13 +256,11 @@ export function CrossmintRecoveryKeyProvider({
 
             const parent = webViewParentRef.current;
             if (parent == null || !isWebViewReady) {
-                const message =
-                    "WebViewParent not ready or handshake incomplete.";
+                const message = "WebViewParent not ready or handshake incomplete.";
                 throw new Error(message);
             }
             if (jwt == null || apiKey == null) {
-                const message =
-                    "Missing authentication credentials (JWT or API Key).";
+                const message = "Missing authentication credentials (JWT or API Key).";
                 throw new Error(message);
             }
 
@@ -335,11 +275,7 @@ export function CrossmintRecoveryKeyProvider({
                     options: defaultEventOptions,
                 });
 
-                if (
-                    response == null ||
-                    response.status === "error" ||
-                    response.address == null
-                ) {
+                if (response == null || response.status === "error" || response.address == null) {
                     throw new Error("Failed to validate encrypted OTP");
                 }
 

--- a/packages/client/ui/react-ui/src/providers/signers/CrossmintSignerProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/signers/CrossmintSignerProvider.tsx
@@ -111,7 +111,11 @@ export function CrossmintSignerProvider({ children, setWalletState, appearance }
                     }),
             };
 
-            setWalletState({ status: "loaded", wallet: walletWithRecovery, type: "solana-smart-wallet" });
+            setWalletState({
+                status: "loaded",
+                wallet: walletWithRecovery,
+                type: "solana-smart-wallet",
+            });
         } catch (error) {
             console.error("There was an error creating a wallet ", error);
             setWalletState(deriveWalletErrorState(error));
@@ -259,16 +263,16 @@ export function CrossmintSignerProvider({ children, setWalletState, appearance }
                             }
 
                             const res = await iframeWindow.current.sendAction({
-                                event: "request:sign-message",
-                                responseEvent: "response:sign-message",
+                                event: "request:sign",
+                                responseEvent: "response:sign",
                                 data: {
                                     authData: {
                                         jwt,
                                         apiKey,
                                     },
                                     data: {
-                                        message: base58.encode(message),
-                                        chainLayer: "solana",
+                                        keyType: "ed25519",
+                                        bytes: base58.encode(message),
                                         encoding: "base58",
                                     },
                                 },
@@ -284,17 +288,18 @@ export function CrossmintSignerProvider({ children, setWalletState, appearance }
                         },
                         signTransaction: async (transaction: VersionedTransaction) => {
                             console.log("Signing transaction...", transaction);
+                            const messageData = transaction.message.serialize();
                             const res = await iframeWindow.current?.sendAction({
-                                event: "request:sign-transaction",
-                                responseEvent: "response:sign-transaction",
+                                event: "request:sign",
+                                responseEvent: "response:sign",
                                 data: {
                                     authData: {
                                         jwt,
                                         apiKey,
                                     },
                                     data: {
-                                        transaction: base58.encode(transaction.serialize()),
-                                        chainLayer: "solana",
+                                        keyType: "ed25519",
+                                        bytes: base58.encode(messageData),
                                         encoding: "base58",
                                     },
                                 },


### PR DESCRIPTION
## Description

These events are being deprecated, as they need the Solana specific logic on the iframe side which increases the static bundle size and increases the attack surface. We're moving to a minimal signing logic implementation on the iframe and moving all the serialization specific logic to the SDK instead!

## Test plan

Tested in the live application https://simple-ncs-demo.vercel.app/  

## Package updates

<!-- 
  List any package updates and ensure you've added the necessary changesets, running `pnpm change:add` to do so.
-->