### PR TITLE
Stellar: fix encode type on sign transaction

### DIFF
--- a/packages/wallets/src/signers/non-custodial/ncs-stellar-signer.ts
+++ b/packages/wallets/src/signers/non-custodial/ncs-stellar-signer.ts
@@ -51,9 +51,9 @@ export class StellarNonCustodialSigner extends NonCustodialSigner {
             throw new Error("No public key found");
         }
 
-        if (publicKey.encoding !== "base58" || publicKey.keyType !== "ed25519" || publicKey.bytes == null) {
+        if (publicKey.encoding !== "base64" || publicKey.keyType !== "ed25519" || publicKey.bytes == null) {
             throw new Error(
-                "Not supported. Expected public key to be in base58 encoding and ed25519 key type. Got: " +
+                "Not supported. Expected public key to be in base64 encoding and ed25519 key type. Got: " +
                     JSON.stringify(publicKey)
             );
         }


### PR DESCRIPTION
## Description

We moved to a base64 encoding bur didn't update the verification of the public key format

<!-- Human must describe here why are we doing this change, and roughly what it does -->
<!-- Optional screenshot or video -->

## Test plan

Tested locally

<!--
  Example:
   * Unit tests which cover functionality X, Y, Z
   * V was tested via UI tests
   * W was tested manually
-->

## Package updates

<!-- 
  List any package updates and ensure you've added the necessary changesets, running `pnpm change:add` to do so.
-->