### PR TITLE
Token Balance: Remove token symbol filtering from balance response

### DIFF
--- a/.changeset/rude-trees-grin.md
+++ b/.changeset/rude-trees-grin.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+Removed filtering of tokens that don't have a symbol

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -156,11 +156,7 @@ export class Wallet<C extends Chain> {
         const usdcData = apiResponse.find((token) => token.symbol === "usdc");
 
         const otherTokens = apiResponse.filter((token) => {
-            return (
-                token.symbol !== nativeTokenSymbol &&
-                token.symbol !== "usdc" &&
-                requestedTokens?.includes(token.symbol ?? "")
-            );
+            return token.symbol !== nativeTokenSymbol && token.symbol !== "usdc";
         });
 
         const createDefaultToken = (symbol: TokenBalance["symbol"]): TokenBalance => ({


### PR DESCRIPTION
## Description

Removes token symbol filtering from the balance response transformation logic to fix 500 errors occurring when requesting balances for SPL tokens that lack metadata/symbols.

The previous implementation filtered out tokens unless their symbol matched the requested tokens list (`requestedTokens?.includes(token.symbol ?? "")`). This caused issues when tokens either had no symbol or symbols that didn't match exactly, leading to API errors.

**Changes:**
- Removed the `requestedTokens?.includes(token.symbol ?? "")` condition from the `otherTokens` filter
- Tokens are now included in the response as long as they're not the native token or USDC, regardless of symbol presence or matching

**Context:** Addresses issue WAL-6354 where specific SPL tokens like `sol:Xs5UJzmCRQ8DWZjskExdSQDnbE6iLkRu2jjrRAB1JSU` were causing 500 errors in staging.

## Test plan

⚠️ **Manual testing required** - This change needs to be tested with the specific failing tokens mentioned in the issue:
- `usdxm`
- `sol:Xs5UJzmCRQ8DWZjskExdSQDnbE6iLkRu2jjrRAB1JSU`
- `sol:XsCPL9dNWBMvFtTmwcCA5v3xWPSMEBCszbQdiLLq6aN`  
- `sol:Xs3eBt7uRfJX8QUs4suhyU8p2M6DoUDrJyWBa8LLZsg`

**Review checklist:**
- [ ] Verify this change aligns with intended API behavior (should we return all tokens vs only requested ones?)
- [ ] Test with the failing token examples from WAL-6354 to confirm 500 errors are resolved
- [ ] Consider if existing client code might break due to receiving additional tokens in responses
- [ ] Evaluate if additional validation/filtering should be added elsewhere

## Package updates

None - this is a logic change only.

---

**Link to Devin run:** https://app.devin.ai/sessions/da92def5782240299612e9409cb2f002  
**Requested by:** @panosinthezone