### PR TITLE
Update getOrCreateWallet error message for better user guidance

### DIFF
--- a/packages/wallets/src/wallets/wallet-factory.ts
+++ b/packages/wallets/src/wallets/wallet-factory.ts
@@ -20,7 +20,7 @@ export class WalletFactory {
 
     public async getOrCreateWallet<C extends Chain>(args: WalletArgsFor<C>): Promise<Wallet<C>> {
         if (this.apiClient.isServerSide) {
-            throw new WalletCreationError("getOrCreateWallet is not supported on server side");
+            throw new WalletCreationError("Error: getOrCreateWallet can only be called from client-side code.\n- Make sure you're running this in the browser (or another client environment), not on your server.\n- Use your Crossmint Client API Key (not a server key).");
         }
 
         const existingWallet = await this.apiClient.getWallet(`me:${args.chain === "solana" ? "solana" : "evm"}:smart`);

--- a/packages/wallets/src/wallets/wallet-factory.ts
+++ b/packages/wallets/src/wallets/wallet-factory.ts
@@ -21,7 +21,7 @@ export class WalletFactory {
     public async getOrCreateWallet<C extends Chain>(args: WalletArgsFor<C>): Promise<Wallet<C>> {
         if (this.apiClient.isServerSide) {
             throw new WalletCreationError(
-                "Error: getOrCreateWallet can only be called from client-side code.\n- Make sure you're running this in the browser (or another client environment), not on your server.\n- Use your Crossmint Client API Key (not a server key)."
+                "getOrCreateWallet can only be called from client-side code.\n- Make sure you're running this in the browser (or another client environment), not on your server.\n- Use your Crossmint Client API Key (not a server key)."
             );
         }
 

--- a/packages/wallets/src/wallets/wallet-factory.ts
+++ b/packages/wallets/src/wallets/wallet-factory.ts
@@ -20,7 +20,9 @@ export class WalletFactory {
 
     public async getOrCreateWallet<C extends Chain>(args: WalletArgsFor<C>): Promise<Wallet<C>> {
         if (this.apiClient.isServerSide) {
-            throw new WalletCreationError("Error: getOrCreateWallet can only be called from client-side code.\n- Make sure you're running this in the browser (or another client environment), not on your server.\n- Use your Crossmint Client API Key (not a server key).");
+            throw new WalletCreationError(
+                "Error: getOrCreateWallet can only be called from client-side code.\n- Make sure you're running this in the browser (or another client environment), not on your server.\n- Use your Crossmint Client API Key (not a server key)."
+            );
         }
 
         const existingWallet = await this.apiClient.getWallet(`me:${args.chain === "solana" ? "solana" : "evm"}:smart`);


### PR DESCRIPTION
# Update getOrCreateWallet error message for better user guidance

## Summary
Updated the error message in `WalletFactory.getOrCreateWallet()` to provide more detailed guidance when the method is called from server-side code. The previous generic message "getOrCreateWallet is not supported on server side" has been replaced with a multi-line explanation that clarifies:

- The method requires client-side execution (browser environment)
- Developers should use a Client API Key rather than a server key
- Provides actionable guidance for resolving the issue

This change addresses Linear ticket WAL-5484 to improve developer experience when encountering this common configuration error.

## Review & Testing Checklist for Human
- [ ] **Verify error message accuracy**: Confirm the guidance about client-side requirements and API key types is technically correct
- [ ] **Test error display formatting**: Trigger the error condition to ensure the multiline message displays properly in the actual error output
- [ ] **Validate against requirements**: Check that this matches the intended improvement described in Linear ticket WAL-5484

**Recommended test plan**: Create a test scenario where `getOrCreateWallet` is called from server-side code to trigger the error and verify the new message appears correctly formatted and provides helpful guidance.

---

### Diagram
```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    A["packages/wallets/src/wallets/<br/>wallet-factory.ts"]:::major-edit
    B["WalletFactory.getOrCreateWallet()"]
    C["apiClient.isServerSide check"]
    D["WalletCreationError<br/>(updated message)"]:::major-edit
    E["Client-side wallet creation flow"]
    
    A --> B
    B --> C
    C -->|true| D
    C -->|false| E
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB
classDef context fill:#FFFFFF
```

### Notes
- This is a focused error message improvement with no logic changes
- The existing server-side detection logic remains unchanged
- Change requested by Alberto Elias (@AlbertoElias) for Linear ticket WAL-5484
- Link to Devin run: https://app.devin.ai/sessions/e154e6ffee8749ab8560afb415e1e818

## Test plan
Verify that when `getOrCreateWallet` is called from a server-side context (when `apiClient.isServerSide` is true), the new detailed error message is displayed correctly with proper formatting and provides clear guidance to developers about using client-side code with a Client API Key.