### PR TITLE
Wallets sdk: Renamed unstable prefix to experimental

### DIFF
--- a/.changeset/nice-baboons-hope.md
+++ b/.changeset/nice-baboons-hope.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+Renamed unstable api prefix to experimental

--- a/apps/wallets/smart-wallet/next/src/app/wallet/page.tsx
+++ b/apps/wallets/smart-wallet/next/src/app/wallet/page.tsx
@@ -65,7 +65,7 @@ export default function Index() {
 
     const { data, isLoading: isLoadingNFTs } = useQuery({
         queryKey: ["smart-wallet"],
-        queryFn: async () => (await wallet?.unstable_nfts({ page: 1, perPage: 11 })) as NFT[],
+        queryFn: async () => (await wallet?.experimental_nfts({ page: 1, perPage: 11 })) as NFT[],
         refetchOnWindowFocus: false,
         refetchOnMount: false,
         staleTime: 1000 * 60 * 5, // 5 minutes

--- a/packages/wallets/src/api/client.ts
+++ b/packages/wallets/src/api/client.ts
@@ -125,7 +125,7 @@ class ApiClient extends CrossmintApiClient {
         return response.json();
     }
 
-    async unstable_getNfts(params: {
+    async experimental_getNfts(params: {
         address: string;
         perPage: number;
         page: number;

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -85,10 +85,10 @@ export class Wallet<C extends Chain> {
      * @param {number} params.page - The page number
      * @param {EvmWalletLocator} [params.locator] - The locator
      * @returns The NFTs
-     * @unstable This API is unstable and may change in the future
+     * @experimental This API is experimental and may change in the future
      */
-    public async unstable_nfts(params: { perPage: number; page: number }) {
-        return await this.#apiClient.unstable_getNfts({
+    public async experimental_nfts(params: { perPage: number; page: number }) {
+        return await this.#apiClient.experimental_getNfts({
             ...params,
             chain: this.chain,
             address: this.address,
@@ -99,7 +99,7 @@ export class Wallet<C extends Chain> {
      * Get the wallet transactions
      * @returns The transactions
      */
-    public async unstable_transactions() {
+    public async experimental_transactions() {
         return await this.#apiClient.getTransactions(this.walletLocator);
     }
 


### PR DESCRIPTION
## Description

To maintain consistency lets use the `experimental_` prefix for unstable api's

## Test plan

Updated demo to use new method name

## Package updates

@crossmint/wallets-sdk