### PR TITLE
Wallets sdk: Expose new param options.experimental_prepareOnly on EVM/SOL wallet

### DIFF
--- a/.changeset/dry-tomatoes-mix.md
+++ b/.changeset/dry-tomatoes-mix.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+Add prepareTransaction method on both EVMWallet and SolanaWallet

--- a/.changeset/dry-tomatoes-mix.md
+++ b/.changeset/dry-tomatoes-mix.md
@@ -2,4 +2,4 @@
 "@crossmint/wallets-sdk": patch
 ---
 
-Add prepareTransaction method on both EVMWallet and SolanaWallet
+Expose new param options.experimental_prepareOnly on EVM/SOL wallet sendTransaction and send methods

--- a/packages/wallets/package.json
+++ b/packages/wallets/package.json
@@ -23,12 +23,12 @@
         "generate:docs": "typedoc"
     },
     "dependencies": {
-        "@crossmint/common-sdk-auth": "workspace:*",
-        "@crossmint/common-sdk-base": "workspace:*",
         "@crossmint/client-sdk-window": "workspace:*",
         "@crossmint/client-signers": "workspace:*",
+        "@crossmint/common-sdk-base": "workspace:*",
         "@hey-api/client-fetch": "0.8.1",
         "@solana/web3.js": "1.98.0",
+        "abitype": "1.0.8",
         "bs58": "5.0.0",
         "ox": "0.6.9",
         "tweetnacl": "1.0.3",

--- a/packages/wallets/src/openapi.json
+++ b/packages/wallets/src/openapi.json
@@ -6875,7 +6875,9 @@
                 }
             },
             "WalletsV1Alpha2TransactionResponseDTO": {
-                "discriminator": { "propertyName": "walletType" },
+                "discriminator": {
+                    "propertyName": "walletType"
+                },
                 "oneOf": [
                     {
                         "type": "object",
@@ -6914,8 +6916,13 @@
                                                                                 "type": "string",
                                                                                 "enum": ["error"]
                                                                             },
-                                                                            "inputs": { "type": "array", "items": {} },
-                                                                            "name": { "type": "string" }
+                                                                            "inputs": {
+                                                                                "type": "array",
+                                                                                "items": {}
+                                                                            },
+                                                                            "name": {
+                                                                                "type": "string"
+                                                                            }
                                                                         },
                                                                         "required": ["type", "inputs", "name"]
                                                                     },
@@ -6926,7 +6933,9 @@
                                                                                 "type": "string",
                                                                                 "enum": ["event"]
                                                                             },
-                                                                            "anonymous": { "type": "boolean" },
+                                                                            "anonymous": {
+                                                                                "type": "boolean"
+                                                                            },
                                                                             "inputs": {
                                                                                 "type": "array",
                                                                                 "items": {
@@ -6955,9 +6964,15 @@
                                                                             {
                                                                                 "type": "object",
                                                                                 "properties": {
-                                                                                    "constant": { "type": "boolean" },
-                                                                                    "gas": { "type": "number" },
-                                                                                    "payable": { "type": "boolean" }
+                                                                                    "constant": {
+                                                                                        "type": "boolean"
+                                                                                    },
+                                                                                    "gas": {
+                                                                                        "type": "number"
+                                                                                    },
+                                                                                    "payable": {
+                                                                                        "type": "boolean"
+                                                                                    }
                                                                                 }
                                                                             },
                                                                             {
@@ -7110,7 +7125,9 @@
                                                 {
                                                     "type": "object",
                                                     "properties": {
-                                                        "transaction": { "description": "Serialized EVM transaction" }
+                                                        "transaction": {
+                                                            "description": "Serialized EVM transaction"
+                                                        }
                                                     },
                                                     "required": ["transaction"],
                                                     "title": "EVM serialized transaction parameters",
@@ -7119,25 +7136,41 @@
                                             ],
                                             "description": "Transaction data to execute"
                                         },
-                                        "description": "Array of transaction calls to execute "
+                                        "minItems": 1,
+                                        "description": "Array of transaction calls to execute"
                                     },
                                     "chain": {
                                         "enum": [
-                                            "base",
-                                            "polygon",
-                                            "optimism",
+                                            "abstract",
+                                            "apechain",
                                             "arbitrum",
-                                            "mode",
-                                            "story",
+                                            "arbitrumnova",
+                                            "base",
                                             "bsc",
+                                            "mantle",
+                                            "mode",
+                                            "optimism",
+                                            "polygon",
+                                            "scroll",
+                                            "sei-pacific-1",
                                             "shape",
-                                            "ethereum-sepolia",
-                                            "base-sepolia",
-                                            "polygon-amoy",
-                                            "optimism-sepolia",
+                                            "story",
+                                            "world-chain",
+                                            "zora",
+                                            "abstract-testnet",
                                             "arbitrum-sepolia",
+                                            "base-sepolia",
+                                            "curtis",
+                                            "ethereum-sepolia",
+                                            "mantle-sepolia",
                                             "mode-sepolia",
-                                            "story-testnet"
+                                            "optimism-sepolia",
+                                            "polygon-amoy",
+                                            "scroll-sepolia",
+                                            "sei-atlantic-2-testnet",
+                                            "story-testnet",
+                                            "world-chain-sepolia",
+                                            "zora-sepolia"
                                         ],
                                         "description": "The chain on which the transaction will be executed"
                                     },
@@ -7163,21 +7196,51 @@
                                     "userOperation": {
                                         "type": "object",
                                         "properties": {
-                                            "sender": { "type": "string" },
-                                            "nonce": { "type": "string" },
-                                            "callData": { "type": "string" },
-                                            "callGasLimit": { "type": "string" },
-                                            "verificationGasLimit": { "type": "string" },
-                                            "preVerificationGas": { "type": "string" },
-                                            "maxFeePerGas": { "type": "string" },
-                                            "maxPriorityFeePerGas": { "type": "string" },
-                                            "paymaster": { "type": "string" },
-                                            "paymasterVerificationGasLimit": { "type": "string" },
-                                            "paymasterData": { "type": "string" },
-                                            "paymasterPostOpGasLimit": { "type": "string" },
-                                            "signature": { "type": "string" },
-                                            "factory": { "type": "string" },
-                                            "factoryData": { "type": "string" }
+                                            "sender": {
+                                                "type": "string"
+                                            },
+                                            "nonce": {
+                                                "type": "string"
+                                            },
+                                            "callData": {
+                                                "type": "string"
+                                            },
+                                            "callGasLimit": {
+                                                "type": "string"
+                                            },
+                                            "verificationGasLimit": {
+                                                "type": "string"
+                                            },
+                                            "preVerificationGas": {
+                                                "type": "string"
+                                            },
+                                            "maxFeePerGas": {
+                                                "type": "string"
+                                            },
+                                            "maxPriorityFeePerGas": {
+                                                "type": "string"
+                                            },
+                                            "paymaster": {
+                                                "type": "string"
+                                            },
+                                            "paymasterVerificationGasLimit": {
+                                                "type": "string"
+                                            },
+                                            "paymasterData": {
+                                                "type": "string"
+                                            },
+                                            "paymasterPostOpGasLimit": {
+                                                "type": "string"
+                                            },
+                                            "signature": {
+                                                "type": "string"
+                                            },
+                                            "factory": {
+                                                "type": "string"
+                                            },
+                                            "factoryData": {
+                                                "type": "string"
+                                            }
                                         },
                                         "required": [
                                             "sender",
@@ -7191,15 +7254,24 @@
                                             "signature"
                                         ]
                                     },
-                                    "userOperationHash": { "type": "string" },
-                                    "txId": { "type": "string" },
-                                    "explorerLink": { "type": "string" }
+                                    "userOperationHash": {
+                                        "type": "string"
+                                    },
+                                    "txId": {
+                                        "type": "string"
+                                    },
+                                    "explorerLink": {
+                                        "type": "string"
+                                    }
                                 },
                                 "required": ["userOperation", "userOperationHash"],
                                 "title": "EVM smart wallet transaction data",
                                 "description": "EVM smart wallet transaction data including input parameters and chain specific details"
                             },
