### PR TITLE
WAL-5344: Harden transport for signers flow

### DIFF
--- a/.changeset/thin-humans-sort.md
+++ b/.changeset/thin-humans-sort.md
@@ -1,0 +1,6 @@
+---
+"@crossmint/client-sdk-window": patch
+"@crossmint/wallets-sdk": patch
+---
+
+Fix Window Transport Error

--- a/packages/client/window/src/index.ts
+++ b/packages/client/window/src/index.ts
@@ -3,3 +3,4 @@ export * from "./handshake";
 export type { Transport, SimpleMessageEvent } from "./transport/Transport";
 export type { EventMap } from "./EventEmitter";
 export { generateRandomString } from "./utils/generateRandomString";
+export { SignersWindowTransport } from "./transport/SignersWindowTransport";

--- a/packages/client/window/src/transport/SignersWindowTransport.ts
+++ b/packages/client/window/src/transport/SignersWindowTransport.ts
@@ -1,0 +1,23 @@
+import type { SimpleMessageEvent } from "./Transport";
+import { generateRandomString } from "../utils/generateRandomString";
+import { WindowTransport } from "./WindowTransport";
+
+export class SignersWindowTransport extends WindowTransport {
+    addMessageListener(listener: (event: SimpleMessageEvent) => void): string {
+        const wrapped = (event: MessageEvent) => {
+            const sameSource = event.source === this.otherWindow;
+            const originMatches = this.isTargetOrigin(event.origin);
+            if (sameSource && originMatches) {
+                listener({
+                    type: event.type,
+                    data: event.data,
+                } as SimpleMessageEvent);
+            }
+        };
+
+        const id = generateRandomString();
+        window.addEventListener("message", wrapped);
+        this.listeners.set(id, wrapped);
+        return id;
+    }
+}

