### PR TITLE
Auth: Fixes storing jwt after Twitter login

### DIFF
--- a/.changeset/eighty-lizards-guess.md
+++ b/.changeset/eighty-lizards-guess.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+---
+
+Fixes generating wallet after Twitter login

--- a/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.tsx
@@ -13,12 +13,14 @@ function CrossmintAuthSync({ children }: { children: ReactNode }) {
         if (jwt == null && experimental_customAuth?.jwt != null) {
             experimental_setCustomAuth(undefined);
         }
-        if ((experimental_externalWalletSigner != null || user?.email != null) && jwt != null) {
+        if (experimental_externalWalletSigner != null || user?.email != null) {
             experimental_setCustomAuth({
                 jwt,
                 email: user?.email,
                 externalWalletSigner: experimental_externalWalletSigner,
             });
+        } else {
+            experimental_setCustomAuth({ jwt });
         }
     }, [experimental_externalWalletSigner, jwt, user]);
 


### PR DESCRIPTION
## Description

We weren't setting the jwt on non-email authentications like Twitter so we would then not generate a wallet

## Test plan

Tested with devkit

## Package updates

react-ui: patch