### PR TITLE
feat: exposes signer address in wallet.signer

### DIFF
--- a/.changeset/unlucky-garlics-complain.md
+++ b/.changeset/unlucky-garlics-complain.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": minor
+---
+
+Exposes the address for different signers that support it

--- a/packages/wallets/src/signers/evm-external-wallet.ts
+++ b/packages/wallets/src/signers/evm-external-wallet.ts
@@ -4,7 +4,7 @@ import type { EVMChain } from "@/chains/chains";
 
 export class EVMExternalWalletSigner implements Signer {
     type = "external-wallet" as const;
-    address: string;
+    private _address: string;
     provider?: GenericEIP1193Provider | ViemEIP1193Provider;
     viemAccount?: Account;
 
@@ -12,9 +12,13 @@ export class EVMExternalWalletSigner implements Signer {
         if (config.address == null) {
             throw new Error("Please provide an address for the External Wallet Signer");
         }
-        this.address = config.address;
+        this._address = config.address;
         this.provider = config.provider;
         this.viemAccount = config.viemAccount;
+    }
+
+    address() {
+        return this._address;
     }
 
     locator() {
@@ -25,7 +29,7 @@ export class EVMExternalWalletSigner implements Signer {
         if (this.provider != null) {
             const signature = await this.provider.request({
                 method: "personal_sign",
-                params: [message, this.address] as any,
+                params: [message, this._address] as any,
             });
             if (signature == null) {
                 throw new Error(

--- a/packages/wallets/src/signers/non-custodial/ncs-signer.ts
+++ b/packages/wallets/src/signers/non-custodial/ncs-signer.ts
@@ -21,6 +21,10 @@ export abstract class NonCustodialSigner implements Signer {
         return this.config.locator;
     }
 
+    address() {
+        return this.config.address;
+    }
+
     abstract signMessage(message: string): Promise<BaseSignResult>;
 
     private async initialize() {
@@ -81,7 +85,10 @@ export abstract class NonCustodialSigner implements Signer {
                     this._needsAuth,
                     () => this.sendMessageWithOtp(),
                     (otp) => this.verifyOtp(otp),
-                    () => reject(new AuthRejectedError())
+                    () => {
+                        reject(new AuthRejectedError());
+                        this._needsAuth = false;
+                    }
                 );
             } catch (error) {
                 reject(error as Error);

--- a/packages/wallets/src/signers/solana-external-wallet.ts
+++ b/packages/wallets/src/signers/solana-external-wallet.ts
@@ -6,15 +6,19 @@ import type { SolanaChain } from "@/chains/chains";
 
 export class SolanaExternalWalletSigner implements Signer {
     type = "external-wallet" as const;
-    address: string;
+    private _address: string;
     onSignTransaction?: (transaction: VersionedTransaction) => Promise<VersionedTransaction>;
 
     constructor(private config: ExternalWalletInternalSignerConfig<SolanaChain>) {
         if (config.address == null) {
             throw new Error("Please provide an address for the External Wallet Signer");
         }
-        this.address = config.address;
+        this._address = config.address;
         this.onSignTransaction = config.onSignTransaction;
+    }
+
+    address() {
+        return this._address;
     }
 
     locator() {
@@ -36,7 +40,7 @@ export class SolanaExternalWalletSigner implements Signer {
         // Sign the transaction (we can't use signMessage on transactions, so we need to sign the transaction directly)
         const signedTxn = await this.onSignTransaction(deserializedTransaction);
         // Get the signature from the signed transaction
-        const externalWalletPublicKey = new PublicKey(this.address);
+        const externalWalletPublicKey = new PublicKey(this._address);
         const signerIndex = signedTxn.message.staticAccountKeys.findIndex((key) => key.equals(externalWalletPublicKey));
         if (signerIndex === -1) {
             throw new TransactionFailedError("Wallet public key not found in transaction signers");

--- a/packages/wallets/src/signers/stellar-external-wallet.ts
+++ b/packages/wallets/src/signers/stellar-external-wallet.ts
@@ -3,15 +3,19 @@ import type { StellarChain } from "@/chains/chains";
 
 export class StellarExternalWalletSigner implements Signer {
     type = "external-wallet" as const;
-    address: string;
+    private _address: string;
     onSignStellarTransaction?: (payload: string) => Promise<string>;
 
     constructor(private config: ExternalWalletInternalSignerConfig<StellarChain>) {
         if (config.address == null) {
             throw new Error("Please provide an address for the External Wallet Signer");
         }
-        this.address = config.address;
+        this._address = config.address;
         this.onSignStellarTransaction = config.onSignStellarTransaction;
+    }
+
+    address() {
+        return this._address;
     }
 
     locator() {

--- a/packages/wallets/src/signers/types.ts
+++ b/packages/wallets/src/signers/types.ts
@@ -72,6 +72,7 @@ export type PasskeySignerConfig = {
 ////////////////////////////////////////////////////////////
 type BaseInternalSignerConfig = {
     locator: string;
+    address: string;
     crossmint: Crossmint;
     clientTEEConnection?: HandshakeParent<typeof signerOutboundEvents, typeof signerInboundEvents>;
 };
@@ -136,6 +137,7 @@ type SignResultMap = {
 export interface Signer<T extends keyof SignResultMap = keyof SignResultMap> {
     type: T;
     locator(): string;
+    address?(): string;
     signMessage(message: string): Promise<SignResultMap[T]>;
     signTransaction(transaction: string): Promise<SignResultMap[T]>;
 }

--- a/packages/wallets/src/wallets/wallet-factory.ts
+++ b/packages/wallets/src/wallets/wallet-factory.ts
@@ -149,11 +149,12 @@ export class WalletFactory {
                     throw new WalletCreationError("Email signer does not match the wallet's signer type");
                 }
 
-                const { locator, email } = walletResponse.config.adminSigner;
+                const { locator, email, address } = walletResponse.config.adminSigner;
                 return {
                     type: "email",
                     email,
                     locator,
+                    address,
                     crossmint: this.apiClient.crossmint,
                     onAuthRequired: signerArgs.onAuthRequired,
                     clientTEEConnection: options?.clientTEEConnection,
@@ -165,11 +166,12 @@ export class WalletFactory {
                     throw new WalletCreationError("Phone signer does not match the wallet's signer type");
                 }
 
-                const { locator, phone } = walletResponse.config.adminSigner;
+                const { locator, phone, address } = walletResponse.config.adminSigner;
                 return {
                     type: "phone",
                     phone,
                     locator,
+                    address,
                     crossmint: this.apiClient.crossmint,
                     onAuthRequired: signerArgs.onAuthRequired,
                     clientTEEConnection: options?.clientTEEConnection,


### PR DESCRIPTION
## Description

Exposes `.address()` for external wallet and ncs as we now expose it for ncs in the api

## Test plan

Tested with quickstart app

## Package updates

wallets: minor