### PR TITLE
WAL-5344: Validate both origin AND source

### DIFF
--- a/.changeset/mighty-cougars-think.md
+++ b/.changeset/mighty-cougars-think.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-window": patch
+---
+
+Same source checking

--- a/packages/client/window/src/transport/WindowTransport.ts
+++ b/packages/client/window/src/transport/WindowTransport.ts
@@ -23,8 +23,9 @@ export class WindowTransport<OutgoingEvents extends EventMap = EventMap> impleme
 
     addMessageListener(listener: (event: SimpleMessageEvent) => void): string {
         const wrapped = (event: MessageEvent) => {
+            const sameSource = event.source === this.otherWindow;
             const originMatches = this.isTargetOrigin(event.origin);
-            if (originMatches) {
+            if (sameSource && originMatches) {
                 listener({
                     type: event.type,
                     data: event.data,


### PR DESCRIPTION
## Description

Context here: https://linear.app/crossmint/issue/WAL-5344/low-missing-eventsource-validation-allows-same-origin-message-spoofing

<!-- Human must describe here why are we doing this change, and roughly what it does -->
<!-- Optional screenshot or video -->

## Test plan

Manual testing

<!--
  Example:
   * Unit tests which cover functionality X, Y, Z
   * V was tested via UI tests
   * W was tested manually
-->

## Package updates

<!-- 
  List any package updates and ensure you've added the necessary changesets, running `pnpm change:add` to do so.
-->