### PR TITLE
WAL-5020: SDK support for sms signer react components

### DIFF
--- a/packages/client/react-base/src/providers/CrossmintWalletBaseProvider.tsx
+++ b/packages/client/react-base/src/providers/CrossmintWalletBaseProvider.tsx
@@ -3,7 +3,7 @@ import {
     type Chain,
     CrossmintWallets,
     type EmailSignerConfig,
-    PhoneSignerConfig,
+    type PhoneSignerConfig,
     type SignerConfigForChain,
     type Wallet,
     type WalletArgsFor,
@@ -18,7 +18,7 @@ export type CrossmintWalletBaseContext = {
     wallet: Wallet<Chain> | undefined;
     status: "not-loaded" | "in-progress" | "loaded" | "error";
     getOrCreateWallet: <C extends Chain>(props: WalletArgsFor<C>) => Promise<Wallet<Chain> | undefined>;
-    onAuthRequired?: EmailSignerConfig["onAuthRequired"];
+    onAuthRequired?: EmailSignerConfig["onAuthRequired"] | PhoneSignerConfig["onAuthRequired"];
     clientTEEConnection?: () => HandshakeParent<typeof signerOutboundEvents, typeof signerInboundEvents>;
 };
 

--- a/packages/client/ui/react-ui/src/components/index.ts
+++ b/packages/client/ui/react-ui/src/components/index.ts
@@ -1,8 +1,8 @@
 export * from "./CrossmintNFTCollectionView";
 export * from "./CrossmintNFTDetail";
-
 export * from "./embed";
 export * from "./hosted";
 export * from "./embed/v3";
+export * from "./signers";
 
 export { EmbeddedAuthForm } from "./auth/EmbeddedAuthForm";

--- a/packages/client/ui/react-ui/src/components/signers/PhoneConfirmation.tsx
+++ b/packages/client/ui/react-ui/src/components/signers/PhoneConfirmation.tsx
@@ -1,0 +1,92 @@
+import { useState } from "react";
+import type { UIConfig } from "@crossmint/common-sdk-base";
+
+import { Spinner } from "@/components/common/Spinner";
+import { classNames } from "@/utils/classNames";
+
+interface PhoneConfirmationProps {
+    phone: string;
+    onConfirm: (phone: string) => Promise<void>;
+    onCancel?: () => void;
+    appearance?: UIConfig;
+}
+
+export function PhoneConfirmation({ phone, onConfirm, onCancel, appearance }: PhoneConfirmationProps) {
+    const [isLoading, setIsLoading] = useState(false);
+    const [error, setError] = useState("");
+
+    const handleSendCode = async () => {
+        setIsLoading(true);
+        try {
+            await onConfirm(phone);
+        } catch (error) {
+            console.error("Error sending authorization code:", error);
+            setError("Failed to send code. Please try again.");
+        } finally {
+            setIsLoading(false);
+        }
+    };
+    const accentColor = appearance?.colors?.accent || "#4CAF50";
+    const textColor = appearance?.colors?.textPrimary || "#000000";
+    const borderColor = appearance?.colors?.border || "#E0E0E0";
+
+    return (
+        <div className="flex flex-col w-full max-w-md mx-auto rounded-xl">
+            <h2 className="mb-2" style={{ color: textColor }}>
+                Send authorization code to
+            </h2>
+
+            <div className="w-full mb-8 p-4 rounded-xl border" style={{ borderColor }}>
+                <div className="flex items-center">
+                    <div className="flex-shrink-0 mr-3">
+                        <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="24"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            className="lucide lucide-phone"
+                        >
+                            <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z" />
+                        </svg>
+                    </div>
+                    <span style={{ color: textColor }}>{phone}</span>
+                </div>
+            </div>
+
+            {error && <div className="text-red-500 mb-4 text-sm">{error}</div>}
+
+            <div className="flex gap-3">
+                <button
+                    onClick={onCancel}
+                    className="flex-1 py-4 px-6 border rounded-full text-center font-medium"
+                    style={{ borderColor }}
+                >
+                    Cancel
+                </button>
+
+                <button
+                    onClick={handleSendCode}
+                    disabled={isLoading}
+                    className={classNames(
+                        "flex-1 py-4 px-6 rounded-full text-white text-center font-medium",
+                        isLoading ? "opacity-70" : ""
+                    )}
+                    style={{ backgroundColor: accentColor }}
+                >
+                    {isLoading ? (
+                        <div className="flex justify-center items-center">
+                            <Spinner style={{ color: "white" }} />
+                        </div>
+                    ) : (
+                        "Send code"
+                    )}
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/packages/client/ui/react-ui/src/components/signers/PhoneOTPInput.tsx
+++ b/packages/client/ui/react-ui/src/components/signers/PhoneOTPInput.tsx
@@ -1,0 +1,106 @@
+import { useState } from "react";
+import { CountdownButton } from "@/components/common/CountdownButton";
+import type { UIConfig } from "@crossmint/common-sdk-base";
+import { InputOTP, InputOTPGroup, InputOTPSlot } from "@/components/common/InputOTP";
+import { PhoneOtpIcon } from "@/icons/phoneOTP";
+
+interface PhoneOTPInputProps {
+    phone: string;
+    onSubmitOTP: (token: string) => Promise<void>;
+    onResendCode?: () => Promise<void>;
+    appearance?: UIConfig;
+}
+
+export function PhoneOTPInput({ phone, onSubmitOTP, onResendCode, appearance }: PhoneOTPInputProps) {
+    const [token, setToken] = useState("");
+    const [hasError, setHasError] = useState(false);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const handleOnSubmitOTP = async () => {
+        setLoading(true);
+        try {
+            await onSubmitOTP(token);
+            setHasError(false);
+            setError(null);
+        } catch (error) {
+            console.error("Error confirming recovery key OTP", error);
+            setError("Invalid code. Please try again.");
+            setHasError(true);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <div className="flex flex-col items-center justify-start w-full">
+            <div className="relative left-3">
+                <PhoneOtpIcon
+                    customAccentColor={appearance?.colors?.accent}
+                    customButtonBackgroundColor={appearance?.colors?.buttonBackground}
+                    customBackgroundColor={appearance?.colors?.background}
+                />
+            </div>
+            <p
+                className="text-base font-normal mt-4 mb-1 text-center text-cm-text-primary"
+                style={{ color: appearance?.colors?.textPrimary }}
+            >
+                Check your phone
+            </p>
+            <p className="text-center text-cm-text-secondary px-4" style={{ color: appearance?.colors?.textSecondary }}>
+                A temporary login code has been sent to {phone}
+            </p>
+            <div className="py-8">
+                <InputOTP
+                    maxLength={6}
+                    value={token}
+                    onChange={(val) => {
+                        setToken(val);
+                        setHasError(false);
+                        setError(null);
+                    }}
+                    onComplete={handleOnSubmitOTP}
+                    disabled={loading}
+                    customStyles={{
+                        accent: appearance?.colors?.accent ?? "#04AA6D",
+                        danger: appearance?.colors?.danger ?? "#f44336",
+                        border: appearance?.colors?.border ?? "#E5E7EB",
+                        textPrimary: appearance?.colors?.textPrimary ?? "#909ca3",
+                        buttonBackground: appearance?.colors?.buttonBackground ?? "#eff6ff",
+                        inputBackground: appearance?.colors?.inputBackground ?? "#FFFFFF",
+                        borderRadius: appearance?.borderRadius,
+                    }}
+                >
+                    <InputOTPGroup>
+                        <InputOTPSlot index={0} hasError={hasError} />
+                        <InputOTPSlot index={1} hasError={hasError} />
+                        <InputOTPSlot index={2} hasError={hasError} />
+                        <InputOTPSlot index={3} hasError={hasError} />
+                        <InputOTPSlot index={4} hasError={hasError} />
+                        <InputOTPSlot index={5} hasError={hasError} />
+                    </InputOTPGroup>
+                </InputOTP>
+            </div>
+
+            {error && <div className="text-sm text-red-500 mb-4">{error}</div>}
+
+            <div className="text-xs leading-tight text-cm-text-secondary text-center">
+                <span style={{ color: appearance?.colors?.textSecondary }}>
+                    Didn't receive the SMS? Check your signal.
+                    {"\n"}
+                    Some messages may take several minutes to arrive.
+                </span>
+            </div>
+
+            {onResendCode && (
+                <CountdownButton
+                    initialSeconds={60}
+                    appearance={appearance}
+                    countdownText={(seconds) => `Re-send code in ${seconds}s`}
+                    countdownCompleteText="Re-send code"
+                    handleOnClick={onResendCode}
+                />
+            )}
+        </div>
+    );
+}

--- a/packages/client/ui/react-ui/src/components/signers/PhoneSignersDialog.tsx
+++ b/packages/client/ui/react-ui/src/components/signers/PhoneSignersDialog.tsx
@@ -1,0 +1,98 @@
+import type { MutableRefObject } from "react";
+import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
+import type { UIConfig } from "@crossmint/common-sdk-base";
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "../common/Dialog";
+import { PhoneOTPInput } from "./PhoneOTPInput";
+import { PhoneConfirmation } from "./PhoneConfirmation";
+
+interface PhoneSignersDialogProps {
+    phone: string;
+    open: boolean;
+    setOpen: (open: boolean) => void;
+    step: "initial" | "otp";
+    onSubmitOTP: (token: string) => Promise<void>;
+    onResendOTPCode: () => Promise<void>;
+    onSubmitPhone: () => Promise<void>;
+    rejectRef: MutableRefObject<((error: Error) => void) | undefined>;
+    appearance?: UIConfig;
+}
+
+export function PhoneSignersDialog({
+    phone,
+    open,
+    setOpen,
+    step,
+    onSubmitOTP,
+    onResendOTPCode,
+    onSubmitPhone,
+    rejectRef,
+    appearance,
+}: PhoneSignersDialogProps) {
+    if (phone == null) {
+        throw new Error("Phone is required");
+    }
+
+    function handleOnCancel(isOpen?: boolean) {
+        if (open || isOpen) {
+            rejectRef.current?.(new Error());
+            setOpen(false);
+        }
+    }
+
+    return (
+        <Dialog modal={false} open={open} onOpenChange={handleOnCancel}>
+            <DialogContent
+                onInteractOutside={(e) => e.preventDefault()}
+                onOpenAutoFocus={(e) => e.preventDefault()}
+                className="!p-0 !min-[480px]:p-0"
+                style={{
+                    borderRadius: appearance?.borderRadius,
+                    backgroundColor: appearance?.colors?.background,
+                }}
+            >
+                <VisuallyHidden asChild>
+                    <DialogTitle>Confirm it's you</DialogTitle>
+                </VisuallyHidden>
+                <VisuallyHidden asChild>
+                    <DialogDescription>Create a recovery key</DialogDescription>
+                </VisuallyHidden>
+
+                <div className="relative pt-10 pb-[30px] px-6 !min-[480px]:px-10 flex flex-col gap-[10px] antialiased animate-none max-w-[448px]">
+                    {step === "initial" ? (
+                        <div className="flex flex-col gap-4">
+                            <h1
+                                className="text-2xl font-bold text-cm-text-primary"
+                                style={{ color: appearance?.colors?.textPrimary }}
+                            >
+                                Confirm it's you
+                            </h1>
+                            <p
+                                className="text-base font-normal mb-3 text-cm-text-secondary"
+                                style={{ color: appearance?.colors?.textSecondary }}
+                            >
+                                You're using this wallet for the first time on this device. Click 'Send code' to get a
+                                one-time verification code via SMS.
+                            </p>
+                        </div>
+                    ) : null}
+
+                    {step === "otp" ? (
+                        <PhoneOTPInput
+                            phone={phone}
+                            onSubmitOTP={onSubmitOTP}
+                            onResendCode={onResendOTPCode}
+                            appearance={appearance}
+                        />
+                    ) : (
+                        <PhoneConfirmation
+                            phone={phone}
+                            onConfirm={onSubmitPhone}
+                            onCancel={handleOnCancel}
+                            appearance={appearance}
+                        />
+                    )}
+                </div>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/packages/client/ui/react-ui/src/components/signers/index.ts
+++ b/packages/client/ui/react-ui/src/components/signers/index.ts
@@ -1,0 +1,6 @@
+export { EmailSignersDialog } from "./EmailSignersDialog";
+export { EmailOTPInput } from "./EmailOTPInput";
+export { EmailConfirmation } from "./EmailConfirmation";
+export { PhoneSignersDialog } from "./PhoneSignersDialog";
+export { PhoneOTPInput } from "./PhoneOTPInput";
+export { PhoneConfirmation } from "./PhoneConfirmation";

--- a/packages/client/ui/react-ui/src/icons/phoneOTP.tsx
+++ b/packages/client/ui/react-ui/src/icons/phoneOTP.tsx
@@ -1,0 +1,56 @@
+interface PhoneOtpIconProps {
+    customAccentColor?: string;
+    customButtonBackgroundColor?: string;
+    customBackgroundColor?: string;
+}
+
+export function PhoneOtpIcon({
+    customAccentColor,
+    customButtonBackgroundColor,
+    customBackgroundColor,
+}: PhoneOtpIconProps) {
+    const accentColor = customAccentColor || "#04AA6D";
+    const buttonBackgroundColor = customButtonBackgroundColor || "#eff6ff";
+    const backgroundColor = customBackgroundColor || "#FFFFFF";
+
+    return (
+        <div className="relative">
+            {/* Phone icon with SMS bubble */}
+            <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+                {/* Background circle */}
+                <circle cx="40" cy="40" r="40" fill={backgroundColor} />
+
+                {/* Phone outline */}
+                <rect
+                    x="25"
+                    y="15"
+                    width="30"
+                    height="50"
+                    rx="4"
+                    fill={buttonBackgroundColor}
+                    stroke={accentColor}
+                    strokeWidth="2"
+                />
+
+                {/* Phone screen */}
+                <rect x="27" y="17" width="26" height="46" rx="2" fill={backgroundColor} />
+
+                {/* SMS bubble */}
+                <rect x="32" y="25" width="16" height="8" rx="4" fill={accentColor} />
+
+                {/* SMS dots */}
+                <circle cx="36" cy="29" r="1" fill={backgroundColor} />
+                <circle cx="40" cy="29" r="1" fill={backgroundColor} />
+                <circle cx="44" cy="29" r="1" fill={backgroundColor} />
+
+                {/* Phone button */}
+                <rect x="35" y="45" width="10" height="2" rx="1" fill={accentColor} />
+
+                {/* Signal waves */}
+                <path d="M55 30 Q60 30 60 35" stroke={accentColor} strokeWidth="2" fill="none" />
+                <path d="M55 35 Q62 35 62 40" stroke={accentColor} strokeWidth="2" fill="none" />
+                <path d="M55 40 Q64 40 64 45" stroke={accentColor} strokeWidth="2" fill="none" />
+            </svg>
+        </div>
+    );
+}

--- a/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
@@ -6,9 +6,10 @@ import { CrossmintWalletBaseProvider, useCrossmint, type CreateOnLogin } from "@
 import { PasskeyPrompt } from "@/components/auth/PasskeyPrompt";
 import { TwindProvider } from "./TwindProvider";
 import { EmailSignersDialog } from "@/components/signers/EmailSignersDialog";
+import { PhoneSignersDialog } from "@/components/signers/PhoneSignersDialog";
 
 const throwNotAvailable = (functionName: string) => () => {
-    throw new Error(`${functionName} is not available. Make sure you're using an email signer wallet.`);
+    throw new Error(`${functionName} is not available. Make sure you're using an email or phone signer wallet.`);
 };
 
 type ValidPasskeyPromptType =
@@ -37,6 +38,12 @@ type CrossmintWalletProviderProps = {
     callbacks?: {
         onWalletCreationStart?: () => Promise<void>;
         onTransactionStart?: () => Promise<void>;
+        // onTEEPhoneAuthRequired?: (
+        //     phone: string,
+        //     sendPhoneWithOtp: () => Promise<void>,
+        //     verifyPhoneOtp: (otp: string) => Promise<void>,
+        //     reject: () => void
+        // ) => Promise<void>;
     };
 };
 
@@ -49,12 +56,26 @@ export function CrossmintWalletProvider({
 }: CrossmintWalletProviderProps) {
     const { experimental_customAuth } = useCrossmint();
     const [passkeyPromptState, setPasskeyPromptState] = useState<PasskeyPromptState>({ open: false });
+
+    // Email signer state (for main wallet authentication)
     const [emailSignerDialogOpen, setEmailSignerDialogOpen] = useState<boolean>(false);
     const [emailSignerDialogStep, setEmailSignerDialogStep] = useState<"initial" | "otp">("initial");
 
+    // Phone signer state (for TEE handshake)
+    const [phoneSignerDialogOpen, setPhoneSignerDialogOpen] = useState<boolean>(false);
+    const [phoneSignerDialogStep, setPhoneSignerDialogStep] = useState<"initial" | "otp">("initial");
+    const [phoneNumber, setPhoneNumber] = useState<string>("");
+
     const [needsAuthState, setNeedsAuthState] = useState<boolean>(false);
+
+    // Email signer refs (for main wallet authentication)
     const sendEmailWithOtpRef = useRef<() => Promise<void>>(throwNotAvailable("sendEmailWithOtp"));
     const verifyOtpRef = useRef<(otp: string) => Promise<void>>(throwNotAvailable("verifyOtp"));
+
+    // Phone signer refs (for TEE handshake)
+    const sendPhoneWithOtpRef = useRef<() => Promise<void>>(throwNotAvailable("sendPhoneWithOtp"));
+    const verifyPhoneOtpRef = useRef<(otp: string) => Promise<void>>(throwNotAvailable("verifyPhoneOtp"));
+
     const rejectRef = useRef<(error: Error) => void>(throwNotAvailable("reject"));
 
     const createPasskeyPrompt = useCallback(
@@ -101,6 +122,28 @@ export function CrossmintWalletProvider({
         }
     };
 
+    // Phone authentication handlers (for TEE handshake)
+    const phonesigners_handleSendPhoneOTP = async () => {
+        try {
+            await sendPhoneWithOtpRef.current();
+            setPhoneSignerDialogStep("otp");
+        } catch (error) {
+            console.error("Failed to send phone OTP", error);
+            rejectRef.current(new Error("Failed to send phone OTP"));
+        }
+    };
+
+    const phonesigners_handleOTPSubmit = async (otp: string) => {
+        try {
+            await verifyPhoneOtpRef.current(otp);
+            setPhoneSignerDialogOpen(false);
+            setPhoneSignerDialogStep("initial");
+        } catch (error) {
+            console.error("Failed to verify phone OTP", error);
+            rejectRef.current(new Error("Failed to verify phone OTP"));
+        }
+    };
+
     const getCallbacks = () => {
         let onWalletCreationStart = callbacks?.onWalletCreationStart;
         let onTransactionStart = callbacks?.onTransactionStart;
@@ -119,10 +162,21 @@ export function CrossmintWalletProvider({
         verifyOtp: (otp: string) => Promise<void>,
         reject: () => void
     ) => {
-        setEmailSignerDialogOpen(needsAuth);
+        // Check if we're dealing with a phone signer
+        if (createOnLogin?.signer.type === "phone" && (createOnLogin.signer as any).phone) {
+            setPhoneNumber((createOnLogin.signer as any).phone);
+            setPhoneSignerDialogOpen(needsAuth);
+            // For phone signers, we need to handle the OTP functions differently
+            // The base provider will call these functions for phone authentication
+            sendPhoneWithOtpRef.current = sendEmailWithOtp; // Reuse the same function signature
+            verifyPhoneOtpRef.current = verifyOtp; // Reuse the same function signature
+        } else {
+            // Default email signer behavior
+            setEmailSignerDialogOpen(needsAuth);
+            sendEmailWithOtpRef.current = sendEmailWithOtp;
+            verifyOtpRef.current = verifyOtp;
+        }
         setNeedsAuthState(needsAuth);
-        sendEmailWithOtpRef.current = sendEmailWithOtp;
-        verifyOtpRef.current = verifyOtp;
         rejectRef.current = reject;
     };
 
@@ -146,6 +200,23 @@ export function CrossmintWalletProvider({
                               onSubmitOTP={emailsigners_handleOTPSubmit}
                               onResendOTPCode={emailsigners_handleSendEmailOTP}
                               onSubmitEmail={emailsigners_handleSendEmailOTP}
+                              appearance={appearance}
+                          />,
+                          document.body
+                      )
+                    : null}
+                {phoneSignerDialogOpen && phoneNumber
+                    ? // {phoneSignerDialogOpen && phoneNumber
+                      createPortal(
+                          <PhoneSignersDialog
+                              rejectRef={rejectRef}
+                              phone={phoneNumber}
+                              open={phoneSignerDialogOpen}
+                              setOpen={setPhoneSignerDialogOpen}
+                              step={phoneSignerDialogStep}
+                              onSubmitOTP={phonesigners_handleOTPSubmit}
+                              onResendOTPCode={phonesigners_handleSendPhoneOTP}
+                              onSubmitPhone={phonesigners_handleSendPhoneOTP}
                               appearance={appearance}
                           />,
                           document.body

--- a/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
@@ -158,22 +158,20 @@ export function CrossmintWalletProvider({
 
     const onAuthRequired = async (
         needsAuth: boolean,
-        sendEmailWithOtp: () => Promise<void>,
+        sendOtp: () => Promise<void>,
         verifyOtp: (otp: string) => Promise<void>,
         reject: () => void
     ) => {
         // Check if we're dealing with a phone signer
-        if (createOnLogin?.signer.type === "phone" && (createOnLogin.signer as any).phone) {
-            setPhoneNumber((createOnLogin.signer as any).phone);
+        if (createOnLogin?.signer.type === "phone" && createOnLogin.signer.phone) {
+            setPhoneNumber(createOnLogin.signer.phone);
             setPhoneSignerDialogOpen(needsAuth);
-            // For phone signers, we need to handle the OTP functions differently
-            // The base provider will call these functions for phone authentication
-            sendPhoneWithOtpRef.current = sendEmailWithOtp; // Reuse the same function signature
-            verifyPhoneOtpRef.current = verifyOtp; // Reuse the same function signature
+            sendPhoneWithOtpRef.current = sendOtp;
+            verifyPhoneOtpRef.current = verifyOtp;
         } else {
             // Default email signer behavior
             setEmailSignerDialogOpen(needsAuth);
-            sendEmailWithOtpRef.current = sendEmailWithOtp;
+            sendEmailWithOtpRef.current = sendOtp;
             verifyOtpRef.current = verifyOtp;
         }
         setNeedsAuthState(needsAuth);
@@ -206,8 +204,7 @@ export function CrossmintWalletProvider({
                       )
                     : null}
                 {phoneSignerDialogOpen && phoneNumber
-                    ? // {phoneSignerDialogOpen && phoneNumber
-                      createPortal(
+                    ? createPortal(
                           <PhoneSignersDialog
                               rejectRef={rejectRef}
                               phone={phoneNumber}


### PR DESCRIPTION
## Description

React components to test this [PR](https://github.com/Crossmint/crossmint-sdk/pull/1253)

<!-- Human must describe here why are we doing this change, and roughly what it does -->
<!-- Optional screenshot or video -->

Component:
![image](https://github.com/user-attachments/assets/8634cc4d-8cbe-423f-bcac-b978aa23fc6e)

Received SMS:
<img width="375" alt="image" src="https://github.com/user-attachments/assets/e3b07e94-f599-4a2b-bad2-3a81c90f3906" />

## Test plan

Full e2e loom: https://www.loom.com/share/e8e445c2dfbb46b7bc3a124f612b1ad0?sid=75635e55-daf4-4216-97f9-dcd2186526bc

<!--
  Example:
   * Unit tests which cover functionality X, Y, Z
   * V was tested via UI tests
   * W was tested manually
-->

## Package updates

<!-- 
  List any package updates and ensure you've added the necessary changesets, running `pnpm change:add` to do so.
-->