### PR TITLE
wallets: remove console.log from transaction creation

### DIFF
--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -271,7 +271,6 @@ export class Wallet<C extends Chain> {
                 transactionId: transactionCreationResponse.id,
             } as Transaction<T extends PrepareOnly<true> ? true : false>;
         }
-        console.log("transactionCreationResponse", transactionCreationResponse);
 
         return await this.approveTransactionAndWait(transactionCreationResponse.id);
     }


### PR DESCRIPTION
## Description

Remove a problematic `console.log` statement from the wallets SDK that was exposing internal transaction response details and confusing developers about the SDK's approval workflow.

This addresses [WAL-6100](https://linear.app/crossmint/issue/WAL-6100) and resolves confusion reported in Slack where a developer was confused by seeing `transactionCreationResponse {"approvals": {"pending": [[Object]], "required": 1, "submitted": []}}` logged to the console, leading them to think they needed to handle server-side approvals manually.

**Changes made:**
- Removed `console.log("transactionCreationResponse", transactionCreationResponse)` from `packages/wallets/src/wallets/wallet.ts` line 274
- Preserved legitimate console logging (e.g., deprecation warnings, README examples, build scripts)

## Test plan

* ✅ Build verification: `pnpm build:libs` passes successfully  
* ✅ Code search: Confirmed this was the only problematic console.log in wallets source code
* ✅ Linting: `pnpm lint:fix` completed (existing unrelated warnings in other packages)
* ⚠️ **Manual testing recommended**: End-to-end transaction flow testing to ensure no internal tooling depends on this log output

## Package updates

No package updates required - this is a code cleanup change that doesn't affect public APIs.

---

**Human review checklist:**
- [ ] Confirm this matches the console.log from line 274 mentioned in WAL-6100
- [ ] Verify `console.warn` deprecation message at lines 291-293 was preserved
- [ ] Check that no other problematic console.logs exist in `/packages/wallets/src/`
- [ ] Ensure no internal debugging workflows depend on this specific log output

---

*Requested by: @alfonso-paella*  
*Link to Devin run: https://app.devin.ai/sessions/27ba1d2bc130448586d30d650c78f9dc*