### PR TITLE
Add query param to iframe init

### DIFF
--- a/.changeset/great-rice-raise.md
+++ b/.changeset/great-rice-raise.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+Add target origin when handshaking with the iframe

--- a/packages/wallets/src/signers/email/email-iframe-manager.ts
+++ b/packages/wallets/src/signers/email/email-iframe-manager.ts
@@ -17,6 +17,7 @@ export class EmailIframeManager {
         }
 
         const iframeUrl = new URL(environmentUrlConfig[this.config.environment]);
+        iframeUrl.searchParams.set("targetOrigin", window.location.origin);
 
         const iframeElement = await this.createInvisibleIFrame(iframeUrl.toString());
         this.handshakeParent = await IFrameWindow.init(iframeElement, {


### PR DESCRIPTION
## Description

Send window.location.origin when starting the iframe handshake

<!-- Human must describe here why are we doing this change, and roughly what it does -->
<!-- Optional screenshot or video -->

## Test plan

Tested locally, will fully test once the signer iframe is deployed

<!--
  Example:
   * Unit tests which cover functionality X, Y, Z
   * V was tested via UI tests
   * W was tested manually
-->

## Package updates

<!-- 
  List any package updates and ensure you've added the necessary changesets, running `pnpm change:add` to do so.
-->