### PR TITLE
Revert hosted checkout newtab change

### DIFF
--- a/.changeset/fair-tomatoes-enjoy.md
+++ b/.changeset/fair-tomatoes-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-window": patch
+---
+
+Reverted change

--- a/packages/client/window/src/windows/NewTab.ts
+++ b/packages/client/window/src/windows/NewTab.ts
@@ -49,7 +49,7 @@ export class NewTabWindow<IncomingEvents extends EventMap, OutgoingEvents extend
 }
 
 function createNewTabSync(url: string) {
-    const _window = window.open(safeUrl(url), "_blank", "noopener,noreferrer");
+    const _window = window.open(safeUrl(url), "_blank");
     if (!_window) {
         throw new Error("Failed to open new tab window");
     }


### PR DESCRIPTION
## Description

Revert hosted checkout newtab changes from this commit: 
- https://github.com/Crossmint/crossmint-sdk/commit/99171e9d06a5c498be189d29fae449e6054c6b2d#diff-e9b2847276cd51b6f16d873926afa23f8ad3df047e04295035e4f82075d09938R10-R52

## Test plan

reverting a bug with this string causing a loss of parent frame communication.

## Package updates

@crossmint/client-sdk-window