### PR TITLE
feat: adds the export signer event that will be used in the export page

### DIFF
--- a/.changeset/tame-kiwis-kneel.md
+++ b/.changeset/tame-kiwis-kneel.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-signers": patch
+---
+
+Adds export-signer event for export frame

--- a/packages/client/signers/src/communications/events.ts
+++ b/packages/client/signers/src/communications/events.ts
@@ -6,7 +6,7 @@ import {
     SignPayloadSchema,
     StartOnboardingPayloadSchema,
     CompleteOnboardingPayloadSchema,
-    ExportKeysPayloadSchema,
+    ExportSignerPayloadSchema,
 } from "./schemas";
 
 export const SIGNER_EVENTS = [
@@ -15,7 +15,7 @@ export const SIGNER_EVENTS = [
     "sign",
     "get-status",
     "get-attestation",
-    "export-keys",
+    "export-signer",
 ] as const;
 export type SignerIFrameEventName = (typeof SIGNER_EVENTS)[number];
 
@@ -25,7 +25,7 @@ export const signerInboundEvents = {
     "request:complete-onboarding": CompleteOnboardingPayloadSchema.request,
     "request:sign": SignPayloadSchema.request,
     "request:get-status": GetStatusPayloadSchema.request,
-    "request:export-keys": ExportKeysPayloadSchema.request,
+    "request:export-signer": ExportSignerPayloadSchema.request,
 } as const;
 
 export const signerOutboundEvents = {
@@ -34,7 +34,7 @@ export const signerOutboundEvents = {
     "response:complete-onboarding": CompleteOnboardingPayloadSchema.response,
     "response:sign": SignPayloadSchema.response,
     "response:get-status": GetStatusPayloadSchema.response,
-    "response:export-keys": ExportKeysPayloadSchema.response,
+    "response:export-signer": ExportSignerPayloadSchema.response,
 } as const;
 
 export type SignerInputEvent<E extends SignerIFrameEventName> = z.infer<(typeof signerInboundEvents)[`request:${E}`]>;

--- a/packages/client/signers/src/communications/schemas.ts
+++ b/packages/client/signers/src/communications/schemas.ts
@@ -124,17 +124,23 @@ export const SignPayloadSchema = {
     ),
 };
 
-export const ExportKeysPayloadSchema = {
+export const ExportSignerPayloadSchema = {
     request: AuthenticatedEventRequest.extend({
         data: z
             .object({
-                keyTypes: z.array(KeyTypeSchema).default(KEY_TYPES).describe("Types of cryptographic keys to export"),
+                scheme: z
+                    .union([z.literal("ed25519"), z.literal("secp256k1")])
+                    .describe("The cryptographic scheme to use"),
+                encoding: z
+                    .union([z.literal("base58"), z.literal("hex")])
+                    .describe("Encoding format for the private key"),
             })
-            .describe("Data needed to export keys"),
+            .describe("Data needed to export the signer"),
     }),
     response: ResultResponse(
         z.object({
-            publicKeys: PublicKeyMappingSchema.describe("The public keys of the signer for the active user"),
+            // No privateKey field - the private key is handled within the iframe
+            // and copied to clipboard when the button is clicked
         })
     ),
 };


### PR DESCRIPTION
## Description

We need to define the event that will be used by both SDKs and the Frame here. This is an export-signer event that requires the authData, scheme and encoding. Upon receiving it, the export frame will load the private key and enable the Copy button so the user can then copy it to their clipboard.

## Test plan

Will test once deployed from the frame app

## Package updates

client-signers: patch