### PR TITLE
Remove deprecation notice from setJwt function

### DIFF
--- a/packages/client/react-base/src/providers/CrossmintProvider.tsx
+++ b/packages/client/react-base/src/providers/CrossmintProvider.tsx
@@ -6,7 +6,6 @@ export interface CrossmintContext {
     crossmint: Crossmint;
     experimental_setCustomAuth: (customAuthParams?: CustomAuth) => void;
     experimental_customAuth?: CustomAuth;
-    /** @deprecated Use experimental_setCustomAuth instead.*/
     setJwt: (jwt: string | undefined) => void;
 }
 


### PR DESCRIPTION
## Description

This PR removes the JSDoc deprecation notice from the `setJwt` function in the CrossmintProvider interface. The function remains fully functional and accessible - only the `@deprecated` comment has been removed.

**Change made:**
- Removed `/** @deprecated Use experimental_setCustomAuth instead.*/` comment from the `setJwt` function in `CrossmintContext` interface

This was requested to clean up the deprecation notice while maintaining backward compatibility.

## Test plan

* Build verification: Confirmed `pnpm build:libs` completes successfully with no new errors
* The change is documentation-only, so no functional testing was required
* Existing TypeScript compilation and linting processes remain unaffected

## Package updates

No package updates required - this is a documentation-only change.

---

**Human Review Checklist:**
- [ ] Verify this aligns with product roadmap for `setJwt` vs `experimental_setCustomAuth`
- [ ] Check if there are other locations where this deprecation notice should also be removed
- [ ] Confirm this doesn't interfere with any planned migration timelines

---
**Link to Devin run:** https://app.devin.ai/sessions/b77cf15bc3744df597a7abb5825599eb  
**Requested by:** @AlbertoElias