### PR TITLE
Wallets sdk: Fix passkey signer validation

### DIFF
--- a/.changeset/empty-keys-try.md
+++ b/.changeset/empty-keys-try.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+Fix bug with passkey signer validation

--- a/packages/wallets/src/utils/signer-validation.ts
+++ b/packages/wallets/src/utils/signer-validation.ts
@@ -5,13 +5,13 @@ export function deepCompare(obj1: Record<string, unknown>, obj2: Record<string, 
         return;
     }
     if (obj1 == null || obj2 == null) {
-        throw new WalletCreationError(`Wallet signer ${path} does not match existing wallet's signer ${path}`);
+        throw new Error(`Cannot compare null or undefined objects at path: ${path}`);
     }
     for (const key of Object.keys(obj1)) {
         const newPath = path ? `${path}.${key}` : key;
         if (!(key in obj2)) {
             throw new WalletCreationError(
-                `Wallet signer ${newPath} does not match existing wallet's signer ${newPath}`
+                `Wallet signer configuration mismatch at "${newPath}" - expected "${obj2[key]}" from existing wallet but found "${obj1[key]}"`
             );
         }
         deepCompare(obj1[key] as Record<string, unknown>, obj2[key] as Record<string, unknown>, newPath);

--- a/packages/wallets/src/utils/signer-validation.ts
+++ b/packages/wallets/src/utils/signer-validation.ts
@@ -1,0 +1,19 @@
+import { WalletCreationError } from "./errors";
+
+export function deepCompare(obj1: Record<string, unknown>, obj2: Record<string, unknown>, path = "") {
+    if (obj1 === obj2) {
+        return;
+    }
+    if (obj1 == null || obj2 == null) {
+        throw new WalletCreationError(`Wallet signer ${path} does not match existing wallet's signer ${path}`);
+    }
+    for (const key of Object.keys(obj1)) {
+        const newPath = path ? `${path}.${key}` : key;
+        if (!(key in obj2)) {
+            throw new WalletCreationError(
+                `Wallet signer ${newPath} does not match existing wallet's signer ${newPath}`
+            );
+        }
+        deepCompare(obj1[key] as Record<string, unknown>, obj2[key] as Record<string, unknown>, newPath);
+    }
+}


### PR DESCRIPTION
## Description

Fix issue with `validateWalletConfig` not working for passkey signer types

## Test plan

passkey signer validation works.

## Package updates

@crossmint/wallets-sdk