### PR TITLE
NCS: detect iframe environment automatically [WAL-4579]

### DIFF
--- a/.changeset/friendly-chairs-share.md
+++ b/.changeset/friendly-chairs-share.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+---
+
+Configure environment automatically

--- a/packages/client/ui/react-ui/src/hooks/useSignerInvisibleIFrame.ts
+++ b/packages/client/ui/react-ui/src/hooks/useSignerInvisibleIFrame.ts
@@ -23,12 +23,13 @@ async function createInvisibleIFrame(url: string): Promise<HTMLIFrameElement> {
     });
 }
 
-export function useSignerIFrameWindow(url?: string) {
+export function useSignerIFrameWindow(environment: string, url?: string) {
     const iframeWindow = useRef<IFrameWindow<typeof signerOutboundEvents, typeof signerInboundEvents> | null>(null);
     useEffect(() => {
         const initIFrameWindow = async () => {
             try {
                 const iframeUrl = new URL(url || "https://signers.crossmint.com/");
+                iframeUrl.searchParams.set("environment", environment);
                 const iframeElement = await createInvisibleIFrame(iframeUrl.toString());
                 iframeWindow.current = await IFrameWindow.init(iframeElement, {
                     targetOrigin: iframeUrl.origin,

--- a/packages/client/ui/react-ui/src/providers/signers/CrossmintSignerProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/signers/CrossmintSignerProvider.tsx
@@ -14,7 +14,7 @@ import { CrossmintWallets } from "@crossmint/wallets-sdk";
 import type { ValidWalletState } from "@crossmint/client-sdk-react-base";
 import { PublicKey, type VersionedTransaction } from "@solana/web3.js";
 import base58 from "bs58";
-import { environmentToCrossmintBaseURL, type UIConfig } from "@crossmint/common-sdk-base";
+import { environmentToCrossmintBaseURL, getEnvironmentForKey, type UIConfig } from "@crossmint/common-sdk-base";
 import { useCrossmint } from "@/hooks";
 import { deriveWalletErrorState } from "@/utils/errorUtils";
 import { EmailSignersDialog } from "@/components/signers/EmailSignersDialog";
@@ -53,7 +53,11 @@ export function CrossmintSignerProvider({
     } = useCrossmint();
     const smartWalletSDK = useMemo(() => CrossmintWallets.from({ apiKey, jwt }), [apiKey, jwt]);
 
-    const iframeWindow = useSignerIFrameWindow(signersURL);
+    const environment = getEnvironmentForKey(apiKey);
+    if (environment == null) {
+        throw new Error("Could not determine environment from API key");
+    }
+    const iframeWindow = useSignerIFrameWindow(environment, signersURL);
     const [email, setEmail] = useState<string>("");
     const [step, setStep] = useState<"initial" | "otp">("initial");
     const [dialogOpen, setDialogOpen] = useState(false);


### PR DESCRIPTION
## Description

For certain API calls we don't have an API key that we can use to infer the environment, so we need to pass it somehow. Here we add a query param for that

## Test plan

<!--
  Example:
   * Unit tests which cover functionality X, Y, Z
   * V was tested via UI tests
   * W was tested manually
-->

## Package updates

<!-- 
  List any package updates and ensure you've added the necessary changesets, running `pnpm change:add` to do so.
-->