### PR TITLE
fixes: makes needsAuth flow when rejecting and pass in delegated signers properly

### DIFF
--- a/.changeset/brown-meals-melt.md
+++ b/.changeset/brown-meals-melt.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+Supports signer param in #send

--- a/.changeset/sweet-rabbits-drum.md
+++ b/.changeset/sweet-rabbits-drum.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-base": patch
+---
+
+Pass through delegatedSigners on wallet creation

--- a/.changeset/twenty-dots-love.md
+++ b/.changeset/twenty-dots-love.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+Sets needsAuth to false when rejecting otp flow

--- a/packages/client/react-base/src/providers/CrossmintWalletBaseProvider.tsx
+++ b/packages/client/react-base/src/providers/CrossmintWalletBaseProvider.tsx
@@ -116,6 +116,7 @@ export function CrossmintWalletBaseProvider({
                     signer: args.signer,
                     owner: args.owner,
                     plugins: args.plugins,
+                    delegatedSigners: args.delegatedSigners,
                     options: {
                         clientTEEConnection: clientTEEConnection?.(),
                         experimental_callbacks: {

--- a/packages/wallets/src/signers/non-custodial/ncs-signer.ts
+++ b/packages/wallets/src/signers/non-custodial/ncs-signer.ts
@@ -85,9 +85,18 @@ export abstract class NonCustodialSigner implements Signer {
                     this._needsAuth,
                     () => this.sendMessageWithOtp(),
                     (otp) => this.verifyOtp(otp),
-                    () => {
-                        reject(new AuthRejectedError());
+                    async () => {
                         this._needsAuth = false;
+                        // We call onAuthRequired again so the needsAuth state is updated for the dev
+                        if (this.config.onAuthRequired != null) {
+                            await this.config.onAuthRequired(
+                                this._needsAuth,
+                                () => this.sendMessageWithOtp(),
+                                (otp) => this.verifyOtp(otp),
+                                () => this._authPromise?.reject(new AuthRejectedError())
+                            );
+                        }
+                        reject(new AuthRejectedError());
                     }
                 );
             } catch (error) {

--- a/packages/wallets/src/wallets/solana.ts
+++ b/packages/wallets/src/wallets/solana.ts
@@ -36,7 +36,7 @@ export class SolanaWallet extends Wallet<SolanaChain> {
     }
 
     public async sendTransaction<T extends TransactionInputOptions | undefined = undefined>(
-        params: SolanaTransactionInput & { options?: T }
+        params: SolanaTransactionInput
     ): Promise<Transaction<T extends PrepareOnly<true> ? true : false>> {
         const createdTransaction = await this.createTransaction(params);
 

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -251,7 +251,11 @@ export class Wallet<C extends Chain> {
     ): Promise<Transaction<T extends PrepareOnly<true> ? true : false>> {
         const recipient = toRecipientLocator(to);
         const tokenLocator = toTokenLocator(token, this.chain);
-        const sendParams = { recipient, amount };
+        const sendParams = {
+            recipient,
+            amount,
+            ...(options?.experimental_signer != null ? { signer: options.experimental_signer } : {}),
+        };
         const transactionCreationResponse = await this.#apiClient.send(this.walletLocator, tokenLocator, sendParams);
 
         if ("message" in transactionCreationResponse) {


### PR DESCRIPTION
## Description

I batched multiple fixes: 

- Pass through delegatedSigners in createOnLogin
- Pass `signer` when calling `send`
- Sets needsAuth to false when the otp flow is rejected

## Test plan

Tested with quickstart

## Package updates

react-base: patch
wallets: patch