### PR TITLE
Signer types vary based on chain (TypeScript)

### DIFF
--- a/.changeset/spicy-tomatoes-relate.md
+++ b/.changeset/spicy-tomatoes-relate.md
@@ -1,0 +1,7 @@
+---
+"@crossmint/client-sdk-react-base": patch
+"@crossmint/common-sdk-base": patch
+"@crossmint/wallets-sdk": patch
+---
+
+Fix createOnLogin wallet types based on chain

--- a/packages/client/react-base/src/types/wallet.ts
+++ b/packages/client/react-base/src/types/wallet.ts
@@ -1,5 +1,5 @@
 import type { UIConfig } from "@crossmint/common-sdk-base";
-import type { Chain, SignerConfigForChain } from "@crossmint/wallets-sdk";
+import type { EVMChain, SignerConfigForChain, SolanaChain } from "@crossmint/wallets-sdk";
 
 export type {
     Balances,
@@ -12,11 +12,17 @@ export type {
 
 export { EVMWallet, SolanaWallet } from "@crossmint/wallets-sdk";
 
-export type CreateOnLogin = {
-    chain: Chain;
-    signer: SignerConfigForChain<Chain>;
-    owner?: string;
-};
+export type CreateOnLogin =
+    | {
+          chain: SolanaChain;
+          signer: SignerConfigForChain<SolanaChain>;
+          owner?: string;
+      }
+    | {
+          chain: EVMChain;
+          signer: SignerConfigForChain<EVMChain>;
+          owner?: string;
+      };
 
 export type BaseCrossmintWalletProviderProps = {
     createOnLogin?: CreateOnLogin;

--- a/packages/common/base/src/types/signers.ts
+++ b/packages/common/base/src/types/signers.ts
@@ -19,5 +19,5 @@ export type EvmExternalWalletSignerConfig = BaseExternalWalletSignerConfig & {
 };
 
 export type SolanaExternalWalletSignerConfig = BaseExternalWalletSignerConfig & {
-    onSignTransaction: (transaction: VersionedTransaction) => Promise<VersionedTransaction>;
+    onSignTransaction?: (transaction: VersionedTransaction) => Promise<VersionedTransaction>;
 };

--- a/packages/wallets/src/signers/solana-external-wallet.ts
+++ b/packages/wallets/src/signers/solana-external-wallet.ts
@@ -6,7 +6,7 @@ import { TransactionFailedError } from "../utils/errors";
 export class SolanaExternalWalletSigner implements Signer {
     type = "external-wallet" as const;
     address: string;
-    onSignTransaction: (transaction: VersionedTransaction) => Promise<VersionedTransaction>;
+    onSignTransaction?: (transaction: VersionedTransaction) => Promise<VersionedTransaction>;
 
     constructor(config: SolanaExternalWalletSignerConfig) {
         if (config.address == null) {

--- a/packages/wallets/src/signers/types.ts
+++ b/packages/wallets/src/signers/types.ts
@@ -93,7 +93,7 @@ export type PasskeySignResult = {
 
 export type SignerConfigForChain<C extends Chain> = C extends SolanaChain
     ? EmailSignerConfig | BaseSignerConfig<C>
-    : PasskeySignerConfig | BaseSignerConfig<C>;
+    : EmailSignerConfig | PasskeySignerConfig | BaseSignerConfig<C>;
 
 ////////////////////////////////////////////////////////////
 // Signer base types


### PR DESCRIPTION
## Description

Typescript types weren't working for when unsupported signer types were passed based on chain passed. For instance, passing `createOnLogin={{ chain: "solana", signer: { type: "passkey" } }}` wasn't throwing a ts error and as you probably know, we don't support passkeys on solana yet. 

closes https://linear.app/crossmint/issue/WAL-4999/signer-types-for-createonlogin-dont-fail-based-on-the-chain

## Test plan

tested that type error throws on react, react native, and just wallets sdk 

## Package updates

@crossmint/client-sdk-react-base
@crossmint/common-sdk-base
@crossmint/wallets-sdk