### PR TITLE
fix: import JSONObject from correct package

### DIFF
--- a/packages/client/base/src/types/embed/v3/CrossmintEmbeddedCheckoutV3Props.ts
+++ b/packages/client/base/src/types/embed/v3/CrossmintEmbeddedCheckoutV3Props.ts
@@ -1,7 +1,9 @@
 import type { Currency as FiatCurrency, Locale } from "@/types";
 import type { CryptoCurrency } from "@/types/CryptoCurrency";
 
-import type { BlockchainIncludingTestnet, PayerSupportedBlockchains, JSONObject } from "@crossmint/common-sdk-base";
+import type { BlockchainIncludingTestnet, PayerSupportedBlockchains } from "@crossmint/common-sdk-base";
+
+type JSONObject = Record<string, any>;
 
 interface CrossmintEmbeddedCheckoutV3CommonProps {
     appearance?: EmbeddedCheckoutV3Appearance;
@@ -85,6 +87,7 @@ export type EmbeddedCheckoutV3AppearanceVariables = {
         backgroundPrimary?: string;
         textPrimary?: string;
         textSecondary?: string;
+        connectWalletButtonText?: string;
         danger?: string;
         warning?: string;
         accent?: string;


### PR DESCRIPTION
## Description

This PR fixes a TypeScript compilation error in the embedded checkout theming system that was preventing the crossbit-main build from succeeding.

The issue was that `CrossmintEmbeddedCheckoutV3Props.ts` was trying to import `JSONObject` from `@crossmint/common-sdk-base`, but this export doesn't exist in that package. The fix:

1. **Removes the incorrect import** of `JSONObject` from `@crossmint/common-sdk-base`
2. **Adds a local type definition**: `type JSONObject = Record<string, any>;`
3. **Adds new theming property**: `connectWalletButtonText?: string;` to support decoupling Connect Wallet button text color from `textPrimary`

This change is part of a larger effort to fix theming issues in embedded checkout where the "Connect Wallet" button text and descriptive text both used `textPrimary`, making them unreadable with darker themes.

## Test plan

* ✅ `pnpm build` passes in the `packages/client/base` directory
* ✅ TypeScript compilation errors resolved
* Manual verification that the new `connectWalletButtonText` property is properly typed and optional

## Package updates

No package dependencies were modified in this change.

---

**Link to Devin run**: https://app.devin.ai/sessions/25fc3e097a5a46299c58f2a2073e605c  
**Requested by**: @VeniaminC

## Review checklist

- [ ] Verify that `Record<string, any>` is an appropriate replacement for the original `JSONObject` type
- [ ] Confirm this change coordinates properly with the crossbit-main repository changes that consume the new `connectWalletButtonText` property
- [ ] Check for any other usages of `JSONObject` in the codebase that might be affected by this change