### PR TITLE
Back to 6 digits otp

### DIFF
--- a/.changeset/large-ducks-reflect.md
+++ b/.changeset/large-ducks-reflect.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+---
+
+Back to 6 digits OTP

--- a/packages/client/ui/react-ui/src/components/signers/EmailOTPInput.tsx
+++ b/packages/client/ui/react-ui/src/components/signers/EmailOTPInput.tsx
@@ -74,12 +74,7 @@ export function EmailOTPInput({ email, onSubmitOTP, onResendCode, appearance }: 
                 >
                     <InputOTPGroup>
                         {Array.from({ length: OTP_LENGTH }).map((_, index) => (
-                            <InputOTPSlot
-                                key={index}
-                                index={index}
-                                hasError={hasError}
-                                className="max-sm:w-7 max-sm:h-11 max-sm:text-xl max-sm:mx-0 h-12 w-9"
-                            />
+                            <InputOTPSlot key={index} index={index} hasError={hasError} />
                         ))}
                     </InputOTPGroup>
                 </InputOTP>

--- a/packages/client/ui/react-ui/src/components/signers/PhoneOTPInput.tsx
+++ b/packages/client/ui/react-ui/src/components/signers/PhoneOTPInput.tsx
@@ -74,12 +74,7 @@ export function PhoneOTPInput({ phone, onSubmitOTP, onResendCode, appearance }: 
                 >
                     <InputOTPGroup>
                         {Array.from({ length: OTP_LENGTH }).map((_, index) => (
-                            <InputOTPSlot
-                                key={index}
-                                index={index}
-                                hasError={hasError}
-                                className="max-sm:w-7 max-sm:h-11 max-sm:text-xl max-sm:mx-0 h-12 w-9"
-                            />
+                            <InputOTPSlot key={index} index={index} hasError={hasError} />
                         ))}
                     </InputOTPGroup>
                 </InputOTP>

--- a/packages/client/ui/react-ui/src/components/signers/consts.ts
+++ b/packages/client/ui/react-ui/src/components/signers/consts.ts
@@ -1,1 +1,1 @@
-export const OTP_LENGTH = 9;
+export const OTP_LENGTH = 6;


### PR DESCRIPTION
## Description

In case we need to release our SDK before the latest TEE code lands in staging, we need to merge this.
Once the TEE starts sending 9 digit OTPs, we have to revert this and release another version

<!-- Human must describe here why are we doing this change, and roughly what it does -->
<!-- Optional screenshot or video -->

## Test plan

Manually verified the modal expect 6 digits again

<!--
  Example:
   * Unit tests which cover functionality X, Y, Z
   * V was tested via UI tests
   * W was tested manually
-->

## Package updates

<!-- 
  List any package updates and ensure you've added the necessary changesets, running `pnpm change:add` to do so.
-->