-                            "id": { "type": "string", "description": "Unique identifier for the transaction" },
+                            "id": {
+                                "type": "string",
+                                "description": "Unique identifier for the transaction"
+                            },
                             "status": {
                                 "type": "string",
                                 "enum": ["awaiting-approval", "pending", "failed", "success"],
@@ -7259,9 +7331,15 @@
                                                 "metadata": {
                                                     "type": "object",
                                                     "properties": {
-                                                        "deviceInfo": { "type": "string" },
-                                                        "ipAddress": { "type": "string" },
-                                                        "userAgent": { "type": "string" }
+                                                        "deviceInfo": {
+                                                            "type": "string"
+                                                        },
+                                                        "ipAddress": {
+                                                            "type": "string"
+                                                        },
+                                                        "userAgent": {
+                                                            "type": "string"
+                                                        }
                                                     },
                                                     "description": "Additional metadata about the signature submission"
                                                 }
@@ -7302,15 +7380,22 @@
                                                     "sanctioned_wallet_address"
                                                 ]
                                             },
-                                            "message": { "type": "string" }
+                                            "message": {
+                                                "type": "string"
+                                            }
                                         },
                                         "required": ["reason", "message"]
                                     },
                                     {
                                         "type": "object",
                                         "properties": {
-                                            "reason": { "type": "string", "enum": ["program_error"] },
-                                            "message": { "type": "string" },
+                                            "reason": {
+                                                "type": "string",
+                                                "enum": ["program_error"]
+                                            },
+                                            "message": {
+                                                "type": "string"
+                                            },
                                             "logs": {}
                                         },
                                         "required": ["reason", "message"]
@@ -7318,8 +7403,13 @@
                                     {
                                         "type": "object",
                                         "properties": {
-                                            "reason": { "type": "string", "enum": ["execution_reverted"] },
-                                            "message": { "type": "string" },
+                                            "reason": {
+                                                "type": "string",
+                                                "enum": ["execution_reverted"]
+                                            },
+                                            "message": {
+                                                "type": "string"
+                                            },
                                             "revert": {
                                                 "type": "object",
                                                 "properties": {
@@ -7331,10 +7421,18 @@
                                                             "wallet_deployment"
                                                         ]
                                                     },
-                                                    "reason": { "type": "string" },
-                                                    "reasonData": { "type": "string" },
-                                                    "explorerLink": { "type": "string" },
-                                                    "simulationLink": { "type": "string" }
+                                                    "reason": {
+                                                        "type": "string"
+                                                    },
+                                                    "reasonData": {
+                                                        "type": "string"
+                                                    },
+                                                    "explorerLink": {
+                                                        "type": "string"
+                                                    },
+                                                    "simulationLink": {
+                                                        "type": "string"
+                                                    }
                                                 },
                                                 "required": ["type", "reason"]
                                             }
@@ -7347,7 +7445,10 @@
                             "sendParams": {
                                 "type": "object",
                                 "properties": {
-                                    "token": { "type": "string", "description": "The token locator that's being sent" },
+                                    "token": {
+                                        "type": "string",
+                                        "description": "The token locator that's being sent"
+                                    },
                                     "params": {
                                         "type": "object",
                                         "properties": {
@@ -7395,7 +7496,7 @@
                                         "items": {
                                             "type": "string",
                                             "title": "Signer Locator",
-                                            "description": "A signer locator that can be either a of format '<signerAddress>' for keypair type signers or '<signerType>:<signerIdentifier>'",
+                                            "description": "A signer locator that can be either a of format '\u003CsignerAddress\u003E' for keypair type signers or '\u003CsignerType\u003E:\u003CsignerIdentifier\u003E'",
                                             "example": [
                                                 "evm-keypair:0x1234567890123456789012345678901234567890",
                                                 "evm-passkey:credential-id-123",
@@ -7413,14 +7514,26 @@
                             "onChain": {
                                 "type": "object",
                                 "properties": {
-                                    "transaction": { "type": "string" },
-                                    "lastValidBlockHeight": { "type": "number" },
-                                    "txId": { "type": "string" }
+                                    "transaction": {
+                                        "type": "string"
+                                    },
+                                    "lastValidBlockHeight": {
+                                        "type": "number"
+                                    },
+                                    "txId": {
+                                        "type": "string"
+                                    },
+                                    "explorerLink": {
+                                        "type": "string"
+                                    }
                                 },
                                 "required": ["transaction"],
                                 "description": "Solana custodial wallet transaction data including input parameters and chain specific details"
                             },
-                            "id": { "type": "string", "description": "Unique identifier for the transaction" },
+                            "id": {
+                                "type": "string",
+                                "description": "Unique identifier for the transaction"
+                            },
                             "status": {
                                 "type": "string",
                                 "enum": ["awaiting-approval", "pending", "failed", "success"],
@@ -7480,9 +7593,15 @@
                                                 "metadata": {
                                                     "type": "object",
                                                     "properties": {
-                                                        "deviceInfo": { "type": "string" },
-                                                        "ipAddress": { "type": "string" },
-                                                        "userAgent": { "type": "string" }
+                                                        "deviceInfo": {
+                                                            "type": "string"
+                                                        },
+                                                        "ipAddress": {
+                                                            "type": "string"
+                                                        },
+                                                        "userAgent": {
+                                                            "type": "string"
+                                                        }
                                                     },
                                                     "description": "Additional metadata about the signature submission"
                                                 }
@@ -7523,15 +7642,22 @@
                                                     "sanctioned_wallet_address"
                                                 ]
                                             },
-                                            "message": { "type": "string" }
+                                            "message": {
+                                                "type": "string"
+                                            }
                                         },
                                         "required": ["reason", "message"]
                                     },
                                     {
                                         "type": "object",
                                         "properties": {
-                                            "reason": { "type": "string", "enum": ["program_error"] },
-                                            "message": { "type": "string" },
+                                            "reason": {
+                                                "type": "string",
+                                                "enum": ["program_error"]
+                                            },
+                                            "message": {
+                                                "type": "string"
+                                            },
                                             "logs": {}
                                         },
                                         "required": ["reason", "message"]
@@ -7539,8 +7665,13 @@
                                     {
                                         "type": "object",
                                         "properties": {
-                                            "reason": { "type": "string", "enum": ["execution_reverted"] },
-                                            "message": { "type": "string" },
+                                            "reason": {
+                                                "type": "string",
+                                                "enum": ["execution_reverted"]
+                                            },
+                                            "message": {
+                                                "type": "string"
+                                            },
                                             "revert": {
                                                 "type": "object",
                                                 "properties": {
@@ -7552,10 +7683,18 @@
                                                             "wallet_deployment"
                                                         ]
                                                     },
-                                                    "reason": { "type": "string" },
-                                                    "reasonData": { "type": "string" },
-                                                    "explorerLink": { "type": "string" },
-                                                    "simulationLink": { "type": "string" }
+                                                    "reason": {
+                                                        "type": "string"
+                                                    },
+                                                    "reasonData": {
+                                                        "type": "string"
+                                                    },
+                                                    "explorerLink": {
+                                                        "type": "string"
+                                                    },
+                                                    "simulationLink": {
+                                                        "type": "string"
+                                                    }
                                                 },
                                                 "required": ["type", "reason"]
                                             }
@@ -7568,7 +7707,10 @@
                             "sendParams": {
                                 "type": "object",
                                 "properties": {
-                                    "token": { "type": "string", "description": "The token locator that's being sent" },
+                                    "token": {
+                                        "type": "string",
+                                        "description": "The token locator that's being sent"
+                                    },
                                     "params": {
                                         "type": "object",
                                         "properties": {
@@ -7640,17 +7782,30 @@
                                                                 {
                                                                     "type": "object",
                                                                     "properties": {
-                                                                        "type": { "type": "string", "enum": ["error"] },
-                                                                        "inputs": { "type": "array", "items": {} },
-                                                                        "name": { "type": "string" }
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": ["error"]
+                                                                        },
+                                                                        "inputs": {
+                                                                            "type": "array",
+                                                                            "items": {}
+                                                                        },
+                                                                        "name": {
+                                                                            "type": "string"
+                                                                        }
                                                                     },
                                                                     "required": ["type", "inputs", "name"]
                                                                 },
                                                                 {
                                                                     "type": "object",
                                                                     "properties": {
-                                                                        "type": { "type": "string", "enum": ["event"] },
-                                                                        "anonymous": { "type": "boolean" },
+                                                                        "type": {
+                                                                            "type": "string",
+                                                                            "enum": ["event"]
+                                                                        },
+                                                                        "anonymous": {
+                                                                            "type": "boolean"
+                                                                        },
                                                                         "inputs": {
                                                                             "type": "array",
                                                                             "items": {
@@ -7679,13 +7834,21 @@
                                                                         {
                                                                             "type": "object",
                                                                             "properties": {
-                                                                                "constant": { "type": "boolean" },
-                                                                                "gas": { "type": "number" },
-                                                                                "payable": { "type": "boolean" }
+                                                                                "constant": {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                "gas": {
+                                                                                    "type": "number"
+                                                                                },
+                                                                                "payable": {
+                                                                                    "type": "boolean"
+                                                                                }
                                                                             }
                                                                         },
                                                                         {
-                                                                            "discriminator": { "propertyName": "type" },
+                                                                            "discriminator": {
+                                                                                "propertyName": "type"
+                                                                            },
                                                                             "oneOf": [
                                                                                 {
                                                                                     "type": "object",
@@ -7900,18 +8063,27 @@
                                                 "type": "string",
                                                 "description": "The recipient address for this transaction call"
                                             },
-                                            "data": { "description": "The encoded calldata for this transaction" }
+                                            "data": {
+                                                "description": "The encoded calldata for this transaction"
+                                            }
                                         },
                                         "required": ["to", "data"]
                                     },
-                                    "txId": { "type": "string" },
-                                    "explorerLink": { "type": "string" }
+                                    "txId": {
+                                        "type": "string"
+                                    },
+                                    "explorerLink": {
+                                        "type": "string"
+                                    }
                                 },
                                 "required": ["call"],
                                 "title": "EVM MPC wallet transaction data",
                                 "description": "EVM MPC wallet transaction data including input parameters and chain specific details"
                             },
-                            "id": { "type": "string", "description": "Unique identifier for the transaction" },
+                            "id": {
+                                "type": "string",
+                                "description": "Unique identifier for the transaction"
+                            },
                             "status": {
                                 "type": "string",
                                 "enum": ["awaiting-approval", "pending", "failed", "success"],
@@ -7971,9 +8143,15 @@
                                                 "metadata": {
                                                     "type": "object",
                                                     "properties": {
-                                                        "deviceInfo": { "type": "string" },
-                                                        "ipAddress": { "type": "string" },
-                                                        "userAgent": { "type": "string" }
+                                                        "deviceInfo": {
+                                                            "type": "string"
+                                                        },
+                                                        "ipAddress": {
+                                                            "type": "string"
+                                                        },
+                                                        "userAgent": {
+                                                            "type": "string"
+                                                        }
                                                     },
                                                     "description": "Additional metadata about the signature submission"
                                                 }
@@ -8014,15 +8192,22 @@
                                                     "sanctioned_wallet_address"
                                                 ]
                                             },
-                                            "message": { "type": "string" }
+                                            "message": {
+                                                "type": "string"
+                                            }
                                         },
                                         "required": ["reason", "message"]
                                     },
                                     {
                                         "type": "object",
                                         "properties": {
-                                            "reason": { "type": "string", "enum": ["program_error"] },
-                                            "message": { "type": "string" },
+                                            "reason": {
+                                                "type": "string",
+                                                "enum": ["program_error"]
+                                            },
+                                            "message": {
+                                                "type": "string"
+                                            },
                                             "logs": {}
                                         },
                                         "required": ["reason", "message"]
@@ -8030,8 +8215,13 @@
                                     {
                                         "type": "object",
                                         "properties": {
-                                            "reason": { "type": "string", "enum": ["execution_reverted"] },
-                                            "message": { "type": "string" },
+                                            "reason": {
+                                                "type": "string",
+                                                "enum": ["execution_reverted"]
+                                            },
+                                            "message": {
+                                                "type": "string"
+                                            },
                                             "revert": {
                                                 "type": "object",
                                                 "properties": {
@@ -8043,10 +8233,18 @@
                                                             "wallet_deployment"
                                                         ]
                                                     },
-                                                    "reason": { "type": "string" },
-                                                    "reasonData": { "type": "string" },
-                                                    "explorerLink": { "type": "string" },
-                                                    "simulationLink": { "type": "string" }
+                                                    "reason": {
+                                                        "type": "string"
+                                                    },
+                                                    "reasonData": {
+                                                        "type": "string"
+                                                    },
+                                                    "explorerLink": {
+                                                        "type": "string"
+                                                    },
+                                                    "simulationLink": {
+                                                        "type": "string"
+                                                    }
                                                 },
                                                 "required": ["type", "reason"]
                                             }
@@ -8059,7 +8257,10 @@
                             "sendParams": {
                                 "type": "object",
                                 "properties": {
-                                    "token": { "type": "string", "description": "The token locator that's being sent" },
+                                    "token": {
+                                        "type": "string",
+                                        "description": "The token locator that's being sent"
+                                    },
                                     "params": {
                                         "type": "object",
                                         "properties": {
@@ -8107,7 +8308,7 @@
                                         "items": {
                                             "type": "string",
                                             "title": "Signer Locator",
-                                            "description": "A signer locator that can be either a of format '<signerAddress>' for keypair type signers or '<signerType>:<signerIdentifier>'",
+                                            "description": "A signer locator that can be either a of format '\u003CsignerAddress\u003E' for keypair type signers or '\u003CsignerType\u003E:\u003CsignerIdentifier\u003E'",
                                             "example": [
                                                 "evm-keypair:0x1234567890123456789012345678901234567890",
                                                 "evm-passkey:credential-id-123",
@@ -8154,7 +8355,10 @@
                                             {
                                                 "type": "object",
                                                 "properties": {
-                                                    "feePayer": { "type": "string", "enum": ["crossmint"] },
+                                                    "feePayer": {
+                                                        "type": "string",
+                                                        "enum": ["crossmint"]
+                                                    },
                                                     "amount": {
                                                         "type": "string",
                                                         "description": "The amount of the fee"
@@ -8171,14 +8375,26 @@
                             "onChain": {
                                 "type": "object",
                                 "properties": {
-                                    "transaction": { "type": "string" },
-                                    "lastValidBlockHeight": { "type": "number" },
-                                    "txId": { "type": "string" }
+                                    "transaction": {
+                                        "type": "string"
+                                    },
+                                    "lastValidBlockHeight": {
+                                        "type": "number"
+                                    },
+                                    "txId": {
+                                        "type": "string"
+                                    },
+                                    "explorerLink": {
+                                        "type": "string"
+                                    }
                                 },
                                 "required": ["transaction"],
                                 "description": "Solana smart wallet transaction data including input parameters and chain specific details"
                             },
-                            "id": { "type": "string", "description": "Unique identifier for the transaction" },
+                            "id": {
+                                "type": "string",
+                                "description": "Unique identifier for the transaction"
+                            },
                             "status": {
                                 "type": "string",
                                 "enum": ["awaiting-approval", "pending", "failed", "success"],
@@ -8238,9 +8454,15 @@
                                                 "metadata": {
                                                     "type": "object",
                                                     "properties": {
-                                                        "deviceInfo": { "type": "string" },
-                                                        "ipAddress": { "type": "string" },
-                                                        "userAgent": { "type": "string" }
+                                                        "deviceInfo": {
+                                                            "type": "string"
+                                                        },
+                                                        "ipAddress": {
+                                                            "type": "string"
+                                                        },
+                                                        "userAgent": {
+                                                            "type": "string"
+                                                        }
                                                     },
                                                     "description": "Additional metadata about the signature submission"
                                                 }
@@ -8281,15 +8503,22 @@
                                                     "sanctioned_wallet_address"
                                                 ]
                                             },
-                                            "message": { "type": "string" }
+                                            "message": {
+                                                "type": "string"
+                                            }
                                         },
                                         "required": ["reason", "message"]
                                     },
                                     {
                                         "type": "object",
                                         "properties": {
-                                            "reason": { "type": "string", "enum": ["program_error"] },
-                                            "message": { "type": "string" },
+                                            "reason": {
+                                                "type": "string",
+                                                "enum": ["program_error"]
+                                            },
+                                            "message": {
+                                                "type": "string"
+                                            },
                                             "logs": {}
                                         },
                                         "required": ["reason", "message"]
@@ -8297,8 +8526,13 @@
                                     {
                                         "type": "object",
                                         "properties": {
-                                            "reason": { "type": "string", "enum": ["execution_reverted"] },
-                                            "message": { "type": "string" },
+                                            "reason": {
+                                                "type": "string",
+                                                "enum": ["execution_reverted"]
+                                            },
+                                            "message": {
+                                                "type": "string"
+                                            },
                                             "revert": {
                                                 "type": "object",
                                                 "properties": {
@@ -8310,10 +8544,18 @@
                                                             "wallet_deployment"
                                                         ]
                                                     },
-                                                    "reason": { "type": "string" },
-                                                    "reasonData": { "type": "string" },
-                                                    "explorerLink": { "type": "string" },
-                                                    "simulationLink": { "type": "string" }
+                                                    "reason": {
+                                                        "type": "string"
+                                                    },
+                                                    "reasonData": {
+                                                        "type": "string"
+                                                    },
+                                                    "explorerLink": {
+                                                        "type": "string"
+                                                    },
+                                                    "simulationLink": {
+                                                        "type": "string"
+                                                    }
                                                 },
                                                 "required": ["type", "reason"]
                                             }
@@ -8326,7 +8568,10 @@
                             "sendParams": {
                                 "type": "object",
                                 "properties": {
-                                    "token": { "type": "string", "description": "The token locator that's being sent" },
+                                    "token": {
+                                        "type": "string",
+                                        "description": "The token locator that's being sent"
+                                    },
                                     "params": {
                                         "type": "object",
                                         "properties": {
@@ -8360,7 +8605,12 @@
                     "walletType": "evm-smart-wallet",
                     "status": "awaiting-approval",
                     "approvals": {
-                        "pending": [{ "signer": "evm-keypair:0xdeadbeef", "message": "Please sign this transaction" }],
+                        "pending": [
+                            {
+                                "signer": "evm-keypair:0xdeadbeef",
+                                "message": "Please sign this transaction"
+                            }
+                        ],
                         "submitted": []
                     },
                     "params": {

--- a/packages/wallets/src/wallets/types.ts
+++ b/packages/wallets/src/wallets/types.ts
@@ -1,18 +1,29 @@
 import type { Keypair, VersionedTransaction } from "@solana/web3.js";
 import type { HandshakeParent } from "@crossmint/client-sdk-window";
 import type { signerInboundEvents, signerOutboundEvents } from "@crossmint/client-signers";
+import type { Abi } from "abitype";
 import type { CreateTransactionSuccessResponse } from "../api";
-import type { EVMSmartWalletChain } from "../chains/chains";
 
 export type { Activity } from "../api/types";
 
-export interface EVMTransactionInput {
-    to: string;
-    chain: EVMSmartWalletChain;
-    data?: string;
-    value?: bigint;
-}
+export type EVMTransactionInput =
+    | {
+          to: string;
+          functionName?: string;
+          args?: unknown[];
+          value?: bigint;
+          abi?: Abi;
+          data?: `0x${string}`;
+      }
+    | { transaction: string };
 
+export type FormattedEVMTransaction =
+    | {
+          to: string;
+          value: string;
+          data: string;
+      }
+    | { transaction: string };
 export interface SolanaTransactionInput {
     transaction: VersionedTransaction;
     additionalSigners?: Keypair[];
@@ -62,4 +73,8 @@ export type UserLocator =
 export type Transaction = {
     hash: string;
     explorerLink: string;
+};
+
+export type PreparedTransaction = {
+    txId: string;
 };

--- a/packages/wallets/src/wallets/types.ts
+++ b/packages/wallets/src/wallets/types.ts
@@ -6,16 +6,32 @@ import type { CreateTransactionSuccessResponse } from "../api";
 
 export type { Activity } from "../api/types";
 
-export type EVMTransactionInput =
-    | {
-          to: string;
-          functionName?: string;
-          args?: unknown[];
-          value?: bigint;
-          abi?: Abi;
-          data?: `0x${string}`;
-      }
-    | { transaction: string };
+export type TransactionInputOptions = {
+    experimental_prepareOnly?: boolean;
+};
+
+type EVMTransactionInputBase = {
+    options?: TransactionInputOptions;
+};
+
+export type EVMTransactionInput = EVMTransactionInputBase &
+    (
+        | {
+              to: string;
+              functionName?: string;
+              args?: unknown[];
+              value?: bigint;
+              abi?: Abi;
+              data?: `0x${string}`;
+          }
+        | { transaction: string }
+    );
+
+export interface SolanaTransactionInput {
+    transaction: VersionedTransaction;
+    additionalSigners?: Keypair[];
+    options?: TransactionInputOptions;
+}
 
 export type FormattedEVMTransaction =
     | {
@@ -24,10 +40,6 @@ export type FormattedEVMTransaction =
           data: string;
       }
     | { transaction: string };
-export interface SolanaTransactionInput {
-    transaction: VersionedTransaction;
-    additionalSigners?: Keypair[];
-}
 
 export type DelegatedSigner = {
     signer: string;
@@ -70,11 +82,14 @@ export type UserLocator =
     | { phone: string }
     | { userId: string };
 
-export type Transaction = {
-    hash: string;
-    explorerLink: string;
-};
-
-export type PreparedTransaction = {
-    txId: string;
-};
+export type Transaction<TPrepareOnly extends boolean = false> = TPrepareOnly extends true
+    ? {
+          hash?: string;
+          explorerLink?: string;
+          transactionId: string;
+      }
+    : {
+          hash: string;
+          explorerLink: string;
+          transactionId: string;
+      };

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -1,11 +1,5 @@
-import { getEnvironmentForKey, isValidAddress } from "@crossmint/common-sdk-base";
-import type {
-    Activity,
-    ApiClient,
-    GetSignatureResponse,
-    GetTransactionSuccessResponse,
-    GetBalanceSuccessResponse,
-} from "../api";
+import { isValidAddress } from "@crossmint/common-sdk-base";
+import type { Activity, ApiClient, GetSignatureResponse, GetBalanceSuccessResponse } from "../api";
 import type {
     PendingApproval,
     DelegatedSigner,
@@ -14,6 +8,7 @@ import type {
     Transaction,
     Balances,
     TokenBalance,
+    TransactionInputOptions,
 } from "./types";
 import {
     InvalidSignerError,
@@ -200,18 +195,34 @@ export class Wallet<C extends Chain> {
      * @param {string | UserLocator} to - The recipient (address or user locator)
      * @param {string} token - The token (address or currency symbol)
      * @param {string} amount - The amount to send (decimal units)
+     * @param {TransactionInputOptions} options - The options for the transaction
      * @returns {Transaction} The transaction
      */
-    public async send(to: string | UserLocator, token: string, amount: string) {
+    public async send<T extends TransactionInputOptions | undefined = undefined>(
+        to: string | UserLocator,
+        token: string,
+        amount: string,
+        options?: T
+    ): Promise<Transaction<T extends { experimental_prepareOnly: true } ? true : false>> {
         const recipient = toRecipientLocator(to);
         const tokenLocator = toTokenLocator(token, this.chain);
-        const params = { recipient, amount };
-        const transactionCreationResponse = await this.#apiClient.send(this.walletLocator, tokenLocator, params);
+        const sendParams = { recipient, amount };
+        const transactionCreationResponse = await this.#apiClient.send(this.walletLocator, tokenLocator, sendParams);
+
         if ("message" in transactionCreationResponse) {
             throw new TransactionNotCreatedError(
                 `Failed to send token: ${JSON.stringify(transactionCreationResponse.message)}`
             );
         }
+
+        if (options?.experimental_prepareOnly) {
+            return {
+                hash: undefined,
+                explorerLink: undefined,
+                transactionId: transactionCreationResponse.id,
+            } as Transaction<T extends { experimental_prepareOnly: true } ? true : false>;
+        }
+
         return await this.approveAndWait(transactionCreationResponse.id);
     }
 
@@ -446,30 +457,13 @@ export class Wallet<C extends Chain> {
 
         return {
             hash: transactionHash,
-            explorerLink: this.toTxExplorerLink(transactionResponse),
+            explorerLink: transactionResponse.onChain.explorerLink ?? "",
+            transactionId: transactionResponse.id,
         };
     }
 
     protected async sleep(ms: number) {
         return new Promise((resolve) => setTimeout(resolve, ms));
-    }
-
-    protected toTxExplorerLink(transactionResponse: GetTransactionSuccessResponse) {
-        let explorerLink: string | undefined;
-        if (transactionResponse.walletType === "evm-smart-wallet") {
-            explorerLink = transactionResponse.onChain.explorerLink;
-        } else if (transactionResponse.walletType === "solana-smart-wallet") {
-            const queryParams = new URLSearchParams();
-            const env = getEnvironmentForKey(this.apiClient.crossmint.apiKey);
-            if (env !== "production") {
-                queryParams.append("cluster", "devnet");
-            }
-            explorerLink = `https://explorer.solana.com/tx/${transactionResponse.onChain.txId}?${queryParams.toString()}`;
-        }
-        if (explorerLink == null || explorerLink === "") {
-            explorerLink = "Explorer link not available";
-        }
-        return explorerLink;
     }
 }
 

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -446,31 +446,31 @@ export class Wallet<C extends Chain> {
 
         return {
             hash: transactionHash,
-            explorerLink: toTxExplorerLink(transactionResponse, this.apiClient.crossmint.apiKey),
+            explorerLink: this.toTxExplorerLink(transactionResponse),
         };
     }
 
     protected async sleep(ms: number) {
         return new Promise((resolve) => setTimeout(resolve, ms));
     }
-}
 
-function toTxExplorerLink(transactionResponse: GetTransactionSuccessResponse, apiKey: string) {
-    let explorerLink: string | undefined;
-    if (transactionResponse.walletType === "evm-smart-wallet") {
-        explorerLink = transactionResponse.onChain.explorerLink;
-    } else if (transactionResponse.walletType === "solana-smart-wallet") {
-        const queryParams = new URLSearchParams();
-        const env = getEnvironmentForKey(apiKey);
-        if (env !== "production") {
-            queryParams.append("cluster", "devnet");
+    protected toTxExplorerLink(transactionResponse: GetTransactionSuccessResponse) {
+        let explorerLink: string | undefined;
+        if (transactionResponse.walletType === "evm-smart-wallet") {
+            explorerLink = transactionResponse.onChain.explorerLink;
+        } else if (transactionResponse.walletType === "solana-smart-wallet") {
+            const queryParams = new URLSearchParams();
+            const env = getEnvironmentForKey(this.apiClient.crossmint.apiKey);
+            if (env !== "production") {
+                queryParams.append("cluster", "devnet");
+            }
+            explorerLink = `https://explorer.solana.com/tx/${transactionResponse.onChain.txId}?${queryParams.toString()}`;
         }
-        explorerLink = `https://explorer.solana.com/tx/${transactionResponse.onChain.txId}?${queryParams.toString()}`;
+        if (explorerLink == null || explorerLink === "") {
+            explorerLink = "Explorer link not available";
+        }
+        return explorerLink;
     }
-    if (explorerLink == null || explorerLink === "") {
-        explorerLink = "Explorer link not available";
-    }
-    return explorerLink;
 }
 
 function toRecipientLocator(to: string | UserLocator): string {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -499,10 +499,10 @@ importers:
         version: 18.3.1
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3))
+        version: 29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3))
       jest-expo:
         specifier: ~52.0.6
-        version: 52.0.6(@babel/core@7.26.10)(bufferutil@4.0.9)(encoding@0.1.13)(expo@52.0.46(tz6j44tf4tmm5rdruadnfs5u6u))(jest@29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3)))(react-dom@18.3.1(react@18.3.1))(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@react-native-community/cli@13.6.4(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@types/react@18.3.20)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(utf-8-validate@5.0.10)(webpack@5.99.7(esbuild@0.21.5))
+        version: 52.0.6(@babel/core@7.26.10)(bufferutil@4.0.9)(encoding@0.1.13)(expo@52.0.46(tz6j44tf4tmm5rdruadnfs5u6u))(jest@29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3)))(react-dom@18.3.1(react@18.3.1))(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@react-native-community/cli@13.6.4(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@types/react@18.3.20)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(utf-8-validate@5.0.10)(webpack@5.99.7(esbuild@0.21.5))
       react-test-renderer:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
@@ -1323,9 +1323,6 @@ importers:
       '@crossmint/client-signers':
         specifier: workspace:*
         version: link:../client/signers
-      '@crossmint/common-sdk-auth':
-        specifier: workspace:*
-        version: link:../common/auth
       '@crossmint/common-sdk-base':
         specifier: workspace:*
         version: link:../common/base
@@ -22841,7 +22838,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3))':
+  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -22855,7 +22852,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3))
+      jest-config: 29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -32425,13 +32422,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3)):
+  create-jest@29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3))
+      jest-config: 29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -36104,16 +36101,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3)):
+  jest-cli@29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3)):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3))
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3))
+      create-jest: 29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3))
+      jest-config: 29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -36253,7 +36250,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3)):
+  jest-config@29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3)):
     dependencies:
       '@babel/core': 7.26.10
       '@jest/test-sequencer': 29.7.0
