### PR TITLE
NCS: add hex encoding

### DIFF
--- a/.changeset/silent-ducks-occur.md
+++ b/.changeset/silent-ducks-occur.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-signers": patch
+---
+
+NCS: Add Hex as encoding

--- a/packages/client/signers/src/communications/index.ts
+++ b/packages/client/signers/src/communications/index.ts
@@ -5,3 +5,5 @@ export type {
     SignerInputEvent,
     SignerOutputEvent,
 } from "./events";
+
+export type { KeyType, Encoding } from "./schemas";

--- a/packages/client/signers/src/communications/schemas.ts
+++ b/packages/client/signers/src/communications/schemas.ts
@@ -1,7 +1,9 @@
 import { z } from "zod";
 
 const KeyTypeSchema = z.enum(["secp256k1", "ed25519"]).describe("Type of cryptographic key");
-const EncodingSchema = z.enum(["base58", "base64"]).describe("Encoding format for the key or data");
+export type KeyType = z.infer<typeof KeyTypeSchema>;
+const EncodingSchema = z.enum(["base58", "base64", "hex"]).describe("Encoding format for the key or data");
+export type Encoding = z.infer<typeof EncodingSchema>;
 
 const UserPublicKeySchema = z.object({
     bytes: z.string().describe("The encoded public key value"),

--- a/packages/client/ui/react-native/src/providers/CrossmintRecoveryKeyProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintRecoveryKeyProvider.tsx
@@ -4,7 +4,7 @@ import { PublicKey, type VersionedTransaction } from "@solana/web3.js";
 import type { WebView, WebViewMessageEvent } from "react-native-webview";
 import { RNWebView } from "@crossmint/client-sdk-rn-window";
 import { WebViewParent } from "@crossmint/client-sdk-rn-window";
-import { signerInboundEvents, signerOutboundEvents } from "@crossmint/client-signers";
+import { type Encoding, type KeyType, signerInboundEvents, signerOutboundEvents } from "@crossmint/client-signers";
 import { useCrossmint } from "../hooks";
 import { View } from "react-native";
 import { validateApiKeyAndGetCrossmintBaseUrl } from "@crossmint/common-sdk-base";
@@ -248,8 +248,8 @@ export function CrossmintRecoveryKeyProvider({
 
     const assertCorrectPublicKey = (publicKey: {
         bytes: string;
-        encoding: "base58" | "base64";
-        keyType: "secp256k1" | "ed25519";
+        encoding: Encoding;
+        keyType: KeyType;
     }) => {
         if (publicKey.encoding !== "base58" || publicKey.keyType !== "ed25519") {
             throw new Error("Unsupported key type and encoding: " + publicKey.keyType + " " + publicKey.encoding);


### PR DESCRIPTION
## Description

Just adding a new encoding that we will use for EVM

## Test plan

<!--
  Example:
   * Unit tests which cover functionality X, Y, Z
   * V was tested via UI tests
   * W was tested manually
-->

## Package updates

<!-- 
  List any package updates and ensure you've added the necessary changesets, running `pnpm change:add` to do so.
-->