### PR TITLE
Wallets sdk: Fix passkey prompt

### DIFF
--- a/.changeset/wicked-trees-fail.md
+++ b/.changeset/wicked-trees-fail.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+---
+
+fix passkey prompts verbiage

--- a/packages/client/ui/react-ui/src/components/auth/PasskeyPrompt.tsx
+++ b/packages/client/ui/react-ui/src/components/auth/PasskeyPrompt.tsx
@@ -140,7 +140,7 @@ export function PasskeyPrompt({ state, appearance }: PasskeyPromptProps) {
         case "transaction":
             return (
                 <PasskeyPromptCore
-                    title="First Time Using Your Wallet"
+                    title="Use Your Wallet"
                     appearance={appearance}
                     content={
                         <div className="flex flex-col gap-2">

--- a/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
@@ -169,15 +169,18 @@ export function CrossmintWalletProvider({
                     };
                 }
 
+                const addPasskeyCallbacks = args.signer.type === "passkey" && showPasskeyHelpers;
                 const wallets = CrossmintWallets.from(crossmint);
                 const wallet = await wallets.getOrCreateWallet<C>({
                     ...args,
                     options: {
                         ...args.options,
-                        experimental_callbacks: {
-                            onWalletCreationStart: createPasskeyPrompt("create-wallet"),
-                            onTransactionStart: createPasskeyPrompt("transaction"),
-                        },
+                        ...(addPasskeyCallbacks && {
+                            experimental_callbacks: {
+                                onWalletCreationStart: createPasskeyPrompt("create-wallet"),
+                                onTransactionStart: createPasskeyPrompt("transaction"),
+                            },
+                        }),
                     },
                 });
                 setWalletState({ status: "loaded", wallet });
@@ -227,12 +230,6 @@ export function CrossmintWalletProvider({
                     chain: createOnLogin.chain,
                     signer: finalSigner,
                     owner: createOnLogin.owner,
-                    options: {
-                        experimental_callbacks: {
-                            onWalletCreationStart: createPasskeyPrompt("create-wallet"),
-                            onTransactionStart: createPasskeyPrompt("transaction"),
-                        },
-                    },
                 });
             } catch (error) {
                 console.error("Failed to create wallet:", error);


### PR DESCRIPTION
## Description

Fix verbiage of passkey prompt and only show it when the signer type is set to `passkey` 

## Test plan

prompt verbiage now says "Use your wallet" instead of "First Time Using Your Wallet". also only shows when using passkey signer type.

## Package updates

@crossmint/client-sdk-react-ui