@@ -36279,38 +36276,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.14.11
-      ts-node: 10.9.2(@types/node@22.7.5)(typescript@5.5.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3)):
-    dependencies:
-      '@babel/core': 7.26.10
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.26.10)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 22.7.5
-      ts-node: 10.9.2(@types/node@22.7.5)(typescript@5.5.3)
+      ts-node: 10.9.2(@types/node@20.14.11)(typescript@5.5.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -36401,7 +36367,7 @@ snapshots:
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
-  jest-expo@52.0.6(@babel/core@7.26.10)(bufferutil@4.0.9)(encoding@0.1.13)(expo@52.0.46(tz6j44tf4tmm5rdruadnfs5u6u))(jest@29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3)))(react-dom@18.3.1(react@18.3.1))(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@react-native-community/cli@13.6.4(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@types/react@18.3.20)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(utf-8-validate@5.0.10)(webpack@5.99.7(esbuild@0.21.5)):
+  jest-expo@52.0.6(@babel/core@7.26.10)(bufferutil@4.0.9)(encoding@0.1.13)(expo@52.0.46(tz6j44tf4tmm5rdruadnfs5u6u))(jest@29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3)))(react-dom@18.3.1(react@18.3.1))(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@react-native-community/cli@13.6.4(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@types/react@18.3.20)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(utf-8-validate@5.0.10)(webpack@5.99.7(esbuild@0.21.5)):
     dependencies:
       '@expo/config': 10.0.11
       '@expo/json-file': 9.0.2
@@ -36414,7 +36380,7 @@ snapshots:
       jest-environment-jsdom: 29.7.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       jest-snapshot: 29.7.0
       jest-watch-select-projects: 2.0.0
-      jest-watch-typeahead: 2.2.1(jest@29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3)))
+      jest-watch-typeahead: 2.2.1(jest@29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3)))
       json5: 2.2.3
       lodash: 4.17.21
       react-native: 0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@react-native-community/cli@13.6.4(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@types/react@18.3.20)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10)
