### PR TITLE
Lint: ignore .turbo and .d.ts files in biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -21,7 +21,9 @@
             "**/android/**",
             "**/gen/**",
             "**/dist/**",
-            "**/build/**"
+            "**/build/**",
+            ".turbo",
+            "*.d.ts"
         ]
     },
     "organizeImports": {
@@ -88,7 +90,9 @@
             "services/snowcrash",
             "pnpm-lock.yaml",
             "**/build/**",
-            "**/dist/**"
+            "**/dist/**",
+            ".turbo",
+            "*.d.ts"
         ]
     },
     "javascript": {


### PR DESCRIPTION
## Description

The linter was useless because it would complain about files we don't care about

## Test plan

Linter stopped throwing unnecessary errors

## Package updates

None