### PR TITLE
React Wallet Provider: BYOA auto wallet create bug

### DIFF
--- a/.changeset/little-lamps-add.md
+++ b/.changeset/little-lamps-add.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+---
+
+Fixed bug with auto wallet creation for bring your own auth

--- a/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.test.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.test.tsx
@@ -19,7 +19,8 @@ import { useDynamicWallet } from "./dynamic/DynamicWalletProvider";
 vi.mock("@dynamic-labs/sdk-react-core", () => ({
     useDynamicContext: vi.fn().mockReturnValue({
         primaryWallet: undefined,
-        sdkHasLoaded: true,
+        isDynamicProviderAvailable: false,
+        hasDynamicSdkLoaded: true,
         removeWallet: vi.fn(),
         handleUnlinkWallet: vi.fn(),
     }),
@@ -39,7 +40,8 @@ vi.mock("@/providers/dynamic/DynamicWalletProvider", () => ({
     useDynamicWallet: vi.fn().mockImplementation(() => ({
         getAdminSigner: vi.fn().mockResolvedValue(null),
         cleanup: vi.fn(),
-        sdkHasLoaded: true,
+        isDynamicProviderAvailable: false,
+        hasDynamicSdkLoaded: true,
         isDynamicWalletConnected: false,
         initialize: vi.fn(),
     })),
@@ -177,7 +179,8 @@ describe("CrossmintAuthProvider", () => {
         vi.mocked(useDynamicWallet).mockImplementation(() => ({
             getAdminSigner: vi.fn().mockResolvedValue(null),
             cleanup: vi.fn(),
-            sdkHasLoaded: true,
+            isDynamicProviderAvailable: false,
+            hasDynamicSdkLoaded: true,
             isDynamicWalletConnected: false,
             initialize: vi.fn(),
         }));

--- a/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
@@ -79,10 +79,11 @@ export function CrossmintWalletProvider({
     appearance?: UIConfig;
     createOnLogin?: CreateOnLogin;
 }) {
-    const { crossmint } = useCrossmint("CrossmintWalletProvider must be used within CrossmintProvider");
+    const { crossmint, experimental_setAuth } = useCrossmint(
+        "CrossmintWalletProvider must be used within CrossmintProvider"
+    );
     const email = crossmint.user?.email;
     const { isDynamicWalletConnected, getAdminSigner, sdkHasLoaded } = useDynamicWallet();
-    const { experimental_setAuth } = useCrossmint();
     const [walletState, setWalletState] = useState<ValidWalletState>({
         status: "not-loaded",
     });

--- a/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
@@ -83,7 +83,8 @@ export function CrossmintWalletProvider({
         "CrossmintWalletProvider must be used within CrossmintProvider"
     );
     const email = crossmint.user?.email;
-    const { isDynamicWalletConnected, getAdminSigner, sdkHasLoaded } = useDynamicWallet();
+    const { isDynamicWalletConnected, isDynamicProviderAvailable, getAdminSigner, hasDynamicSdkLoaded } =
+        useDynamicWallet();
     const [walletState, setWalletState] = useState<ValidWalletState>({
         status: "not-loaded",
     });
@@ -210,14 +211,17 @@ export function CrossmintWalletProvider({
             if (
                 walletState.status !== "not-loaded" ||
                 crossmint.jwt == null ||
-                !sdkHasLoaded ||
+                (isDynamicProviderAvailable && !hasDynamicSdkLoaded) ||
                 createOnLogin?.chain == null
             ) {
                 return;
             }
 
             try {
-                const finalSigner = isDynamicWalletConnected ? await getAdminSigner() : createOnLogin.signer;
+                const finalSigner =
+                    isDynamicProviderAvailable && isDynamicWalletConnected
+                        ? await getAdminSigner()
+                        : createOnLogin.signer;
 
                 await getOrCreateWallet({
                     chain: createOnLogin.chain,
@@ -242,7 +246,7 @@ export function CrossmintWalletProvider({
     }, [
         walletState.status,
         crossmint.jwt,
-        sdkHasLoaded,
+        hasDynamicSdkLoaded,
         isDynamicWalletConnected,
         getAdminSigner,
         getOrCreateWallet,

--- a/packages/client/ui/react-ui/src/providers/dynamic/DynamicWalletProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/dynamic/DynamicWalletProvider.tsx
@@ -15,7 +15,8 @@ import base58 from "bs58";
 
 type DynamicWalletContextType = {
     isDynamicWalletConnected: boolean;
-    sdkHasLoaded: boolean;
+    isDynamicProviderAvailable: boolean;
+    hasDynamicSdkLoaded: boolean;
     getAdminSigner: () => Promise<EvmExternalWalletSignerConfig | SolanaExternalWalletSignerConfig>;
     initialize: (jwt?: string, onSdkLoaded?: (loaded: boolean) => void) => void;
     cleanup: () => void;
@@ -28,7 +29,8 @@ export function useDynamicWallet() {
     if (!context) {
         return {
             isDynamicWalletConnected: false,
-            sdkHasLoaded: true,
+            isDynamicProviderAvailable: false,
+            hasDynamicSdkLoaded: true,
             getAdminSigner: () => {
                 throw new Error("useDynamicWallet must be used within DynamicWalletProvider");
             },
@@ -72,7 +74,7 @@ function DynamicWalletStateProvider({ children, enabled, onSdkLoaded }: DynamicW
     } = useDynamicContext();
 
     const isDynamicWalletConnected = !!connectedDynamicWallet;
-    const dynamicSdkHasLoaded = !enabled || sdkHasLoaded;
+    const hasDynamicSdkLoaded = !enabled || sdkHasLoaded;
 
     const initialize = useCallback((newJwt?: string, onSdkLoaded?: (loaded: boolean) => void) => {
         setJwt(newJwt);
@@ -89,10 +91,10 @@ function DynamicWalletStateProvider({ children, enabled, onSdkLoaded }: DynamicW
 
     useEffect(() => {
         if (enabled) {
-            onSdkLoadedCallback?.(dynamicSdkHasLoaded);
-            onSdkLoaded?.(dynamicSdkHasLoaded);
+            onSdkLoadedCallback?.(hasDynamicSdkLoaded);
+            onSdkLoaded?.(hasDynamicSdkLoaded);
         }
-    }, [dynamicSdkHasLoaded, enabled, onSdkLoadedCallback, onSdkLoaded]);
+    }, [hasDynamicSdkLoaded, enabled, onSdkLoadedCallback, onSdkLoaded]);
 
     useEffect(() => {
         if (jwt == null && isInitialized) {
@@ -141,12 +143,13 @@ function DynamicWalletStateProvider({ children, enabled, onSdkLoaded }: DynamicW
     const contextValue = useMemo(
         () => ({
             isDynamicWalletConnected,
-            sdkHasLoaded: dynamicSdkHasLoaded,
+            isDynamicProviderAvailable: true,
+            hasDynamicSdkLoaded,
             getAdminSigner,
             initialize,
             cleanup,
         }),
-        [isDynamicWalletConnected, dynamicSdkHasLoaded, getAdminSigner, initialize, cleanup]
+        [isDynamicWalletConnected, hasDynamicSdkLoaded, getAdminSigner, initialize, cleanup]
     );
 
     return <DynamicWalletContext.Provider value={contextValue}>{children}</DynamicWalletContext.Provider>;

--- a/packages/client/ui/react-ui/src/providers/dynamic/DynamicWalletProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/dynamic/DynamicWalletProvider.tsx
@@ -28,7 +28,7 @@ export function useDynamicWallet() {
     if (!context) {
         return {
             isDynamicWalletConnected: false,
-            sdkHasLoaded: false,
+            sdkHasLoaded: true,
             getAdminSigner: () => {
                 throw new Error("useDynamicWallet must be used within DynamicWalletProvider");
             },


### PR DESCRIPTION
## Description

When automatically creating a wallet for BYOA, state relating to Dynamic (which isn't used during BYOA) was being set to false by default `sdkHasLoaded`. Added more state to account for whether the dynamic provider is being used in the first place. 

## Test plan

Auto wallet creation works for both Crossmint auth and BYOA.

## Package updates

@crossmint/client-sdk-react-ui