@@ -36857,11 +36823,11 @@ snapshots:
       string-length: 5.0.1
       strip-ansi: 7.1.0
 
-  jest-watch-typeahead@2.2.1(jest@29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3))):
+  jest-watch-typeahead@2.2.1(jest@29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3))):
     dependencies:
       ansi-escapes: 6.2.1
       chalk: 4.1.2
-      jest: 29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3))
+      jest: 29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3))
       jest-regex-util: 29.6.3
       jest-watcher: 29.7.0
       slash: 5.1.0
@@ -36961,12 +36927,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3)):
+  jest@29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3)):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3))
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3))
+      jest-cli: 29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -499,10 +499,10 @@ importers:
         version: 18.3.1
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3))
+        version: 29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3))
       jest-expo:
         specifier: ~52.0.6
-        version: 52.0.6(@babel/core@7.26.10)(bufferutil@4.0.9)(encoding@0.1.13)(expo@52.0.46(tz6j44tf4tmm5rdruadnfs5u6u))(jest@29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3)))(react-dom@18.3.1(react@18.3.1))(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@react-native-community/cli@13.6.4(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@types/react@18.3.20)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(utf-8-validate@5.0.10)(webpack@5.99.7(esbuild@0.21.5))
+        version: 52.0.6(@babel/core@7.26.10)(bufferutil@4.0.9)(encoding@0.1.13)(expo@52.0.46(tz6j44tf4tmm5rdruadnfs5u6u))(jest@29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3)))(react-dom@18.3.1(react@18.3.1))(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@react-native-community/cli@13.6.4(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@types/react@18.3.20)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(utf-8-validate@5.0.10)(webpack@5.99.7(esbuild@0.21.5))
       react-test-renderer:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
@@ -1335,6 +1335,9 @@ importers:
       '@solana/web3.js':
         specifier: 1.98.0
         version: 1.98.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
+      abitype:
+        specifier: 1.0.8
+        version: 1.0.8(typescript@5.8.2)(zod@3.22.4)
       bs58:
         specifier: 5.0.0
         version: 5.0.0
@@ -22838,7 +22841,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3))':
+  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -22852,7 +22855,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3))
+      jest-config: 29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -32422,13 +32425,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3)):
+  create-jest@29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3))
+      jest-config: 29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -36101,16 +36104,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3)):
+  jest-cli@29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3)):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3))
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3))
+      create-jest: 29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3))
+      jest-config: 29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -36250,7 +36253,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3)):
+  jest-config@29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3)):
     dependencies:
       '@babel/core': 7.26.10
       '@jest/test-sequencer': 29.7.0