--- a/packages/client/window/src/transport/WindowTransport.ts
+++ b/packages/client/window/src/transport/WindowTransport.ts
@@ -4,11 +4,11 @@ import type { Transport, SimpleMessageEvent } from "./Transport";
 import { generateRandomString } from "../utils/generateRandomString";
 
 export class WindowTransport<OutgoingEvents extends EventMap = EventMap> implements Transport<OutgoingEvents> {
-    private listeners = new Map<string, (event: MessageEvent) => void>();
+    protected listeners = new Map<string, (event: MessageEvent) => void>();
 
     constructor(
-        private otherWindow: Window,
-        private targetOrigin: string | string[]
+        protected otherWindow: Window,
+        protected targetOrigin: string | string[]
     ) {}
 
     send<K extends keyof OutgoingEvents>(message: { event: K; data: z.infer<OutgoingEvents[K]> }): void {

--- a/packages/client/window/src/windows/IFrame.ts
+++ b/packages/client/window/src/windows/IFrame.ts
@@ -6,6 +6,11 @@ import { HandshakeParent } from "../handshake/Parent";
 import { WindowTransport } from "../transport/WindowTransport";
 import type { Transport } from "../transport/Transport";
 
+type TransportClassConstructor<OutgoingEvents extends EventMap> = new (
+    otherWindow: Window,
+    targetOrigin: string | string[]
+) => Transport<OutgoingEvents>;
+
 export class IFrameWindow<IncomingEvents extends EventMap, OutgoingEvents extends EventMap> extends HandshakeParent<
     IncomingEvents,
     OutgoingEvents
@@ -14,10 +19,7 @@ export class IFrameWindow<IncomingEvents extends EventMap, OutgoingEvents extend
         public iframe: HTMLIFrameElement,
         targetOrigin: string,
         options?: EventEmitterWithHandshakeOptions<IncomingEvents, OutgoingEvents>,
-        TransportClass: new (
-            otherWindow: Window,
-            targetOrigin: string | string[]
-        ) => Transport<OutgoingEvents> = WindowTransport
+        TransportClass: TransportClassConstructor<OutgoingEvents> = WindowTransport
     ) {
         const contentWindow = iframe.contentWindow;
         if (!contentWindow) {
@@ -30,10 +32,7 @@ export class IFrameWindow<IncomingEvents extends EventMap, OutgoingEvents extend
     static async init<IncomingEvents extends EventMap, OutgoingEvents extends EventMap>(
         urlOrExistingIframe: string | HTMLIFrameElement,
         options?: EventEmitterWithHandshakeOptions<IncomingEvents, OutgoingEvents>,
-        TransportClass: new (
-            otherWindow: Window,
-            targetOrigin: string | string[]
-        ) => Transport<OutgoingEvents> = WindowTransport
+        TransportClass: TransportClassConstructor<OutgoingEvents> = WindowTransport
     ) {
         const iframe =
             typeof urlOrExistingIframe === "string" ? await createIFrame(urlOrExistingIframe) : urlOrExistingIframe;
@@ -44,10 +43,7 @@ export class IFrameWindow<IncomingEvents extends EventMap, OutgoingEvents extend
     static initExistingIFrame<IncomingEvents extends EventMap, OutgoingEvents extends EventMap>(
         iframe: HTMLIFrameElement,
         options?: EventEmitterWithHandshakeOptions<IncomingEvents, OutgoingEvents>,
-        TransportClass: new (
-            otherWindow: Window,
-            targetOrigin: string | string[]
-        ) => Transport<OutgoingEvents> = WindowTransport
+        TransportClass: TransportClassConstructor<OutgoingEvents> = WindowTransport
     ) {
         const targetOrigin = options?.targetOrigin || urlToOrigin(iframe.src);
         return new IFrameWindow<IncomingEvents, OutgoingEvents>(iframe, targetOrigin, options, TransportClass);

--- a/packages/client/window/src/windows/IFrame.ts
+++ b/packages/client/window/src/windows/IFrame.ts
@@ -4,6 +4,7 @@ import type { EventMap } from "../EventEmitter";
 import type { EventEmitterWithHandshakeOptions } from "../handshake";
 import { HandshakeParent } from "../handshake/Parent";
 import { WindowTransport } from "../transport/WindowTransport";
+import type { Transport } from "../transport/Transport";
 
 export class IFrameWindow<IncomingEvents extends EventMap, OutgoingEvents extends EventMap> extends HandshakeParent<
     IncomingEvents,
@@ -12,32 +13,44 @@ export class IFrameWindow<IncomingEvents extends EventMap, OutgoingEvents extend
     private constructor(
         public iframe: HTMLIFrameElement,
         targetOrigin: string,
-        options?: EventEmitterWithHandshakeOptions<IncomingEvents, OutgoingEvents>
+        options?: EventEmitterWithHandshakeOptions<IncomingEvents, OutgoingEvents>,
+        TransportClass: new (
+            otherWindow: Window,
+            targetOrigin: string | string[]
+        ) => Transport<OutgoingEvents> = WindowTransport
     ) {
         const contentWindow = iframe.contentWindow;
         if (!contentWindow) {
             throw new Error("IFrame must have a contentWindow");
         }
-        const transport = new WindowTransport<OutgoingEvents>(contentWindow, targetOrigin);
+        const transport = new TransportClass(contentWindow, targetOrigin);
         super(transport, options);
     }
 
     static async init<IncomingEvents extends EventMap, OutgoingEvents extends EventMap>(
         urlOrExistingIframe: string | HTMLIFrameElement,
-        options?: EventEmitterWithHandshakeOptions<IncomingEvents, OutgoingEvents>
+        options?: EventEmitterWithHandshakeOptions<IncomingEvents, OutgoingEvents>,
+        TransportClass: new (
+            otherWindow: Window,
+            targetOrigin: string | string[]
+        ) => Transport<OutgoingEvents> = WindowTransport
     ) {
         const iframe =
             typeof urlOrExistingIframe === "string" ? await createIFrame(urlOrExistingIframe) : urlOrExistingIframe;
         const targetOrigin = options?.targetOrigin || urlToOrigin(iframe.src);
-        return new IFrameWindow<IncomingEvents, OutgoingEvents>(iframe, targetOrigin, options);
+        return new IFrameWindow<IncomingEvents, OutgoingEvents>(iframe, targetOrigin, options, TransportClass);
     }
 
     static initExistingIFrame<IncomingEvents extends EventMap, OutgoingEvents extends EventMap>(
         iframe: HTMLIFrameElement,
-        options?: EventEmitterWithHandshakeOptions<IncomingEvents, OutgoingEvents>
+        options?: EventEmitterWithHandshakeOptions<IncomingEvents, OutgoingEvents>,
+        TransportClass: new (
+            otherWindow: Window,
+            targetOrigin: string | string[]
+        ) => Transport<OutgoingEvents> = WindowTransport
     ) {
         const targetOrigin = options?.targetOrigin || urlToOrigin(iframe.src);
-        return new IFrameWindow<IncomingEvents, OutgoingEvents>(iframe, targetOrigin, options);
+        return new IFrameWindow<IncomingEvents, OutgoingEvents>(iframe, targetOrigin, options, TransportClass);
     }
 }
 

--- a/packages/wallets/src/signers/email/email-iframe-manager.ts
+++ b/packages/wallets/src/signers/email/email-iframe-manager.ts
@@ -1,4 +1,4 @@
-import { IFrameWindow, type HandshakeParent } from "@crossmint/client-sdk-window";
+import { IFrameWindow, SignersWindowTransport, type HandshakeParent } from "@crossmint/client-sdk-window";
 import { environmentUrlConfig, signerInboundEvents, signerOutboundEvents } from "@crossmint/client-signers";
 import type { APIKeyEnvironmentPrefix } from "@crossmint/common-sdk-base";
 
@@ -20,11 +20,15 @@ export class EmailIframeManager {
         iframeUrl.searchParams.set("targetOrigin", window.location.origin);
 
         const iframeElement = await this.createInvisibleIFrame(iframeUrl.toString());
-        this.handshakeParent = await IFrameWindow.init(iframeElement, {
-            targetOrigin: iframeUrl.origin,
-            incomingEvents: signerOutboundEvents,
-            outgoingEvents: signerInboundEvents,
-        });
+        this.handshakeParent = await IFrameWindow.init(
+            iframeElement,
+            {
+                targetOrigin: iframeUrl.origin,
+                incomingEvents: signerOutboundEvents,
+                outgoingEvents: signerInboundEvents,
+            },
+            SignersWindowTransport
+        );
 
         await this.handshakeParent.handshakeWithChild();
         return this.handshakeParent;


### PR DESCRIPTION
## Description

We add a specific window transport for our ncs flow, with a tighter security control, as recommended by the auditors.

For context if the current changes were applied to the WindowTransport class, then our social auth flows would break.

<!-- Human must describe here why are we doing this change, and roughly what it does -->
<!-- Optional screenshot or video -->

## Test plan

Tested e2e ncs flows, and social login flows.

<!--
  Example:
   * Unit tests which cover functionality X, Y, Z
   * V was tested via UI tests
   * W was tested manually
-->

## Package updates

<!-- 
  List any package updates and ensure you've added the necessary changesets, running `pnpm change:add` to do so.
-->