### PR TITLE
Fix issue with signer validation deep obj comparison

### DIFF
--- a/.changeset/seven-kings-sleep.md
+++ b/.changeset/seven-kings-sleep.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+Fix bug with signer object comparison


### PR DESCRIPTION
## Description

Our signer deep object comparison wasn't accounting for when an object wasn't deep/nested.
![Screenshot 2025-06-11 at 6 06 33 PM](https://github.com/user-attachments/assets/b6eba200-2a1a-4079-84c8-c5f2ec095faf)


## Test plan

Error no longer fires, other signers still work.

## Package updates

@crossmint/wallets-sdk