@@ -36276,7 +36279,38 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.14.11
-      ts-node: 10.9.2(@types/node@20.14.11)(typescript@5.5.3)
+      ts-node: 10.9.2(@types/node@22.7.5)(typescript@5.5.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3)):
+    dependencies:
+      '@babel/core': 7.26.10
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.26.10)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.7.5
+      ts-node: 10.9.2(@types/node@22.7.5)(typescript@5.5.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -36367,7 +36401,7 @@ snapshots:
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
-  jest-expo@52.0.6(@babel/core@7.26.10)(bufferutil@4.0.9)(encoding@0.1.13)(expo@52.0.46(tz6j44tf4tmm5rdruadnfs5u6u))(jest@29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3)))(react-dom@18.3.1(react@18.3.1))(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@react-native-community/cli@13.6.4(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@types/react@18.3.20)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(utf-8-validate@5.0.10)(webpack@5.99.7(esbuild@0.21.5)):
+  jest-expo@52.0.6(@babel/core@7.26.10)(bufferutil@4.0.9)(encoding@0.1.13)(expo@52.0.46(tz6j44tf4tmm5rdruadnfs5u6u))(jest@29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3)))(react-dom@18.3.1(react@18.3.1))(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@react-native-community/cli@13.6.4(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@types/react@18.3.20)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(utf-8-validate@5.0.10)(webpack@5.99.7(esbuild@0.21.5)):
     dependencies:
       '@expo/config': 10.0.11
       '@expo/json-file': 9.0.2
@@ -36380,7 +36414,7 @@ snapshots:
       jest-environment-jsdom: 29.7.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       jest-snapshot: 29.7.0
       jest-watch-select-projects: 2.0.0
-      jest-watch-typeahead: 2.2.1(jest@29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3)))
+      jest-watch-typeahead: 2.2.1(jest@29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3)))
       json5: 2.2.3
       lodash: 4.17.21
       react-native: 0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@react-native-community/cli@13.6.4(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@types/react@18.3.20)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10)
