### PR TITLE
⚠️ Fix issue with email signers and jwt not being set

### DIFF
--- a/.changeset/fifty-books-impress.md
+++ b/.changeset/fifty-books-impress.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+Fixed issue with email not set error even when email is set

--- a/.changeset/spotty-brooms-ring.md
+++ b/.changeset/spotty-brooms-ring.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/common-sdk-base": patch
+---
+
+Fixed issue with jwt not being set correctly

--- a/packages/common/base/src/apiClient/CrossmintApiClient.ts
+++ b/packages/common/base/src/apiClient/CrossmintApiClient.ts
@@ -30,7 +30,6 @@ export class CrossmintApiClient extends ApiClient {
             throw new Error(apiKeyValidationResult.message);
         }
         super();
-        this.crossmint.jwt = this.crossmint.jwt || this.crossmint.experimental_customAuth?.jwt;
         this.parsedAPIKey = apiKeyValidationResult;
         this.internalConfig = internalConfig;
     }
@@ -50,11 +49,15 @@ export class CrossmintApiClient extends ApiClient {
             "x-api-key": this.crossmint.apiKey,
             ...(this.crossmint.appId ? { "x-app-identifier": this.crossmint.appId } : {}),
             ...(this.crossmint.extensionId ? { "x-extension-id": this.crossmint.extensionId } : {}),
-            ...(this.crossmint.jwt ? { Authorization: `Bearer ${this.crossmint.jwt}` } : {}),
+            ...(this.resolvedJwt ? { Authorization: `Bearer ${this.resolvedJwt}` } : {}),
         };
     }
 
     get environment() {
         return this.parsedAPIKey.environment;
+    }
+
+    private get resolvedJwt(): string | undefined {
+        return this.crossmint.experimental_customAuth?.jwt || this.crossmint.jwt;
     }
 }

--- a/packages/common/base/src/apiClient/CrossmintApiClient.ts
+++ b/packages/common/base/src/apiClient/CrossmintApiClient.ts
@@ -30,6 +30,7 @@ export class CrossmintApiClient extends ApiClient {
             throw new Error(apiKeyValidationResult.message);
         }
         super();
+        this.crossmint.jwt = this.crossmint.jwt || this.crossmint.experimental_customAuth?.jwt;
         this.parsedAPIKey = apiKeyValidationResult;
         this.internalConfig = internalConfig;
     }
@@ -49,9 +50,7 @@ export class CrossmintApiClient extends ApiClient {
             "x-api-key": this.crossmint.apiKey,
             ...(this.crossmint.appId ? { "x-app-identifier": this.crossmint.appId } : {}),
             ...(this.crossmint.extensionId ? { "x-extension-id": this.crossmint.extensionId } : {}),
-            ...(this.crossmint.experimental_customAuth?.jwt
-                ? { Authorization: `Bearer ${this.crossmint.experimental_customAuth.jwt}` }
-                : {}),
+            ...(this.crossmint.jwt ? { Authorization: `Bearer ${this.crossmint.jwt}` } : {}),
         };
     }
 

--- a/packages/wallets/src/signers/email/email.ts
+++ b/packages/wallets/src/signers/email/email.ts
@@ -208,14 +208,13 @@ export class EmailSigner implements Signer {
     }
 
     static async pregenerateSigner(email: string, crossmint: Crossmint): Promise<string> {
-        if (email == null || crossmint.experimental_customAuth?.email == null) {
+        const emailToUse = email ?? crossmint.experimental_customAuth?.email;
+        if (emailToUse == null) {
             throw new Error("Email is required to pregenerate a signer");
         }
 
         try {
-            const response = await new EmailSignerApiClient(crossmint).pregenerateSigner(
-                email ?? crossmint.experimental_customAuth.email
-            );
+            const response = await new EmailSignerApiClient(crossmint).pregenerateSigner(emailToUse);
             const publicKey = response.publicKey;
 
             if (publicKey == null) {


### PR DESCRIPTION
## Description

A rather critical bug has been found and fixed. 

**issue 1:** 
jwt value wasn't using a single source of truth and incorrect value was being used even though jwt was being set on crossmint instance.
**issue 2:** 
email signer error being thrown about email not being set even though it was being set in wallet instance. 

## Test plan

Tested setting jwt in `createCrossmint` instance and setting email signer in `getOrCreateWallet` on wallet instance.

## Package updates

@crossmint/common-sdk-base
@crossmint/wallets-sdk