### PR TITLE
Wallets sdk: Owner not being passed to wallet instance

### DIFF
--- a/.changeset/wise-shirts-scream.md
+++ b/.changeset/wise-shirts-scream.md
@@ -1,0 +1,6 @@
+---
+"@crossmint/client-sdk-react-base": patch
+"@crossmint/wallets-sdk": patch
+---
+
+Pass owner prop through wallet instance

--- a/packages/client/react-base/src/providers/CrossmintWalletBaseProvider.tsx
+++ b/packages/client/react-base/src/providers/CrossmintWalletBaseProvider.tsx
@@ -103,6 +103,7 @@ export function CrossmintWalletBaseProvider({
                 const wallet = await wallets.getOrCreateWallet<C>({
                     chain: args.chain,
                     signer: args.signer,
+                    owner: args.owner,
                     options: {
                         clientTEEConnection: clientTEEConnection?.(),
                         experimental_callbacks: {

--- a/packages/wallets/src/wallets/wallet-factory.ts
+++ b/packages/wallets/src/wallets/wallet-factory.ts
@@ -89,6 +89,7 @@ export class WalletFactory {
             {
                 chain: args.chain,
                 address: walletResponse.address,
+                owner: walletResponse.linkedUser,
                 signer: assembleSigner(args.chain, signerConfig),
                 options: args.options,
             },


### PR DESCRIPTION
## Description

Passes `owner` when creating the wallet instance. 

Closes https://linear.app/crossmint/issue/WAL-5180/owner-is-null-even-though-linkeduser-is-set-up

## Test plan

tested owner

## Package updates

@crossmint/client-sdk-react-base
@crossmint/wallets-sdk