### PR TITLE
React Native: expose 'callbacks' prop in CrossmintWalletProvider

### DIFF
--- a/.changeset/warm-rings-leave.md
+++ b/.changeset/warm-rings-leave.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-native-ui": minor
+---
+
+Expose 'callbacks' prop in CrossmintWalletProvider

--- a/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
@@ -29,9 +29,13 @@ export const CrossmintWalletEmailSignerContext = createContext<CrossmintWalletEm
 export interface CrossmintWalletProviderProps {
     children: ReactNode;
     createOnLogin?: CreateOnLogin;
+    callbacks?: {
+        onWalletCreationStart?: () => Promise<void>;
+        onTransactionStart?: () => Promise<void>;
+    };
 }
 
-export function CrossmintWalletProvider({ children, createOnLogin }: CrossmintWalletProviderProps) {
+export function CrossmintWalletProvider({ children, createOnLogin, callbacks }: CrossmintWalletProviderProps) {
     const { crossmint } = useCrossmint("CrossmintWalletProvider must be used within CrossmintProvider");
     const { apiKey, appId } = crossmint;
     const parsedAPIKey = validateAPIKey(apiKey);
@@ -160,6 +164,7 @@ export function CrossmintWalletProvider({ children, createOnLogin }: CrossmintWa
             createOnLogin={createOnLogin}
             onAuthRequired={onAuthRequired}
             _getEmailSignerIframe={_getEmailSignerIframe}
+            callbacks={callbacks}
         >
             <CrossmintWalletEmailSignerContext.Provider value={authContextValue}>
                 {children}


### PR DESCRIPTION
## Description

Expose the 'callbacks' prop from the react native CrossmintWalletProvider.

## Test plan

prop is exposed and can be used from client app.

## Package updates

@crossmint/client-sdk-react-native-ui