### PR TITLE
WAL-4805: Add EVM email signers

### DIFF
--- a/.changeset/spotty-bees-double.md
+++ b/.changeset/spotty-bees-double.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+Add EVM email signer

--- a/packages/wallets/src/signers/email/email-signer-api-client.ts
+++ b/packages/wallets/src/signers/email/email-signer-api-client.ts
@@ -13,9 +13,9 @@ export class EmailSignerApiClient extends CrossmintApiClient {
         });
     }
 
-    async pregenerateSigner(email: string) {
+    async pregenerateSigner(email: string, keyType: "ed25519" | "secp256k1") {
         const response = await this.post(`${this.apiPrefix}/derive-public-key`, {
-            body: JSON.stringify({ authId: `email:${email}`, keyType: "ed25519" }),
+            body: JSON.stringify({ authId: `email:${email}`, keyType }),
             headers: this.headers,
         });
         if (!response.ok) {

--- a/packages/wallets/src/signers/email/evm-email-signer.ts
+++ b/packages/wallets/src/signers/email/evm-email-signer.ts
@@ -1,0 +1,87 @@
+import type { EmailInternalSignerConfig } from "../types";
+import { EmailSignerApiClient } from "./email-signer-api-client";
+import { EmailSigner, DEFAULT_EVENT_OPTIONS } from "./email-signer";
+import type { Crossmint } from "@crossmint/common-sdk-base";
+import { Address, PublicKey } from "ox";
+
+export class EvmEmailSigner extends EmailSigner {
+    constructor(config: EmailInternalSignerConfig) {
+        super(config);
+    }
+
+    locator() {
+        return `evm-keypair:${this.config.signerAddress}`;
+    }
+
+    async signMessage() {
+        return await Promise.reject(new Error("signMessage method not implemented for email signer"));
+    }
+
+    async signTransaction(transaction: string): Promise<{ signature: string }> {
+        await this.handleAuthRequired();
+
+        const hexString = transaction.startsWith("0x") ? transaction.slice(2) : transaction;
+
+        const res = await this.config._handshakeParent?.sendAction({
+            event: "request:sign",
+            responseEvent: "response:sign",
+            data: {
+                authData: {
+                    jwt: this.config.crossmint.experimental_customAuth?.jwt ?? "",
+                    apiKey: this.config.crossmint.apiKey,
+                },
+                data: {
+                    keyType: "secp256k1",
+                    bytes: hexString,
+                    encoding: "hex",
+                },
+            },
+            options: DEFAULT_EVENT_OPTIONS,
+        });
+
+        if (res?.status === "error") {
+            throw new Error(res.error);
+        }
+
+        if (res?.signature == null) {
+            throw new Error("Failed to sign transaction");
+        }
+
+        return { signature: res.signature.bytes };
+    }
+
+    static async pregenerateSigner(email: string, crossmint: Crossmint): Promise<string> {
+        if (email == null || crossmint.experimental_customAuth?.email == null) {
+            throw new Error("Email is required to pregenerate a signer");
+        }
+
+        try {
+            const response = await new EmailSignerApiClient(crossmint).pregenerateSigner(
+                email ?? crossmint.experimental_customAuth.email,
+                "secp256k1"
+            );
+            const publicKey = response.publicKey;
+
+            if (publicKey == null) {
+                throw new Error("No public key found");
+            }
+
+            if (publicKey.encoding !== "hex" || publicKey.keyType !== "secp256k1" || publicKey.bytes == null) {
+                throw new Error(
+                    "Not supported. Expected public key to be in hex encoding and secp256k1 key type. Got: " +
+                        JSON.stringify(publicKey)
+                );
+            }
+
+            return this.publicKeyToEvmAddress(publicKey.bytes);
+        } catch (error) {
+            console.error("[EvmEmailSigner] Failed to pregenerate signer:", error);
+            throw error;
+        }
+    }
+
+    private static publicKeyToEvmAddress(publicKeyHex: string): string {
+        const publicKey = PublicKey.from(`0x${publicKeyHex}`);
+        return Address.fromPublicKey(publicKey, { checksum: true });
+    }
+}

--- a/packages/wallets/src/signers/email/index.ts
+++ b/packages/wallets/src/signers/email/index.ts
@@ -1,1 +1,3 @@
-export * from "./email";
+export * from "./email-signer";
+export * from "./solana-email-signer";
+export * from "./evm-email-signer";

--- a/packages/wallets/src/signers/email/solana-email-signer.ts
+++ b/packages/wallets/src/signers/email/solana-email-signer.ts
@@ -1,0 +1,85 @@
+import { VersionedTransaction } from "@solana/web3.js";
+import base58 from "bs58";
+import type { EmailInternalSignerConfig } from "../types";
+import { EmailSignerApiClient } from "./email-signer-api-client";
+import { EmailSigner, DEFAULT_EVENT_OPTIONS } from "./email-signer";
+import type { Crossmint } from "@crossmint/common-sdk-base";
+
+export class SolanaEmailSigner extends EmailSigner {
+    constructor(config: EmailInternalSignerConfig) {
+        super(config);
+    }
+
+    locator() {
+        return `solana-keypair:${this.config.signerAddress}`;
+    }
+
+    async signMessage() {
+        return await Promise.reject(new Error("signMessage method not implemented for email signer"));
+    }
+
+    async signTransaction(transaction: string): Promise<{ signature: string }> {
+        await this.handleAuthRequired();
+
+        const transactionBytes = base58.decode(transaction);
+        const deserializedTransaction = VersionedTransaction.deserialize(transactionBytes);
+        const messageData = deserializedTransaction.message.serialize();
+
+        const res = await this.config._handshakeParent?.sendAction({
+            event: "request:sign",
+            responseEvent: "response:sign",
+            data: {
+                authData: {
+                    jwt: this.config.crossmint.experimental_customAuth?.jwt ?? "",
+                    apiKey: this.config.crossmint.apiKey,
+                },
+                data: {
+                    keyType: "ed25519",
+                    bytes: base58.encode(messageData),
+                    encoding: "base58",
+                },
+            },
+            options: DEFAULT_EVENT_OPTIONS,
+        });
+
+        if (res?.status === "error") {
+            throw new Error(res.error);
+        }
+
+        if (res?.signature == null) {
+            throw new Error("Failed to sign transaction");
+        }
+
+        return { signature: res.signature.bytes };
+    }
+
+    static async pregenerateSigner(email: string, crossmint: Crossmint): Promise<string> {
+        if (email == null || crossmint.experimental_customAuth?.email == null) {
+            throw new Error("Email is required to pregenerate a signer");
+        }
+
+        try {
+            const response = await new EmailSignerApiClient(crossmint).pregenerateSigner(
+                email ?? crossmint.experimental_customAuth.email,
+                "ed25519"
+            );
+            const publicKey = response.publicKey;
+
+            if (publicKey == null) {
+                throw new Error("No public key found");
+            }
+
+            if (publicKey.encoding !== "base58" || publicKey.keyType !== "ed25519" || publicKey.bytes == null) {
+                throw new Error(
+                    "Not supported. Expected public key to be in base58 encoding and ed25519 key type. Got: " +
+                        JSON.stringify(publicKey)
+                );
+            }
+
+            return publicKey.bytes;
+        } catch (error) {
+            console.error("[EmailSigner] Failed to pregenerate signer:", error);
+            throw error;
+        }
+    }
+}

--- a/packages/wallets/src/signers/index.ts
+++ b/packages/wallets/src/signers/index.ts
@@ -1,4 +1,4 @@
-import { EmailSigner } from "./email";
+import { EvmEmailSigner, SolanaEmailSigner } from "./email";
 import { SolanaExternalWalletSigner } from "./solana-external-wallet";
 import { EVMExternalWalletSigner } from "./evm-external-wallet";
 import { PasskeySigner } from "./passkey";
@@ -10,7 +10,7 @@ import type { InternalSignerConfig, Signer, SolanaExternalWalletSignerConfig } f
 export function assembleSigner<C extends Chain>(chain: C, config: InternalSignerConfig<C>): Signer {
     switch (config.type) {
         case "email":
-            return new EmailSigner(config);
+            return chain === "solana" ? new SolanaEmailSigner(config) : new EvmEmailSigner(config);
 
         case "api-key":
             return chain === "solana" ? new SolanaApiKeySigner(config) : new EVMApiKeySigner(config);

--- a/packages/wallets/src/wallets/wallet-factory.ts
+++ b/packages/wallets/src/wallets/wallet-factory.ts
@@ -6,8 +6,9 @@ import type { InternalSignerConfig, SignerConfigForChain, ExternalWalletInternal
 import { Wallet } from "./wallet";
 import { assembleSigner } from "../signers";
 import type { WalletOptions } from "./types";
-import { EmailSigner } from "@/signers/email/email";
 import { deepCompare } from "@/utils/signer-validation";
+import { EvmEmailSigner } from "@/signers/email/evm-email-signer";
+import { SolanaEmailSigner } from "@/signers/email/solana-email-signer";
 
 export type WalletArgsFor<C extends Chain> = {
     chain: C;
@@ -144,8 +145,12 @@ export class WalletFactory {
 
             case "email": {
                 if (
-                    walletResponse.type !== "solana-smart-wallet" ||
-                    walletResponse.config.adminSigner.type !== "solana-keypair"
+                    !(
+                        (walletResponse.type === "solana-smart-wallet" &&
+                            walletResponse.config.adminSigner.type === "solana-keypair") ||
+                        (walletResponse.type === "evm-smart-wallet" &&
+                            walletResponse.config.adminSigner.type === "evm-keypair")
+                    )
                 ) {
                     throw new WalletCreationError("Wallet signer 'email' has no address");
                 }
@@ -228,15 +233,20 @@ export class WalletFactory {
             if (email == null) {
                 throw new Error("Email is required to create a wallet with email signer");
             }
-            if (chain !== "solana") {
-                throw new Error("Email signer is only supported for Solana wallets");
-            }
 
-            const emailSignerAddress = await EmailSigner.pregenerateSigner(email, this.apiClient.crossmint);
-            return {
-                type: "solana-keypair",
-                address: emailSignerAddress,
-            };
+            if (chain === "solana") {
+                const emailSignerAddress = await SolanaEmailSigner.pregenerateSigner(email, this.apiClient.crossmint);
+                return {
+                    type: "solana-keypair",
+                    address: emailSignerAddress,
+                };
+            } else {
+                const emailSignerAddress = await EvmEmailSigner.pregenerateSigner(email, this.apiClient.crossmint);
+                return {
+                    type: "evm-keypair",
+                    address: emailSignerAddress,
+                };
+            }
         }
 
         throw new Error("Invalid signer type");


### PR DESCRIPTION
## Description

Added EVM email signers. Created an abstract class for shared functionality with the Solana email signer.

<!-- Human must describe here why are we doing this change, and roughly what it does -->
<!-- Optional screenshot or video -->

## Test plan

Created a wallet and sent some usdc: https://scope.sh/11155111/op/0x756f435f8d3214d5cad10d4abe51632891e6952f8e3b844582f4c7fc91e63bb5

<!--
  Example:
   * Unit tests which cover functionality X, Y, Z
   * V was tested via UI tests
   * W was tested manually
-->

## Package updates
@crossmint/wallets-sdk
<!-- 
  List any package updates and ensure you've added the necessary changesets, running `pnpm change:add` to do so.
-->