### PR TITLE
Wallets sdk: Rename permissions to delegateSigners

### DIFF
--- a/.changeset/lucky-weeks-melt.md
+++ b/.changeset/lucky-weeks-melt.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-base": patch
+---
+
+Renamed type Permission to DelegatedSigner

--- a/.changeset/seven-owls-play.md
+++ b/.changeset/seven-owls-play.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+---
+
+Renamed type Permission to DelegatedSigner

--- a/.changeset/two-eyes-clap.md
+++ b/.changeset/two-eyes-clap.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+added getDelegatedSigner and delegatedSigners method

--- a/apps/wallets/quickstart-devkit/components/permissions.tsx
+++ b/apps/wallets/quickstart-devkit/components/permissions.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { type Permission, useCrossmint, useWallet } from "@crossmint/client-sdk-react-ui";
+import { type DelegatedSigner, useCrossmint, useWallet } from "@crossmint/client-sdk-react-ui";
 import { cn } from "../lib/utils";
 
 export function Permissions() {
@@ -11,13 +11,13 @@ export function Permissions() {
     const { wallet } = useWallet();
 
     const [isLoading, setIsLoading] = useState(false);
-    const [permissions, setPermissions] = useState<Permission[]>([]);
+    const [permissions, setPermissions] = useState<DelegatedSigner[]>([]);
     const [newSigner, setNewSigner] = useState<string>("");
 
     useEffect(() => {
         const fetchPermissions = async () => {
             if (wallet != null) {
-                const signers = await wallet.permissions();
+                const signers = await wallet.delegatedSigners();
                 setPermissions(signers);
             }
         };
@@ -34,8 +34,8 @@ export function Permissions() {
         }
         try {
             setIsLoading(true);
-            await wallet.updatePermissions({ signer: newSigner });
-            const signers = await wallet.permissions();
+            await wallet.addDelegatedSigner({ signer: newSigner });
+            const signers = await wallet.delegatedSigners();
             setPermissions(signers);
         } catch (err) {
             console.error("Permissions: ", err);

--- a/packages/client/react-base/src/types/wallet.ts
+++ b/packages/client/react-base/src/types/wallet.ts
@@ -5,7 +5,7 @@ export type {
     Balances,
     Chain,
     EvmExternalWalletSignerConfig,
-    Permission,
+    DelegatedSigner,
     SolanaExternalWalletSignerConfig,
     Wallet,
 } from "@crossmint/wallets-sdk";

--- a/packages/client/ui/react-ui/src/types/wallet.ts
+++ b/packages/client/ui/react-ui/src/types/wallet.ts
@@ -1,3 +1,3 @@
 export type { BaseCrossmintWalletProviderProps } from "@crossmint/client-sdk-react-base";
-export type { Activity, Balances, Wallet, Chain, Permission } from "@crossmint/wallets-sdk";
+export type { Activity, Balances, Wallet, Chain, DelegatedSigner } from "@crossmint/wallets-sdk";
 export { EVMWallet, SolanaWallet } from "@crossmint/wallets-sdk";

--- a/packages/wallets/src/index.ts
+++ b/packages/wallets/src/index.ts
@@ -7,24 +7,3 @@ export * from "./wallets/evm";
 export * from "./wallets/types";
 export * from "./chains/chains";
 export * from "./signers/types";
-
-/**
-    Activity,
-    Balances,
-    Chain,
-    CrossmintWallets,
-    EmailInternalSignerConfig,
-    EvmExternalWalletSignerConfig,
-    EVMWallet,
-    PasskeySignerConfig,
-    DelegatedSigner,
-    SignerConfigForChain,
-    SolanaExternalWalletSignerConfig,
-    SolanaWallet,
-    Wallet,
-    WalletArgsFor
- */
-
-// TODO:
-// 1. rename updatePermissions to addDelegatedSigner, and permissions to delegatedSigners.
-// 2.

--- a/packages/wallets/src/index.ts
+++ b/packages/wallets/src/index.ts
@@ -7,3 +7,24 @@ export * from "./wallets/evm";
 export * from "./wallets/types";
 export * from "./chains/chains";
 export * from "./signers/types";
+
+/**
+    Activity,
+    Balances,
+    Chain,
+    CrossmintWallets,
+    EmailInternalSignerConfig,
+    EvmExternalWalletSignerConfig,
+    EVMWallet,
+    PasskeySignerConfig,
+    DelegatedSigner,
+    SignerConfigForChain,
+    SolanaExternalWalletSignerConfig,
+    SolanaWallet,
+    Wallet,
+    WalletArgsFor
+ */
+
+// TODO:
+// 1. rename updatePermissions to addDelegatedSigner, and permissions to delegatedSigners.
+// 2.

--- a/packages/wallets/src/wallets/types.ts
+++ b/packages/wallets/src/wallets/types.ts
@@ -16,7 +16,7 @@ export interface SolanaTransactionInput {
     additionalSigners?: Keypair[];
 }
 
-export type Permission = {
+export type DelegatedSigner = {
     signer: string;
 };
 

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -1,6 +1,6 @@
 import { isValidAddress } from "@crossmint/common-sdk-base";
 import type { Activity, ApiClient, Balances, GetSignatureResponse } from "../api";
-import type { PendingApproval, Permission, WalletOptions } from "./types";
+import type { PendingApproval, DelegatedSigner, WalletOptions } from "./types";
 import {
     InvalidSignerError,
     SignatureNotAvailableError,
@@ -138,11 +138,11 @@ export class Wallet<C extends Chain> {
     }
 
     /**
-     * Update permissions for a signer
+     * Add a delegated signer to the wallet
      * @param signer - The signer
-     * @returns The permissions
+     * @returns The delegated signer
      */
-    public async updatePermissions({ signer }: { signer: string }) {
+    public async addDelegatedSigner({ signer }: { signer: string }) {
         const response = await this.#apiClient.registerSigner(this.walletLocator, {
             signer: signer,
             chain: this.chain === "solana" ? undefined : this.chain,
@@ -172,7 +172,7 @@ export class Wallet<C extends Chain> {
         }
     }
 
-    public async permissions(): Promise<Permission[]> {
+    public async delegatedSigners(): Promise<DelegatedSigner[]> {
         const walletResponse = await this.#apiClient.getWallet(this.walletLocator);
         if ("error" in walletResponse) {
             throw new WalletNotAvailableError(JSON.stringify(walletResponse));


### PR DESCRIPTION
## Description

Renamed permission methods to delegate signers

## Test plan

build passes and method names are updated.

## Package updates

@crossmint/wallets-sdk
@crossmint/client-sdk-react-base
@crossmint/client-sdk-react-ui