### PR TITLE
Fix React Native crypto polyfill documentation

### DIFF
--- a/packages/client/rn-window/package.json
+++ b/packages/client/rn-window/package.json
@@ -4,11 +4,7 @@
     "repository": "https://github.com/Crossmint/crossmint-sdk",
     "license": "Apache-2.0",
     "author": "Paella Labs Inc",
-    "sideEffects": [
-        "src/polyfills.ts",
-        "dist/polyfills.js",
-        "dist/polyfills.cjs"
-    ],
+    "sideEffects": ["src/polyfills.ts", "dist/polyfills.js", "dist/polyfills.cjs"],
     "type": "module",
     "exports": {
         "import": "./dist/index.js",

--- a/packages/client/rn-window/package.json
+++ b/packages/client/rn-window/package.json
@@ -4,7 +4,11 @@
     "repository": "https://github.com/Crossmint/crossmint-sdk",
     "license": "Apache-2.0",
     "author": "Paella Labs Inc",
-    "sideEffects": false,
+    "sideEffects": [
+        "src/polyfills.ts",
+        "dist/polyfills.js",
+        "dist/polyfills.cjs"
+    ],
     "type": "module",
     "exports": {
         "import": "./dist/index.js",

--- a/packages/client/rn-window/package.json
+++ b/packages/client/rn-window/package.json
@@ -21,6 +21,7 @@
     },
     "dependencies": {
         "@crossmint/client-sdk-window": "workspace:*",
+        "react-native-get-random-values": "^1.11.0",
         "zod": "3.22.4"
     },
     "peerDependencies": {

--- a/packages/client/rn-window/src/polyfills.ts
+++ b/packages/client/rn-window/src/polyfills.ts
@@ -1,0 +1,1 @@
+import "react-native-get-random-values";

--- a/packages/client/rn-window/src/transport/RNWebViewTransport.ts
+++ b/packages/client/rn-window/src/transport/RNWebViewTransport.ts
@@ -1,3 +1,4 @@
+import "../polyfills";
 import type { z } from "zod";
 import type { WebViewMessageEvent, WebView } from "react-native-webview";
 import type { EventMap, SimpleMessageEvent, Transport } from "@crossmint/client-sdk-window";

--- a/packages/client/ui/react-native/README.md
+++ b/packages/client/ui/react-native/README.md
@@ -5,36 +5,9 @@
 
 ## 🚀 Quick Start
 
-### Required Polyfill Setup
-
-This package requires the `react-native-get-random-values` polyfill to be installed and imported before using any Crossmint SDK functionality. This is necessary because the SDK uses Web Crypto API features that are not available in React Native by default.
-
-#### Installation
-
 ```bash
-pnpm add @crossmint/client-sdk-react-native-ui expo-secure-store expo-web-browser react-native-get-random-values
+pnpm add @crossmint/client-sdk-react-native-ui expo-secure-store expo-web-browser
 ```
-
-#### Import the polyfill
-
-Create a polyfills file (e.g., `utils/polyfills.ts`) and import it at the very beginning of your app:
-
-```typescript
-// utils/polyfills.ts
-import "react-native-get-random-values";
-```
-
-Then import this polyfill file in your app's entry point (e.g., `App.tsx` or `_layout.tsx` for Expo Router):
-
-```typescript
-// App.tsx or _layout.tsx
-import "./utils/polyfills"; // Import this FIRST, before any other imports
-
-import { CrossmintProvider } from "@crossmint/client-sdk-react-native-ui";
-// ... other imports
-```
-
-**Important**: The polyfill must be imported before any Crossmint SDK components or functionality is used.
 
 ### 1. Setup Providers
 
@@ -228,4 +201,4 @@ EXPO_PUBLIC_CROSSMINT_API_KEY=your_api_key_here
 
 ---
 
-**Questions?** Visit our [documentation](https://docs.crossmint.com/introduction/about-crossmint) or contact our support team.  
+**Questions?** Visit our [documentation](https://docs.crossmint.com/introduction/about-crossmint) or contact our support team. 

--- a/packages/client/ui/react-native/README.md
+++ b/packages/client/ui/react-native/README.md
@@ -5,9 +5,36 @@
 
 ## 🚀 Quick Start
 
+### Required Polyfill Setup
+
+This package requires the `react-native-get-random-values` polyfill to be installed and imported before using any Crossmint SDK functionality. This is necessary because the SDK uses Web Crypto API features that are not available in React Native by default.
+
+#### Installation
+
 ```bash
-pnpm add @crossmint/client-sdk-react-native-ui expo-secure-store expo-web-browser
+pnpm add @crossmint/client-sdk-react-native-ui expo-secure-store expo-web-browser react-native-get-random-values
 ```
+
+#### Import the polyfill
+
+Create a polyfills file (e.g., `utils/polyfills.ts`) and import it at the very beginning of your app:
+
+```typescript
+// utils/polyfills.ts
+import "react-native-get-random-values";
+```
+
+Then import this polyfill file in your app's entry point (e.g., `App.tsx` or `_layout.tsx` for Expo Router):
+
+```typescript
+// App.tsx or _layout.tsx
+import "./utils/polyfills"; // Import this FIRST, before any other imports
+
+import { CrossmintProvider } from "@crossmint/client-sdk-react-native-ui";
+// ... other imports
+```
+
+**Important**: The polyfill must be imported before any Crossmint SDK components or functionality is used.
 
 ### 1. Setup Providers
 
@@ -201,4 +228,4 @@ EXPO_PUBLIC_CROSSMINT_API_KEY=your_api_key_here
 
 ---
 
-**Questions?** Visit our [documentation](https://docs.crossmint.com/introduction/about-crossmint) or contact our support team. 
+**Questions?** Visit our [documentation](https://docs.crossmint.com/introduction/about-crossmint) or contact our support team.  

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -670,6 +670,9 @@ importers:
       '@crossmint/client-sdk-window':
         specifier: workspace:*
         version: link:../window
+      react-native-get-random-values:
+        specifier: ^1.11.0
+        version: 1.11.0(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@react-native-community/cli@13.6.4(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@types/react@18.3.20)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))
       react-native-webview:
         specifier: '>=13.0.0'
         version: 13.12.5(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@react-native-community/cli@13.6.4(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@types/react@18.3.20)(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)


### PR DESCRIPTION
# fix: React Native crypto polyfill for rn-window package

## Summary

This PR fixes React Native compatibility issues introduced by PR #1276, which added `crypto.getRandomValues` usage that breaks React Native apps without proper polyfill setup. The fix adds the required `react-native-get-random-values` polyfill directly to the `@crossmint/client-sdk-rn-window` package.

**Root Cause**: 
- PR #1276 introduced `crypto.getRandomValues` in `generateRandomString.ts`
- `@crossmint/client-sdk-rn-window` imports this function, causing React Native apps to crash
- React Native doesn't have Web Crypto API support by default

**Solution**: 
- Added `react-native-get-random-values` dependency to rn-window package
- Created polyfill import that runs before any crypto usage
- Configured bundler sideEffects to prevent tree-shaking
- Removed documentation changes per reviewer feedback

## Review & Testing Checklist for Human

- [ ] **Test actual crypto functionality** - Create a fresh React Native app, install the SDK, and verify crypto operations work without errors (not just app startup)
- [ ] **Verify polyfill import order** - Ensure the polyfill import in `RNWebViewTransport.ts` stays at the top even after code formatting/refactoring
- [ ] **Check for other affected packages** - Review if other React Native packages in the SDK need similar polyfill fixes
- [ ] **Test in production builds** - Verify the sideEffects configuration works correctly with Metro bundler and prevents tree-shaking in release builds
- [ ] **Cross-environment compatibility** - Test beyond Expo (plain React Native CLI, different RN versions) to ensure broad compatibility

**Recommended Test Plan**: Create a minimal React Native app that uses the SDK and attempts to generate random strings to confirm the polyfill resolves the crypto errors completely across different build configurations.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    A["packages/client/window/src/utils/<br/>generateRandomString.ts"]:::context
    B["packages/client/rn-window/<br/>package.json"]:::major-edit  
    C["packages/client/rn-window/src/<br/>polyfills.ts"]:::major-edit
    D["packages/client/rn-window/src/transport/<br/>RNWebViewTransport.ts"]:::major-edit
    E["apps/wallets/smart-wallet/expo/<br/>utils/polyfills.ts"]:::context

    A -->|"imports generateRandomString<br/>(uses crypto.getRandomValues)"| D
    B -->|"adds react-native-get-random-values<br/>dependency + sideEffects config"| C
    C -->|"polyfill import"| D
    D -->|"imports polyfills first"| A
    E -->|"existing polyfill pattern<br/>(reference implementation)"| C

    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- The expo app already had the correct polyfill setup, confirming this solution works
- The `sideEffects` configuration is critical - prevents bundlers from ignoring the polyfill import
- This follows the same pattern recommended by the React Native community for crypto polyfills
- README documentation was removed per reviewer feedback to keep this as a pure code fix
- **Risk**: Import order dependency - the polyfill must be imported before any crypto usage

**Link to Devin run**: https://app.devin.ai/sessions/753544c6ba6a4337bdd0c65ca7b92b72  
**Requested by**: @maxisch