### PR TITLE
feat: deprecates experimental_setCustomAuth in favour of setJwt

### DIFF
--- a/.changeset/gentle-bears-cheat.md
+++ b/.changeset/gentle-bears-cheat.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-base": patch
+---
+
+Deprecated customAuth in favor of setJwt

--- a/packages/client/react-base/src/providers/CrossmintProvider.tsx
+++ b/packages/client/react-base/src/providers/CrossmintProvider.tsx
@@ -4,7 +4,9 @@ import isEqual from "lodash.isequal";
 
 export interface CrossmintContext {
     crossmint: Crossmint;
+    /* @deprecated Use setJwt instead */
     experimental_setCustomAuth: (customAuthParams?: CustomAuth) => void;
+    /* @deprecated Use crossmint.jwt instead */
     experimental_customAuth?: CustomAuth;
     setJwt: (jwt: string | undefined) => void;
 }
@@ -38,6 +40,11 @@ export function CrossmintProvider({
     const setJwt = useCallback((jwt: string | undefined) => {
         if (jwt !== crossmintRef.current.jwt) {
             crossmintRef.current.jwt = jwt;
+            if (crossmintRef.current.experimental_customAuth == null) {
+                crossmintRef.current.experimental_customAuth = { jwt };
+            } else {
+                crossmintRef.current.experimental_customAuth.jwt = jwt;
+            }
         }
     }, []);
 


### PR DESCRIPTION
## Description

We are going to be removing setCustomAuth in v1 of the sdk, this adds a deprecation notice and makes sure developers can start using setJwt 

## Test plan

Tested with quickstart using Firebase

## Package updates

react-base: patch