### PR TITLE
fix: enable delegated signers support for Stellar wallets

### DIFF
--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -352,13 +352,11 @@ export class Wallet<C extends Chain> {
             throw new WalletNotAvailableError(JSON.stringify(walletResponse));
         }
 
-        if (this.chain === "stellar") {
-            return [];
-        }
-
         if (
             walletResponse.type !== "smart" ||
-            (walletResponse.chainType !== "evm" && walletResponse.chainType !== "solana")
+            (walletResponse.chainType !== "evm" &&
+                walletResponse.chainType !== "solana" &&
+                walletResponse.chainType !== "stellar")
         ) {
             throw new WalletTypeNotSupportedError(`Wallet type ${walletResponse.type} not supported`);
         }


### PR DESCRIPTION
## Description

Previously, the `delegatedSigners()` method explicitly excluded Stellar wallets by returning an empty array, while the `addDelegatedSigner()` method already supported Stellar wallets correctly. This created an inconsistency where you could add delegated signers to Stellar wallets but couldn't retrieve them.

This PR fixes the inconsistency by:
- Removing the early return that excluded Stellar chains from delegated signer functionality
- Updating the wallet type validation to include `stellar` alongside `evm` and `solana` chainTypes
- Allowing Stellar wallets to use the same delegated signer fetching and mapping logic as other supported chains

The change aligns the `delegatedSigners()` getter method with the existing `addDelegatedSigner()` setter method behavior, where Stellar is treated the same as Solana (no chain parameter required).

## Test plan

⚠️ **Important**: This change enables previously untested code paths for Stellar wallets. The delegated signer mapping logic (lines 367-376) was never executed for Stellar chains before this change.

**Reviewers should verify:**
- [ ] Delegated signer functionality works correctly with Stellar wallets
- [ ] The signer locator mapping logic handles Stellar signer formats properly  
- [ ] API responses for Stellar wallet delegated signers are compatible with existing parsing logic
- [ ] No regression in existing EVM/Solana delegated signer functionality

**Automated testing:**
- [x] Lint checks passed
- [x] Build compilation successful
- [ ] Manual functional testing (not performed - requires reviewer verification)

## Package updates

No package updates required for this change.

---

**Link to Devin run:** https://app.devin.ai/sessions/e5b3a3ee3af648c08dd50736c8bb19cd  
**Requested by:** @AlbertoElias