### PR TITLE
feat: rename serializedTransaction parameter to transaction in Stellar

### DIFF
--- a/.changeset/fifty-sheep-crash.md
+++ b/.changeset/fifty-sheep-crash.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": minor
+---
+
+Rename `serializedTransaction` parameter to `transaction` in Stellar wallet sendTransaction method

--- a/packages/wallets/src/wallets/stellar.ts
+++ b/packages/wallets/src/wallets/stellar.ts
@@ -57,10 +57,10 @@ export class StellarWallet extends Wallet<StellarChain> {
 
         let transaction: any;
 
-        if ("serializedTransaction" in params) {
+        if ("transaction" in params) {
             transaction = {
                 type: "serialized-transaction",
-                serializedTransaction: params.serializedTransaction,
+                serializedTransaction: params.transaction,
                 contractId,
             };
         } else {

--- a/packages/wallets/src/wallets/types.ts
+++ b/packages/wallets/src/wallets/types.ts
@@ -58,7 +58,7 @@ export type StellarTransactionInput = (
           args: Record<string, any>;
       }
     | {
-          serializedTransaction: string;
+          transaction: string;
           contractId: string;
       }
 ) & {


### PR DESCRIPTION
## Description

Rename `serializedTransaction` parameter to `transaction` in Stellar wallet for consistency with EVM and Solana

## Test plan

SDK builds.

## Package updates

wallets-sdk