@@ -36823,11 +36857,11 @@ snapshots:
       string-length: 5.0.1
       strip-ansi: 7.1.0
 
-  jest-watch-typeahead@2.2.1(jest@29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3))):
+  jest-watch-typeahead@2.2.1(jest@29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3))):
     dependencies:
       ansi-escapes: 6.2.1
       chalk: 4.1.2
-      jest: 29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3))
+      jest: 29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3))
       jest-regex-util: 29.6.3
       jest-watcher: 29.7.0
       slash: 5.1.0
@@ -36927,12 +36961,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3)):
+  jest@29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3)):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3))
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@20.14.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3))
+      jest-cli: 29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros


### PR DESCRIPTION
## Description

Add new param `options` with `experimental_prepareOnly` that will return an unsigned transaction id if used. 

added to wallet `send` method and evm and solana specific `sendTransaction` methods. 

Closes: https://linear.app/crossmint/issue/WAL-5150/add-preparetransaction-to-solanawallet-and-evmwallet-server-side
Closes: https://linear.app/crossmint/issue/WAL-5179/update-sendtransaction-method-on-evm-with-missing-inputs

## Test plan

new params works on both evm and sol wallet instances. return types also infer based on the options passed for the txn return type.

## Package updates

@crossmint/wallets-sdk