### PR TITLE
fix: exclude Dynamic Labs Apple auth module for Chrome extension manifest v3 compliance

### DIFF
--- a/packages/client/ui/react-ui/tsup.config.ts
+++ b/packages/client/ui/react-ui/tsup.config.ts
@@ -4,7 +4,7 @@ import { treeShakableConfig } from "../../../../tsup.config.base";
 
 const config: Options = {
     ...treeShakableConfig,
-    external: ["react", "react-dom"],
+    external: ["react", "react-dom", "@dynamic-labs/utils/src/services/Oauth2Service/utils/loadAppleId/loadAppleId"],
 };
 
 export default config;


### PR DESCRIPTION
# Fix Chrome Extension Manifest v3 Compliance by Excluding Dynamic Labs Apple Auth Module

## Summary

This PR fixes Chrome extension manifest v3 compliance issues in the `@crossmint/client-sdk-react-ui` package by excluding the problematic Dynamic Labs Apple authentication module from the build output.

The issue was caused by `@dynamic-labs/utils/src/services/Oauth2Service/utils/loadAppleId/loadAppleId.js` which dynamically loads Apple's authentication script from a remote URL (`https://appleid.cdn-apple.com/appleauth/static/jsapi/appleid/1/en_US/appleid.auth.js`). This violates Chrome extension manifest v3 content security policies that prohibit dynamic script loading from remote URLs.

**Solution**: Added the specific problematic module to the `external` array in the tsup configuration, preventing it from being bundled while preserving all other Dynamic Labs functionality.

## Test plan

1. Build the package and integrate into a Chrome extension
2. Test extension loading with manifest v3
3. Verify Crossmint auth flows work (email OTP, Google OAuth, etc.)
4. Confirm no console errors related to Dynamic Labs functionality
5. Manually search the built package for any remaining references to `appleid.cdn-apple.com` or `loadAppleId` to ensure complete exclusion

## Review & Testing Checklist for Human

⚠️ **Critical - 4 items requiring manual verification:**

- [ ] **Test in actual Chrome extension**: Deploy the updated package in a real Chrome extension environment and verify manifest v3 compliance (most important)
- [ ] **Verify Dynamic Labs functionality**: Test that non-Apple auth flows (email, OAuth, passkeys) still work correctly without the excluded module
- [ ] **Confirm module path accuracy**: Verify that the exact path `@dynamic-labs/utils/src/services/Oauth2Service/utils/loadAppleId/loadAppleId` correctly targets the problematic code
- [ ] **Check build output**: Manually search the built package for any remaining references to `appleid.cdn-apple.com` or `loadAppleId` to ensure complete exclusion

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    Config["packages/client/ui/react-ui/tsup.config.ts"]:::major-edit
    DynamicUtils["@dynamic-labs/utils"]:::context
    LoadAppleId["loadAppleId module"]:::context
    BuildOutput["dist/ (build output)"]:::context
    ChromeExt["Chrome Extension"]:::context
    
    Config --> |"excludes via external array"| LoadAppleId
    DynamicUtils --> LoadAppleId
    LoadAppleId -.-> |"blocked from"| BuildOutput
    BuildOutput --> ChromeExt
    
    LoadAppleId --> |"would load"| AppleScript["appleid.cdn-apple.com script"]:::context
    AppleScript -.-> |"violates"| ManifestV3["Manifest v3 CSP"]:::context
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#f9f9f9
```

### Notes

- The change is minimal and surgical - only excluding the specific problematic module while preserving all other Dynamic Labs functionality
- Crossmint doesn't use Dynamic's Apple auth functionality, so this exclusion shouldn't impact any existing features
- Build, lint, and tests all pass successfully after the change
- Verified that `appleid.cdn-apple.com` and `loadAppleId` references are not present in the build output


**Link to Devin run**: https://app.devin.ai/sessions/6c43e614c17c48dd8d85eaade7facd53  
**Requested by**: @AlbertoElias
