### PR TITLE
React-native app: Adding scheme to auth providers

### DIFF
--- a/.changeset/seven-dingos-itch.md
+++ b/.changeset/seven-dingos-itch.md
@@ -1,0 +1,5 @@
+---
+"expo-demo": patch
+---
+
+Adding the app scheme to the auth provider

--- a/apps/wallets/smart-wallet/expo/app/_layout.tsx
+++ b/apps/wallets/smart-wallet/expo/app/_layout.tsx
@@ -23,7 +23,7 @@ function CrossmintProviders({ children }: { children: ReactNode }) {
 
     return (
         <CrossmintProvider apiKey={process.env.EXPO_PUBLIC_CROSSMINT_API_KEY ?? ""} overrideBaseUrl="">
-            <CrossmintAuthProvider appSchema={appScheme}>
+            <CrossmintAuthProvider>
                 <CrossmintWalletProvider>{children}</CrossmintWalletProvider>
             </CrossmintAuthProvider>
         </CrossmintProvider>

--- a/apps/wallets/smart-wallet/expo/app/_layout.tsx
+++ b/apps/wallets/smart-wallet/expo/app/_layout.tsx
@@ -5,6 +5,7 @@ import {
     CrossmintWalletProvider,
 } from "@crossmint/client-sdk-react-native-ui";
 import { Stack } from "expo-router";
+import Constants from "expo-constants";
 
 import "../utils/polyfills";
 
@@ -17,9 +18,12 @@ export default function RootLayout() {
 }
 
 function CrossmintProviders({ children }: { children: ReactNode }) {
+    // The scheme is used for deep linking
+    const appScheme = Constants.expoConfig?.scheme;
+
     return (
         <CrossmintProvider apiKey={process.env.EXPO_PUBLIC_CROSSMINT_API_KEY ?? ""} overrideBaseUrl="">
-            <CrossmintAuthProvider>
+            <CrossmintAuthProvider appSchema={appScheme}>
                 <CrossmintWalletProvider>{children}</CrossmintWalletProvider>
             </CrossmintAuthProvider>
         </CrossmintProvider>

--- a/apps/wallets/smart-wallet/expo/app/_layout.tsx
+++ b/apps/wallets/smart-wallet/expo/app/_layout.tsx
@@ -5,7 +5,6 @@ import {
     CrossmintWalletProvider,
 } from "@crossmint/client-sdk-react-native-ui";
 import { Stack } from "expo-router";
-import Constants from "expo-constants";
 
 import "../utils/polyfills";
 
@@ -18,9 +17,6 @@ export default function RootLayout() {
 }
 
 function CrossmintProviders({ children }: { children: ReactNode }) {
-    // The scheme is used for deep linking
-    const appScheme = Constants.expoConfig?.scheme;
-
     return (
         <CrossmintProvider apiKey={process.env.EXPO_PUBLIC_CROSSMINT_API_KEY ?? ""} overrideBaseUrl="">
             <CrossmintAuthProvider>

--- a/packages/client/ui/react-native/src/providers/CrossmintAuthProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintAuthProvider.tsx
@@ -3,6 +3,7 @@ import type { StorageProvider } from "@crossmint/client-sdk-auth";
 
 import { useAuth, useCrossmint } from "../hooks";
 import { CrossmintAuthProviderInternal } from "./CrossmintAuthProviderInternal";
+import Constants from "expo-constants";
 
 export type CrossmintAuthProviderProps = {
     prefetchOAuthUrls?: boolean;
@@ -35,8 +36,10 @@ function CrossmintAuthSync({ children }: { children: ReactNode }) {
 }
 
 export function CrossmintAuthProvider({ children, ...props }: CrossmintAuthProviderProps) {
+    const appSchema = props.appSchema ?? Constants.expoConfig?.scheme;
+
     return (
-        <CrossmintAuthProviderInternal {...props}>
+        <CrossmintAuthProviderInternal {...props} appSchema={appSchema}>
             <CrossmintAuthSync>{children}</CrossmintAuthSync>
         </CrossmintAuthProviderInternal>
     );


### PR DESCRIPTION
## Description
The callbackUrl will be the same as the `scheme` that is found within `app.json`.

## Test plan
`https://api.stytch.com/v1/public/oauth/google/start?public_token=public-token-live-f9456a2e-4d5a-494d-baf7-27bdacd8b160&login_redirect_url=https://staging.crossmint.com/api/2024-09-26/session/sdk/auth/authenticate?callbackUrl=myapp%3A%2F%2F&signinAuthenticationMethod=google&apiKey={{apiKey}}&signup_redirect_url=https://staging.crossmint.com/api/2024-09-26/session/sdk/auth/authenticate?callbackUrl=myapp%3A%2F%2F&signinAuthenticationMethod=google&apiKey={{apiKey}}&provider_prompt=select_account`

Testing on android
https://github.com/user-attachments/assets/56a8dcda-ad7f-4457-8df0-ab9283236e47

Testing on ios

https://github.com/user-attachments/assets/0df6bc0c-e4fb-456f-925e-d17e7f3a8b27


