### PR TITLE
Fix: NCS otp ui styles

### DIFF
--- a/.changeset/curly-moles-joke.md
+++ b/.changeset/curly-moles-joke.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+---
+
+Fixed style with non custodial signer ui

--- a/.changeset/smart-planets-look.md
+++ b/.changeset/smart-planets-look.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-native-ui": patch
+---
+
+removed unused file

--- a/apps/wallets/quickstart-devkit/app/providers.tsx
+++ b/apps/wallets/quickstart-devkit/app/providers.tsx
@@ -28,14 +28,14 @@ function EVMCrossmintAuthProvider({ children }: { children: React.ReactNode }) {
         <CrossmintProvider apiKey={process.env.NEXT_PUBLIC_CROSSMINT_API_KEY || ""}>
             <CrossmintAuthProvider
                 authModalTitle="EVM Wallets Quickstart"
-                // loginMethods={["google", "twitter", "email"]}
+                loginMethods={["google", "twitter", "email"]}
             >
-                {/* <CrossmintWalletProvider
+                <CrossmintWalletProvider
                     showPasskeyHelpers={false}
                     createOnLogin={{ chain: process.env.NEXT_PUBLIC_EVM_CHAIN as any, signer: { type: "passkey" } }}
-                > */}
-                {children}
-                {/* </CrossmintWalletProvider> */}
+                >
+                    {children}
+                </CrossmintWalletProvider>
             </CrossmintAuthProvider>
         </CrossmintProvider>
     );

--- a/packages/client/ui/react-native/src/testUtils.ts
+++ b/packages/client/ui/react-native/src/testUtils.ts
@@ -1,2 +1,0 @@
-export const MOCK_API_KEY = "sk_development_12341234";
-export const MOCK_APP_ID = "com.app.id";

--- a/packages/client/ui/react-ui/src/components/signers/EmailOTPInput.tsx
+++ b/packages/client/ui/react-ui/src/components/signers/EmailOTPInput.tsx
@@ -82,7 +82,7 @@ export function EmailOTPInput({ email, onSubmitOTP, onResendCode, appearance }: 
                                 key={index}
                                 index={index}
                                 hasError={hasError}
-                                className={tw("max-sm:w-7 max-sm:h-11 max-sm:text-xl max-sm:mx-0 h-12 w-9")}
+                                className={tw("max-sm:w-7 max-sm:h-11 max-sm:text-xl max-sm:mx-0 sm:h-12 sm:w-9")}
                             />
                         ))}
                     </InputOTPGroup>

--- a/packages/client/ui/react-ui/src/hooks/useOAuthWindowListener.ts
+++ b/packages/client/ui/react-ui/src/hooks/useOAuthWindowListener.ts
@@ -33,10 +33,6 @@ export const useOAuthWindowListener = (oauthUrlMap: OAuthUrlMap, setError: (erro
             setIsLoading(true);
             setError(null);
 
-            console.log("oauthUrlMap:", oauthUrlMap);
-            console.log("provider:", provider);
-            console.log("oauthUrlMap[provider]:", oauthUrlMap[provider]);
-            console.log("providerLoginHint:", providerLoginHint);
             const baseUrl = new URL(oauthUrlMap[provider]);
 
             // The provider_login_hint is a parameter that can be used to pre-fill the email field of the OAuth provider to allow auto-login if session exists.

--- a/packages/client/ui/react-ui/src/testUtils.ts
+++ b/packages/client/ui/react-ui/src/testUtils.ts
@@ -1,1 +1,0 @@
-export const MOCK_API_KEY = "sk_development_12341234";


### PR DESCRIPTION
## Description

Our otp styles broke after updating our twind configuration. 

### Before
<img width="642" height="554" alt="Screenshot 2025-07-21 at 1 00 15 PM" src="https://github.com/user-attachments/assets/8411ee66-fd3f-4da3-9a08-9c45859ac2ff" />

### After
<img width="604" height="578" alt="Screenshot 2025-07-21 at 12 53 11 PM" src="https://github.com/user-attachments/assets/2b71b278-0aa2-4e43-8ee9-2d3579c12263" />


## Test plan

tested styles

## Package updates

@crossmint/client-sdk-react-ui