### PR TITLE
Move _handshakeParent from signer to options

### DIFF
--- a/.changeset/lovely-lemons-obey.md
+++ b/.changeset/lovely-lemons-obey.md
@@ -4,4 +4,4 @@
 "@crossmint/wallets-sdk": patch
 ---
 
-Move \_handshakeParent from signer to options config
+Move \_handshakeParent from signer to options config and rename to clientTEEConnection

--- a/.changeset/lovely-lemons-obey.md
+++ b/.changeset/lovely-lemons-obey.md
@@ -1,0 +1,7 @@
+---
+"@crossmint/client-sdk-react-native-ui": patch
+"@crossmint/client-sdk-react-base": patch
+"@crossmint/wallets-sdk": patch
+---
+
+Move \_handshakeParent from signer to options config

--- a/packages/client/react-base/src/providers/CrossmintWalletBaseProvider.tsx
+++ b/packages/client/react-base/src/providers/CrossmintWalletBaseProvider.tsx
@@ -18,7 +18,7 @@ export type CrossmintWalletBaseContext = {
     status: "not-loaded" | "in-progress" | "loaded" | "error";
     getOrCreateWallet: <C extends Chain>(props: WalletArgsFor<C>) => Promise<Wallet<Chain> | undefined>;
     onAuthRequired?: EmailSignerConfig["onAuthRequired"];
-    _getEmailSignerIframe?: () => HandshakeParent<typeof signerOutboundEvents, typeof signerInboundEvents>;
+    _getSignerConnection?: () => HandshakeParent<typeof signerOutboundEvents, typeof signerInboundEvents>;
 };
 
 export const CrossmintWalletBaseContext = createContext<CrossmintWalletBaseContext>({
@@ -26,7 +26,7 @@ export const CrossmintWalletBaseContext = createContext<CrossmintWalletBaseConte
     status: "not-loaded",
     getOrCreateWallet: () => Promise.resolve(undefined),
     onAuthRequired: undefined,
-    _getEmailSignerIframe: undefined,
+    _getSignerConnection: undefined,
 });
 
 export interface CrossmintWalletBaseProviderProps {
@@ -37,7 +37,7 @@ export interface CrossmintWalletBaseProviderProps {
         onTransactionStart?: () => Promise<void>;
     };
     onAuthRequired?: EmailSignerConfig["onAuthRequired"];
-    _getEmailSignerIframe?: () => HandshakeParent<typeof signerOutboundEvents, typeof signerInboundEvents>;
+    _getSignerConnection?: () => HandshakeParent<typeof signerOutboundEvents, typeof signerInboundEvents>;
 }
 
 export function CrossmintWalletBaseProvider({
@@ -45,7 +45,7 @@ export function CrossmintWalletBaseProvider({
     createOnLogin,
     callbacks,
     onAuthRequired,
-    _getEmailSignerIframe,
+    _getSignerConnection,
 }: CrossmintWalletBaseProviderProps) {
     const { crossmint, experimental_customAuth } = useCrossmint(
         "CrossmintWalletBaseProvider must be used within CrossmintProvider"
@@ -81,7 +81,6 @@ export function CrossmintWalletBaseProvider({
                         ...args.signer,
                         email,
                         onAuthRequired: _onAuthRequired,
-                        _handshakeParent: _getEmailSignerIframe?.(),
                     };
                 }
 
@@ -105,6 +104,7 @@ export function CrossmintWalletBaseProvider({
                     chain: args.chain,
                     signer: args.signer,
                     options: {
+                        _handshakeParent: _getSignerConnection?.(),
                         experimental_callbacks: {
                             onWalletCreationStart: _onWalletCreationStart ?? callbacks?.onWalletCreationStart,
                             onTransactionStart: _onTransactionStart ?? callbacks?.onTransactionStart,
@@ -143,9 +143,9 @@ export function CrossmintWalletBaseProvider({
             status: walletStatus,
             getOrCreateWallet,
             onAuthRequired,
-            _getEmailSignerIframe,
+            _getSignerConnection,
         }),
-        [getOrCreateWallet, wallet, walletStatus, onAuthRequired, _getEmailSignerIframe]
+        [getOrCreateWallet, wallet, walletStatus, onAuthRequired, _getSignerConnection]
     );
 
     return <CrossmintWalletBaseContext.Provider value={contextValue}>{children}</CrossmintWalletBaseContext.Provider>;

--- a/packages/client/react-base/src/providers/CrossmintWalletBaseProvider.tsx
+++ b/packages/client/react-base/src/providers/CrossmintWalletBaseProvider.tsx
@@ -18,7 +18,7 @@ export type CrossmintWalletBaseContext = {
     status: "not-loaded" | "in-progress" | "loaded" | "error";
     getOrCreateWallet: <C extends Chain>(props: WalletArgsFor<C>) => Promise<Wallet<Chain> | undefined>;
     onAuthRequired?: EmailSignerConfig["onAuthRequired"];
-    _getSignerConnection?: () => HandshakeParent<typeof signerOutboundEvents, typeof signerInboundEvents>;
+    clientTEEConnection?: () => HandshakeParent<typeof signerOutboundEvents, typeof signerInboundEvents>;
 };
 
 export const CrossmintWalletBaseContext = createContext<CrossmintWalletBaseContext>({
@@ -26,7 +26,7 @@ export const CrossmintWalletBaseContext = createContext<CrossmintWalletBaseConte
     status: "not-loaded",
     getOrCreateWallet: () => Promise.resolve(undefined),
     onAuthRequired: undefined,
-    _getSignerConnection: undefined,
+    clientTEEConnection: undefined,
 });
 
 export interface CrossmintWalletBaseProviderProps {
@@ -37,7 +37,7 @@ export interface CrossmintWalletBaseProviderProps {
         onTransactionStart?: () => Promise<void>;
     };
     onAuthRequired?: EmailSignerConfig["onAuthRequired"];
-    _getSignerConnection?: () => HandshakeParent<typeof signerOutboundEvents, typeof signerInboundEvents>;
+    clientTEEConnection?: () => HandshakeParent<typeof signerOutboundEvents, typeof signerInboundEvents>;
 }
 
 export function CrossmintWalletBaseProvider({
@@ -45,7 +45,7 @@ export function CrossmintWalletBaseProvider({
     createOnLogin,
     callbacks,
     onAuthRequired,
-    _getSignerConnection,
+    clientTEEConnection,
 }: CrossmintWalletBaseProviderProps) {
     const { crossmint, experimental_customAuth } = useCrossmint(
         "CrossmintWalletBaseProvider must be used within CrossmintProvider"
@@ -104,7 +104,7 @@ export function CrossmintWalletBaseProvider({
                     chain: args.chain,
                     signer: args.signer,
                     options: {
-                        _handshakeParent: _getSignerConnection?.(),
+                        clientTEEConnection: clientTEEConnection?.(),
                         experimental_callbacks: {
                             onWalletCreationStart: _onWalletCreationStart ?? callbacks?.onWalletCreationStart,
                             onTransactionStart: _onTransactionStart ?? callbacks?.onTransactionStart,
@@ -143,9 +143,9 @@ export function CrossmintWalletBaseProvider({
             status: walletStatus,
             getOrCreateWallet,
             onAuthRequired,
-            _getSignerConnection,
+            clientTEEConnection,
         }),
-        [getOrCreateWallet, wallet, walletStatus, onAuthRequired, _getSignerConnection]
+        [getOrCreateWallet, wallet, walletStatus, onAuthRequired, clientTEEConnection]
     );
 
     return <CrossmintWalletBaseContext.Provider value={contextValue}>{children}</CrossmintWalletBaseContext.Provider>;

--- a/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
@@ -130,7 +130,7 @@ export function CrossmintWalletProvider({ children, createOnLogin, callbacks }: 
     }, []);
 
     // Get the handshake parent for email signer
-    const clientTEEConnection = () => {
+    const getClientTEEConnection = () => {
         if (webViewParentRef.current == null) {
             throw new Error("WebView not ready or handshake incomplete");
         }
@@ -163,7 +163,7 @@ export function CrossmintWalletProvider({ children, createOnLogin, callbacks }: 
         <CrossmintWalletBaseProvider
             createOnLogin={createOnLogin}
             onAuthRequired={onAuthRequired}
-            clientTEEConnection={clientTEEConnection}
+            clientTEEConnection={getClientTEEConnection}
             callbacks={callbacks}
         >
             <CrossmintWalletEmailSignerContext.Provider value={authContextValue}>

--- a/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
@@ -130,7 +130,7 @@ export function CrossmintWalletProvider({ children, createOnLogin, callbacks }: 
     }, []);
 
     // Get the handshake parent for email signer
-    const _getSignerConnection = () => {
+    const clientTEEConnection = () => {
         if (webViewParentRef.current == null) {
             throw new Error("WebView not ready or handshake incomplete");
         }
@@ -163,7 +163,7 @@ export function CrossmintWalletProvider({ children, createOnLogin, callbacks }: 
         <CrossmintWalletBaseProvider
             createOnLogin={createOnLogin}
             onAuthRequired={onAuthRequired}
-            _getSignerConnection={_getSignerConnection}
+            clientTEEConnection={clientTEEConnection}
             callbacks={callbacks}
         >
             <CrossmintWalletEmailSignerContext.Provider value={authContextValue}>

--- a/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
@@ -130,7 +130,7 @@ export function CrossmintWalletProvider({ children, createOnLogin, callbacks }: 
     }, []);
 
     // Get the handshake parent for email signer
-    const _getEmailSignerIframe = () => {
+    const _getSignerConnection = () => {
         if (webViewParentRef.current == null) {
             throw new Error("WebView not ready or handshake incomplete");
         }
@@ -163,7 +163,7 @@ export function CrossmintWalletProvider({ children, createOnLogin, callbacks }: 
         <CrossmintWalletBaseProvider
             createOnLogin={createOnLogin}
             onAuthRequired={onAuthRequired}
-            _getEmailSignerIframe={_getEmailSignerIframe}
+            _getSignerConnection={_getSignerConnection}
             callbacks={callbacks}
         >
             <CrossmintWalletEmailSignerContext.Provider value={authContextValue}>

--- a/packages/wallets/src/signers/email/email-signer.ts
+++ b/packages/wallets/src/signers/email/email-signer.ts
@@ -20,13 +20,13 @@ export abstract class EmailSigner implements Signer {
 
     private async initialize() {
         // Initialize iframe if no custom handshake parent is provided
-        if (this.config._handshakeParent == null) {
+        if (this.config.clientTEEConnection == null) {
             const parsedAPIKey = validateAPIKey(this.config.crossmint.apiKey);
             if (!parsedAPIKey.isValid) {
                 throw new Error("Invalid API key");
             }
             const iframeManager = new EmailIframeManager({ environment: parsedAPIKey.environment });
-            this.config._handshakeParent = await iframeManager.initialize();
+            this.config.clientTEEConnection = await iframeManager.initialize();
         }
     }
 
@@ -37,12 +37,12 @@ export abstract class EmailSigner implements Signer {
     abstract signTransaction(transaction: string): Promise<{ signature: string }>;
 
     protected async handleAuthRequired() {
-        if (this.config._handshakeParent == null) {
+        if (this.config.clientTEEConnection == null) {
             throw new Error("Handshake parent not initialized");
         }
 
         // Determine if we need to authenticate the user via OTP or not
-        const signerResponse = await this.config._handshakeParent?.sendAction({
+        const signerResponse = await this.config.clientTEEConnection?.sendAction({
             event: "request:get-status",
             responseEvent: "response:get-status",
             data: {
@@ -107,11 +107,11 @@ export abstract class EmailSigner implements Signer {
     }
 
     private async sendEmailWithOtp() {
-        if (this.config._handshakeParent == null) {
+        if (this.config.clientTEEConnection == null) {
             throw new Error("Handshake parent not initialized");
         }
 
-        const handshakeParent = this.config._handshakeParent;
+        const handshakeParent = this.config.clientTEEConnection;
         const authId = `email:${this.config.email}`;
         const response = await handshakeParent.sendAction({
             event: "request:start-onboarding",
@@ -138,11 +138,11 @@ export abstract class EmailSigner implements Signer {
     }
 
     private async verifyOtp(encryptedOtp: string) {
-        if (this.config._handshakeParent == null) {
+        if (this.config.clientTEEConnection == null) {
             throw new Error("Handshake parent not initialized");
         }
 
-        const handshakeParent = this.config._handshakeParent;
+        const handshakeParent = this.config.clientTEEConnection;
         try {
             const response = await handshakeParent.sendAction({
                 event: "request:complete-onboarding",

--- a/packages/wallets/src/signers/email/evm-email-signer.ts
+++ b/packages/wallets/src/signers/email/evm-email-signer.ts
@@ -23,7 +23,7 @@ export class EvmEmailSigner extends EmailSigner {
 
         const hexString = transaction.replace("0x", "");
 
-        const res = await this.config._handshakeParent?.sendAction({
+        const res = await this.config.clientTEEConnection?.sendAction({
             event: "request:sign",
             responseEvent: "response:sign",
             data: {

--- a/packages/wallets/src/signers/email/solana-email-signer.ts
+++ b/packages/wallets/src/signers/email/solana-email-signer.ts
@@ -26,7 +26,7 @@ export class SolanaEmailSigner extends EmailSigner {
         const deserializedTransaction = VersionedTransaction.deserialize(transactionBytes);
         const messageData = deserializedTransaction.message.serialize();
 
-        const res = await this.config._handshakeParent?.sendAction({
+        const res = await this.config.clientTEEConnection?.sendAction({
             event: "request:sign",
             responseEvent: "response:sign",
             data: {

--- a/packages/wallets/src/signers/types.ts
+++ b/packages/wallets/src/signers/types.ts
@@ -56,7 +56,7 @@ export type PasskeySignerConfig = {
 export type EmailInternalSignerConfig = EmailSignerConfig & {
     signerAddress: string;
     crossmint: Crossmint;
-    _handshakeParent?: HandshakeParent<typeof signerOutboundEvents, typeof signerInboundEvents>;
+    clientTEEConnection?: HandshakeParent<typeof signerOutboundEvents, typeof signerInboundEvents>;
 };
 
 export type PasskeyInternalSignerConfig = PasskeySignerConfig & {

--- a/packages/wallets/src/signers/types.ts
+++ b/packages/wallets/src/signers/types.ts
@@ -33,7 +33,6 @@ export type EmailSignerConfig = {
         verifyOtp: (otp: string) => Promise<void>,
         reject: () => void
     ) => Promise<void>;
-    _handshakeParent?: HandshakeParent<typeof signerOutboundEvents, typeof signerInboundEvents>;
 };
 
 export type ExternalWalletSignerConfigForChain<C extends Chain> = C extends SolanaChain

--- a/packages/wallets/src/wallets/types.ts
+++ b/packages/wallets/src/wallets/types.ts
@@ -1,4 +1,6 @@
 import type { Keypair, VersionedTransaction } from "@solana/web3.js";
+import type { HandshakeParent } from "@crossmint/client-sdk-window";
+import type { signerInboundEvents, signerOutboundEvents } from "@crossmint/client-signers";
 import type { CreateTransactionSuccessResponse } from "../api";
 import type { EVMSmartWalletChain } from "../chains/chains";
 
@@ -32,6 +34,7 @@ export type Callbacks = {
 
 export type WalletOptions = {
     experimental_callbacks?: Callbacks;
+    _handshakeParent?: HandshakeParent<typeof signerOutboundEvents, typeof signerInboundEvents>;
 };
 
 export type TokenBalance = {

--- a/packages/wallets/src/wallets/types.ts
+++ b/packages/wallets/src/wallets/types.ts
@@ -34,7 +34,7 @@ export type Callbacks = {
 
 export type WalletOptions = {
     experimental_callbacks?: Callbacks;
-    _handshakeParent?: HandshakeParent<typeof signerOutboundEvents, typeof signerInboundEvents>;
+    clientTEEConnection?: HandshakeParent<typeof signerOutboundEvents, typeof signerInboundEvents>;
 };
 
 export type TokenBalance = {

--- a/packages/wallets/src/wallets/wallet-factory.ts
+++ b/packages/wallets/src/wallets/wallet-factory.ts
@@ -165,7 +165,7 @@ export class WalletFactory {
                     signerAddress: address,
                     crossmint: this.apiClient.crossmint,
                     onAuthRequired: signer.onAuthRequired,
-                    _handshakeParent: options?._handshakeParent,
+                    clientTEEConnection: options?.clientTEEConnection,
                 };
             }
 

--- a/packages/wallets/src/wallets/wallet-factory.ts
+++ b/packages/wallets/src/wallets/wallet-factory.ts
@@ -84,7 +84,7 @@ export class WalletFactory {
         walletResponse: GetWalletSuccessResponse,
         args: WalletArgsFor<C>
     ): Wallet<C> {
-        const signerConfig = this.toInternalSignerConfig(walletResponse, args.signer);
+        const signerConfig = this.toInternalSignerConfig(walletResponse, args.signer, args.options);
         return new Wallet(
             {
                 chain: args.chain,
@@ -98,7 +98,8 @@ export class WalletFactory {
 
     private toInternalSignerConfig<C extends Chain>(
         walletResponse: GetWalletSuccessResponse,
-        signer: SignerConfigForChain<C>
+        signer: SignerConfigForChain<C>,
+        options?: WalletOptions
     ): InternalSignerConfig<C> {
         if (signer == null) {
             throw new WalletCreationError("Signer is required to create a wallet");
@@ -164,7 +165,7 @@ export class WalletFactory {
                     signerAddress: address,
                     crossmint: this.apiClient.crossmint,
                     onAuthRequired: signer.onAuthRequired,
-                    _handshakeParent: signer._handshakeParent,
+                    _handshakeParent: options?._handshakeParent,
                 };
             }
 


### PR DESCRIPTION
## Description

Move _handshakeParent property from the signer to the options config. Also in CrossmintWalletBaseProvider, rename `_getEmailSignerIframe` to `_getSignerConnection`.

closes https://linear.app/crossmint/issue/WAL-4794/handshakeparent-should-not-be-on-email-signer

## Test plan

ensured that the `_handshakeParent` is no longer on signer and instead in options.

## Package updates

@crossmint/client-sdk-react-native-ui
@crossmint/client-sdk-react-base
@crossmint/wallets-sdk