### PR TITLE
fix: Make export-signer events a specific type 

### DIFF
--- a/.changeset/five-fishes-heal.md
+++ b/.changeset/five-fishes-heal.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-signers": patch
+---
+
+Separates export-signer event so it can be used in a separate frame page

--- a/packages/client/signers/src/communications/events.ts
+++ b/packages/client/signers/src/communications/events.ts
@@ -15,7 +15,6 @@ export const SIGNER_EVENTS = [
     "sign",
     "get-status",
     "get-attestation",
-    "export-signer",
 ] as const;
 export type SignerIFrameEventName = (typeof SIGNER_EVENTS)[number];
 
@@ -25,7 +24,6 @@ export const signerInboundEvents = {
     "request:complete-onboarding": CompleteOnboardingPayloadSchema.request,
     "request:sign": SignPayloadSchema.request,
     "request:get-status": GetStatusPayloadSchema.request,
-    "request:export-signer": ExportSignerPayloadSchema.request,
 } as const;
 
 export const signerOutboundEvents = {
@@ -34,10 +32,26 @@ export const signerOutboundEvents = {
     "response:complete-onboarding": CompleteOnboardingPayloadSchema.response,
     "response:sign": SignPayloadSchema.response,
     "response:get-status": GetStatusPayloadSchema.response,
-    "response:export-signer": ExportSignerPayloadSchema.response,
 } as const;
-
 export type SignerInputEvent<E extends SignerIFrameEventName> = z.infer<(typeof signerInboundEvents)[`request:${E}`]>;
 export type SignerOutputEvent<E extends SignerIFrameEventName> = z.infer<
     (typeof signerOutboundEvents)[`response:${E}`]
+>;
+
+export const EXPORT_SIGNER_EVENTS = ["export-signer"] as const;
+export type ExportSignerEventName = (typeof EXPORT_SIGNER_EVENTS)[number];
+
+export const exportSignerInboundEvents = {
+    "request:export-signer": ExportSignerPayloadSchema.request,
+} as const;
+
+export const exportSignerOutboundEvents = {
+    "response:export-signer": ExportSignerPayloadSchema.response,
+} as const;
+
+export type ExportSignerInputEvent<E extends ExportSignerEventName> = z.infer<
+    (typeof exportSignerInboundEvents)[`request:${E}`]
+>;
+export type ExportSignerOutputEvent<E extends ExportSignerEventName> = z.infer<
+    (typeof exportSignerOutboundEvents)[`response:${E}`]
 >;

--- a/packages/client/signers/src/communications/index.ts
+++ b/packages/client/signers/src/communications/index.ts
@@ -1,9 +1,17 @@
-export { signerInboundEvents, signerOutboundEvents } from "./events";
+export {
+    signerInboundEvents,
+    signerOutboundEvents,
+    exportSignerInboundEvents,
+    exportSignerOutboundEvents,
+} from "./events";
 
 export type {
     SignerIFrameEventName,
     SignerInputEvent,
     SignerOutputEvent,
+    ExportSignerEventName,
+    ExportSignerInputEvent,
+    ExportSignerOutputEvent,
 } from "./events";
 
 export { environmentUrlConfig } from "./urls";

--- a/packages/client/signers/src/communications/schemas.ts
+++ b/packages/client/signers/src/communications/schemas.ts
@@ -132,7 +132,7 @@ export const ExportSignerPayloadSchema = {
                     .union([z.literal("ed25519"), z.literal("secp256k1")])
                     .describe("The cryptographic scheme to use"),
                 encoding: z
-                    .union([z.literal("base58"), z.literal("hex")])
+                    .union([z.literal("base58"), z.literal("hex"), z.literal("strkey")])
                     .describe("Encoding format for the private key"),
             })
             .describe("Data needed to export the signer"),


### PR DESCRIPTION
## Description

We want the index and export page to handle different events, so we separate it here. Export should only listen to the export event and it should not be accessible from index.

## Test plan

Tested with the react apps

## Package updates

client-signers: patch