### PR TITLE
React: Support app id in web for extensions

### DIFF
--- a/.changeset/large-doors-punch.md
+++ b/.changeset/large-doors-punch.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+---
+
+Support appId in web for extensions

--- a/packages/client/ui/react-ui/src/hooks/useCrossmint.tsx
+++ b/packages/client/ui/react-ui/src/hooks/useCrossmint.tsx
@@ -13,14 +13,15 @@ const CrossmintContext = createContext<CrossmintContext | null>(null);
 export function CrossmintProvider({
     children,
     apiKey,
+    appId,
     overrideBaseUrl,
-}: Pick<CrossmintConfig, "apiKey" | "overrideBaseUrl"> & {
+}: Pick<CrossmintConfig, "apiKey" | "appId" | "overrideBaseUrl"> & {
     children: ReactNode;
 }) {
     const [version, setVersion] = useState(0);
 
     const crossmintRef = useRef<Crossmint>(
-        new Proxy<Crossmint>(createCrossmint({ apiKey, overrideBaseUrl }), {
+        new Proxy<Crossmint>(createCrossmint({ apiKey, overrideBaseUrl, appId }), {
             set(target, prop, value) {
                 if (prop === "jwt" && target.jwt !== value) {
                     setVersion((v) => v + 1);


### PR DESCRIPTION
## Description

We are going to use app ids for browser extensions

## Test plan

None needed, same code as react native

## Package updates

react-ui: patch