### PR TITLE
Wallets SDK: add prepareOnly signatures and fix approve return type

### DIFF
--- a/.changeset/hot-ligers-mate.md
+++ b/.changeset/hot-ligers-mate.md
@@ -1,0 +1,6 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+- Support correct return type based on input for `approve` method.
+- Add a `experimental_prepareOnly` option for `signTypedData` and `signMessage`.

--- a/.changeset/six-books-vanish.md
+++ b/.changeset/six-books-vanish.md
@@ -1,0 +1,6 @@
+---
+"@crossmint/client-sdk-react-native-ui": patch
+"@crossmint/client-sdk-react-ui": patch
+---
+
+Exported Signature type

--- a/apps/wallets/quickstart-devkit/components/approval-test.tsx
+++ b/apps/wallets/quickstart-devkit/components/approval-test.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useWallet } from "@crossmint/client-sdk-react-ui";
+import { type Signature, type Transaction, useWallet } from "@crossmint/client-sdk-react-ui";
 import { PublicKey } from "@solana/web3.js";
 import { isAddress } from "viem";
 
@@ -24,7 +24,7 @@ export function ApprovalTest() {
     const [isCreatingTransaction, setIsCreatingTransaction] = useState(false);
     const [isApprovingTransaction, setIsApprovingTransaction] = useState(false);
     const [isApprovingSignature, setIsApprovingSignature] = useState(false);
-    const [approvalResult, setApprovalResult] = useState<any>(null);
+    const [approvalResult, setApprovalResult] = useState<Transaction<false> | Signature<false> | null>(null);
     const [error, setError] = useState<string | null>(null);
 
     const isEVMWallet = wallet?.chain !== "solana";
@@ -56,6 +56,43 @@ export function ApprovalTest() {
             setError("Invalid recipient address");
             return;
         }
+
+        // const evmWallet = EVMWallet.from(wallet);
+        // const txn = await evmWallet.sendTransaction({
+        //     transaction: "0x",
+        //     options: { experimental_prepareOnly: true },
+        // });
+
+        // const sigSigned = await evmWallet.signTypedData({
+        //     chain: "apechain",
+        //     types: {
+        //         EIP712Domain: [
+        //             { name: "name", type: "string" },
+        //             { name: "version", type: "string" },
+        //             { name: "chainId", type: "uint256" },
+        //             { name: "verifyingContract", type: "address" },
+        //         ],
+        //     },
+        //     domain: {
+        //         name: "Test",
+        //         version: "1",
+        //         chainId: BigInt(1),
+        //         verifyingContract: "0x0000000000000000000000000000000000000000",
+        //     },
+        //     primaryType: "EIP712Domain",
+        //     message: {
+        //         name: "Test",
+        //         version: "1",
+        //         chainId: BigInt(1),
+        //         verifyingContract: "0x0000000000000000000000000000000000000000",
+        //     },
+        //     options: { experimental_prepareOnly: false },
+        // });
+
+        // const sigMessage = await evmWallet.signMessage({
+        //     message: "Hello, world!",
+        //     options: { experimental_prepareOnly: true },
+        // });
 
         try {
             setIsCreatingTransaction(true);
@@ -91,11 +128,7 @@ export function ApprovalTest() {
             setError(null);
 
             const result = await wallet.approve({ transactionId });
-            setApprovalResult({
-                type: "transaction",
-                id: transactionId,
-                result,
-            });
+            setApprovalResult(result);
         } catch (err: any) {
             console.error("Failed to approve transaction:", err);
             setError(`Failed to approve transaction: ${err.message || err}`);
@@ -116,11 +149,8 @@ export function ApprovalTest() {
             setError(null);
 
             const result = await wallet.approve({ signatureId: manualSignatureId });
-            setApprovalResult({
-                type: "signature",
-                id: manualSignatureId,
-                result,
-            });
+
+            setApprovalResult(result);
         } catch (err: any) {
             console.error("Failed to approve signature:", err);
             setError(`Failed to approve signature: ${err.message || err}`);
@@ -294,20 +324,23 @@ export function ApprovalTest() {
             </div>
 
             {/* Results Display */}
-            {approvalResult && (
+            {approvalResult != null && (
                 <div className="border rounded-lg p-4 bg-gray-50">
                     <h3 className="font-medium mb-3">Approval Result</h3>
                     <div className="space-y-2">
                         <p className="text-sm">
-                            <strong>Type:</strong> {approvalResult.type}
+                            <strong>Type:</strong> {"transactionId" in approvalResult ? "Transaction" : "Signature"}
                         </p>
                         <p className="text-sm">
-                            <strong>ID:</strong> {approvalResult.id}
+                            <strong>ID:</strong>{" "}
+                            {"transactionId" in approvalResult
+                                ? approvalResult.transactionId
+                                : approvalResult.signatureId}
                         </p>
                         <div className="text-sm">
                             <strong>Result:</strong>
                             <pre className="mt-1 p-2 bg-gray-100 rounded text-xs overflow-auto">
-                                {JSON.stringify(approvalResult.result, null, 2)}
+                                {JSON.stringify(approvalResult, null, 2)}
                             </pre>
                         </div>
                     </div>

--- a/packages/client/ui/react-native/src/index.ts
+++ b/packages/client/ui/react-native/src/index.ts
@@ -12,6 +12,7 @@ export {
     type Chain,
     type DelegatedSigner,
     type Transaction,
+    type Signature,
     EVMWallet,
     SolanaWallet,
     Wallet,

--- a/packages/client/ui/react-ui/src/types/wallet.ts
+++ b/packages/client/ui/react-ui/src/types/wallet.ts
@@ -5,6 +5,7 @@ export {
     type Chain,
     type DelegatedSigner,
     type Transaction,
+    type Signature,
     EVMWallet,
     SolanaWallet,
     StellarWallet,

--- a/packages/wallets/src/index.ts
+++ b/packages/wallets/src/index.ts
@@ -18,6 +18,7 @@ export type {
     EVMTransactionInput,
     Transaction,
     WalletArgsFor,
+    Signature,
     SolanaTransactionInput,
 } from "./wallets/types";
 export type { Chain, EVMChain, SolanaChain, StellarChain } from "./chains/chains";

--- a/packages/wallets/src/wallets/evm.ts
+++ b/packages/wallets/src/wallets/evm.ts
@@ -3,6 +3,7 @@ import { isValidEvmAddress } from "@crossmint/common-sdk-base";
 import type {
     EVMTransactionInput,
     FormattedEVMTransaction,
+    PrepareOnly,
     Signature,
     SignMessageInput,
     SignTypedDataInput,
@@ -39,7 +40,7 @@ export class EVMWallet extends Wallet<EVMChain> {
 
     public async sendTransaction<T extends EVMTransactionInput>(
         params: T
-    ): Promise<Transaction<T["options"] extends { experimental_prepareOnly: true } ? true : false>> {
+    ): Promise<Transaction<T["options"] extends PrepareOnly<true> ? true : false>> {
         const builtTransaction = this.buildTransaction(params);
         const createdTransaction = await this.createTransaction(builtTransaction, params.options);
 
@@ -48,7 +49,7 @@ export class EVMWallet extends Wallet<EVMChain> {
                 hash: undefined,
                 explorerLink: undefined,
                 transactionId: createdTransaction.id,
-            } as Transaction<T["options"] extends { experimental_prepareOnly: true } ? true : false>;
+            } as Transaction<T["options"] extends PrepareOnly<true> ? true : false>;
         }
 
         return await this.approveTransactionAndWait(createdTransaction.id);
@@ -56,7 +57,7 @@ export class EVMWallet extends Wallet<EVMChain> {
 
     public async signMessage<T extends SignMessageInput>(
         params: T
-    ): Promise<Signature<T["options"] extends { experimental_prepareOnly: true } ? true : false>> {
+    ): Promise<Signature<T["options"] extends PrepareOnly<true> ? true : false>> {
         const signatureCreationResponse = await this.apiClient.createSignature(this.walletLocator, {
             type: "message",
             params: {
@@ -73,7 +74,7 @@ export class EVMWallet extends Wallet<EVMChain> {
             return {
                 signature: undefined,
                 signatureId: signatureCreationResponse.id,
-            } as Signature<T["options"] extends { experimental_prepareOnly: true } ? true : false>;
+            } as Signature<T["options"] extends PrepareOnly<true> ? true : false>;
         }
 
         return await this.approveSignatureAndWait(signatureCreationResponse.id);
@@ -81,7 +82,7 @@ export class EVMWallet extends Wallet<EVMChain> {
 
     public async signTypedData<T extends SignTypedDataInput>(
         params: T
-    ): Promise<Signature<T["options"] extends { experimental_prepareOnly: true } ? true : false>> {
+    ): Promise<Signature<T["options"] extends PrepareOnly<true> ? true : false>> {
         const { domain, message, primaryType, types, chain } = params;
         if (!domain || !message || !types || !chain) {
             throw new InvalidTypedDataError("Invalid typed data");
@@ -120,7 +121,7 @@ export class EVMWallet extends Wallet<EVMChain> {
             return {
                 signature: undefined,
                 signatureId: signatureCreationResponse.id,
-            } as Signature<T["options"] extends { experimental_prepareOnly: true } ? true : false>;
+            } as Signature<T["options"] extends PrepareOnly<true> ? true : false>;
         }
 
         return await this.approveSignatureAndWait(signatureCreationResponse.id);

--- a/packages/wallets/src/wallets/solana.ts
+++ b/packages/wallets/src/wallets/solana.ts
@@ -1,7 +1,13 @@
 import bs58 from "bs58";
 import { isValidSolanaAddress } from "@crossmint/common-sdk-base";
 import type { Chain, SolanaChain } from "../chains/chains";
-import type { ApproveOptions, SolanaTransactionInput, Transaction, TransactionInputOptions } from "./types";
+import type {
+    ApproveOptions,
+    PrepareOnly,
+    SolanaTransactionInput,
+    Transaction,
+    TransactionInputOptions,
+} from "./types";
 import { Wallet } from "./wallet";
 import { TransactionNotCreatedError } from "../utils/errors";
 import { SolanaExternalWalletSigner } from "@/signers/solana-external-wallet";
@@ -31,7 +37,7 @@ export class SolanaWallet extends Wallet<SolanaChain> {
 
     public async sendTransaction<T extends TransactionInputOptions | undefined = undefined>(
         params: SolanaTransactionInput & { options?: T }
-    ): Promise<Transaction<T extends { experimental_prepareOnly: true } ? true : false>> {
+    ): Promise<Transaction<T extends PrepareOnly<true> ? true : false>> {
         const createdTransaction = await this.createTransaction(params);
 
         if (params.options?.experimental_prepareOnly) {
@@ -39,7 +45,7 @@ export class SolanaWallet extends Wallet<SolanaChain> {
                 hash: undefined,
                 explorerLink: undefined,
                 transactionId: createdTransaction.id,
-            } as Transaction<T extends { experimental_prepareOnly: true } ? true : false>;
+            } as Transaction<T extends PrepareOnly<true> ? true : false>;
         }
 
         const _additionalSigners = params.additionalSigners?.map(

--- a/packages/wallets/src/wallets/stellar.ts
+++ b/packages/wallets/src/wallets/stellar.ts
@@ -1,6 +1,12 @@
 import { isValidStellarAddress } from "@crossmint/common-sdk-base";
 import type { Chain, StellarChain } from "../chains/chains";
-import type { ApproveOptions, StellarTransactionInput, Transaction, TransactionInputOptions } from "./types";
+import type {
+    ApproveOptions,
+    PrepareOnly,
+    StellarTransactionInput,
+    Transaction,
+    TransactionInputOptions,
+} from "./types";
 import { Wallet } from "./wallet";
 import { TransactionNotCreatedError } from "../utils/errors";
 import type { CreateTransactionSuccessResponse } from "@/api";
@@ -29,7 +35,7 @@ export class StellarWallet extends Wallet<StellarChain> {
 
     public async sendTransaction<T extends TransactionInputOptions | undefined = undefined>(
         params: StellarTransactionInput & { options?: T }
-    ): Promise<Transaction<T extends { experimental_prepareOnly: true } ? true : false>> {
+    ): Promise<Transaction<T extends PrepareOnly<true> ? true : false>> {
         const createdTransaction = await this.createTransaction(params);
 
         if (params.options?.experimental_prepareOnly) {
@@ -37,7 +43,7 @@ export class StellarWallet extends Wallet<StellarChain> {
                 hash: undefined,
                 explorerLink: undefined,
                 transactionId: createdTransaction.id,
-            } as Transaction<T extends { experimental_prepareOnly: true } ? true : false>;
+            } as Transaction<T extends PrepareOnly<true> ? true : false>;
         }
 
         const options: ApproveOptions = {};

--- a/packages/wallets/src/wallets/types.ts
+++ b/packages/wallets/src/wallets/types.ts
@@ -9,14 +9,13 @@ import type { SignerConfigForChain, Signer, BaseSignResult, PasskeySignResult } 
 
 export type { Activity } from "../api/types";
 
-export type TransactionInputOptions = {
-    experimental_prepareOnly?: boolean;
+export type PrepareOnly<T extends boolean = boolean> = { experimental_prepareOnly: T };
+
+export type TransactionInputOptions = PrepareOnly & {
     experimental_signer?: string;
 };
 
-export type SignatureInputOptions = {
-    experimental_prepareOnly?: boolean;
-};
+export type SignatureInputOptions = PrepareOnly;
 
 export type SignMessageInput = {
     message: string;

--- a/packages/wallets/src/wallets/types.ts
+++ b/packages/wallets/src/wallets/types.ts
@@ -1,9 +1,10 @@
 import type { Keypair, VersionedTransaction } from "@solana/web3.js";
 import type { HandshakeParent } from "@crossmint/client-sdk-window";
 import type { signerInboundEvents, signerOutboundEvents } from "@crossmint/client-signers";
+import type { TypedData, TypedDataDefinition } from "viem";
 import type { Abi } from "abitype";
 import type { CreateTransactionSuccessResponse } from "../api";
-import type { Chain } from "../chains/chains";
+import type { Chain, EVMSmartWalletChain } from "../chains/chains";
 import type { SignerConfigForChain, Signer, BaseSignResult, PasskeySignResult } from "../signers/types";
 
 export type { Activity } from "../api/types";
@@ -12,6 +13,26 @@ export type TransactionInputOptions = {
     experimental_prepareOnly?: boolean;
     experimental_signer?: string;
 };
+
+export type SignatureInputOptions = {
+    experimental_prepareOnly?: boolean;
+};
+
+export type SignMessageInput = {
+    message: string;
+    options?: SignatureInputOptions;
+};
+
+export type SignTypedDataInput = TypedDataDefinition<TypedData, string> & {
+    chain: EVMSmartWalletChain;
+    options?: SignatureInputOptions;
+};
+
+export type ApproveResult<T extends ApproveParams> = T extends { transactionId: string }
+    ? Transaction<false>
+    : T extends { signatureId: string }
+      ? Signature<false>
+      : Error;
 
 type EVMTransactionInputBase = {
     options?: TransactionInputOptions;
@@ -110,6 +131,16 @@ export type Transaction<TPrepareOnly extends boolean = false> = TPrepareOnly ext
           hash: string;
           explorerLink: string;
           transactionId: string;
+      };
+
+export type Signature<TPrepareOnly extends boolean = false> = TPrepareOnly extends true
+    ? {
+          signature?: string;
+          signatureId: string;
+      }
+    : {
+          signature: string;
+          signatureId: string;
       };
 
 export type ApproveOptions = {

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -22,6 +22,7 @@ import type {
     Approval,
     Signature,
     ApproveResult,
+    PrepareOnly,
 } from "./types";
 import {
     InvalidSignerError,
@@ -250,7 +251,7 @@ export class Wallet<C extends Chain> {
         token: string,
         amount: string,
         options?: T
-    ): Promise<Transaction<T extends { experimental_prepareOnly: true } ? true : false>> {
+    ): Promise<Transaction<T extends PrepareOnly<true> ? true : false>> {
         const recipient = toRecipientLocator(to);
         const tokenLocator = toTokenLocator(token, this.chain);
         const sendParams = { recipient, amount };
@@ -267,7 +268,7 @@ export class Wallet<C extends Chain> {
                 hash: undefined,
                 explorerLink: undefined,
                 transactionId: transactionCreationResponse.id,
-            } as Transaction<T extends { experimental_prepareOnly: true } ? true : false>;
+            } as Transaction<T extends PrepareOnly<true> ? true : false>;
         }
 
         return await this.approveTransactionAndWait(transactionCreationResponse.id);


### PR DESCRIPTION
## Description

- Support correct return type based on input for `approve` method. (closes https://linear.app/crossmint/issue/WAL-5757/approve-to-return-a-different-object-based-on-input)
- Add a `experimental_prepareOnly` option for our existing signature methods (`signTypedData` and `signMessage`). (closes https://linear.app/crossmint/issue/WAL-5526/add-prepareonly-to-signatures)

## Test plan

- tested adding `experimental_prepareOnly` to both signature methods, and expected type is retuned.
- tested approving a signatureId with `approve` and a signature was returned.
- tested approving a transactionId with `approve` and a transaction was returned.

## Package updates

@crossmint/client-sdk-react-ui
@crossmint/client-sdk-react-native-ui
@crossmint/wallets-sdk