### PR TITLE
NCS: fix some RN event handling issues

### DIFF
--- a/.changeset/violet-plums-work.md
+++ b/.changeset/violet-plums-work.md
@@ -1,0 +1,7 @@
+---
+"@crossmint/client-sdk-rn-window": patch
+"@crossmint/client-sdk-window": patch
+"@crossmint/wallets-sdk": patch
+---
+
+Minor issues with retries in event handling

--- a/packages/client/rn-window/src/rn-webview/RNWebView.tsx
+++ b/packages/client/rn-window/src/rn-webview/RNWebView.tsx
@@ -12,11 +12,20 @@ const INJECTED_BRIDGE_JS = `
         info: console.info,
     };
 
+    // Function to get timestamp
+    const getTimestamp = () => {
+        return new Date().toISOString();
+    };
+
     // Function to send messages to RN
     const postToRN = (type, args) => {
         try {
+            // Add timestamp to the beginning of args
+            const timestamp = getTimestamp();
+            const timestampedArgs = ['[' + timestamp + ']'].concat(args);
+
             // Attempt to serialize arguments, handling potential circular references safely
-            const serializedArgs = args.map(arg => {
+            const serializedArgs = timestampedArgs.map(arg => {
                  // Basic type checking and string conversion
                 if (typeof arg === 'function') {
                     return '[Function]';
@@ -43,7 +52,7 @@ const INJECTED_BRIDGE_JS = `
                 return String(arg); // Convert primitive types to string directly
             });
              var seen = new Set(); // Declare seen here for the final stringify
-            const message = JSON.stringify({ type: \`console.\${type}\`, data: serializedArgs });
+            const message = JSON.stringify({ type: 'console.' + type, data: serializedArgs });
             if (window.ReactNativeWebView && typeof window.ReactNativeWebView.postMessage === 'function') {
                  window.ReactNativeWebView.postMessage(message);
             } else {
@@ -57,19 +66,23 @@ const INJECTED_BRIDGE_JS = `
 
     // Override console methods
     console.log = (...args) => {
-        originalConsole.log.apply(console, args); // Call original console.log
+        const timestamp = getTimestamp();
+        originalConsole.log('[' + timestamp + ']', ...args); // Call original console.log with timestamp
         postToRN('log', args);
     };
     console.error = (...args) => {
-        originalConsole.error.apply(console, args); // Call original console.error
+        const timestamp = getTimestamp();
+        originalConsole.error('[' + timestamp + ']', ...args); // Call original console.error with timestamp
         postToRN('error', args);
     };
     console.warn = (...args) => {
-        originalConsole.warn.apply(console, args); // Call original console.warn
+        const timestamp = getTimestamp();
+        originalConsole.warn('[' + timestamp + ']', ...args); // Call original console.warn with timestamp
         postToRN('warn', args);
     };
     console.info = (...args) => {
-        originalConsole.info.apply(console, args); // Call original console.info
+        const timestamp = getTimestamp();
+        originalConsole.info('[' + timestamp + ']', ...args); // Call original console.info with timestamp
         postToRN('info', args);
     };
 

--- a/packages/wallets/src/signers/non-custodial/ncs-signer.ts
+++ b/packages/wallets/src/signers/non-custodial/ncs-signer.ts
@@ -11,6 +11,7 @@ export abstract class NonCustodialSigner implements Signer {
         resolve: () => void;
         reject: (error: Error) => void;
     } | null = null;
+    private _initializationPromise: Promise<void> | null = null;
 
     constructor(protected config: EmailInternalSignerConfig | PhoneInternalSignerConfig) {
         this.initialize();
@@ -41,21 +42,59 @@ export abstract class NonCustodialSigner implements Signer {
 
     abstract signTransaction(transaction: string): Promise<{ signature: string }>;
 
-    protected async handleAuthRequired() {
+    private async getTEEConnection() {
         if (this.config.clientTEEConnection == null) {
-            if (this.config.onAuthRequired == null) {
-                throw new Error(
-                    `${this.type} signer requires the onAuthRequired callback to handle OTP verification. ` +
-                        `This callback manages the authentication flow (sending OTP and verifying user input). ` +
-                        `If using our React/React Native SDK, this is handled automatically by the provider. ` +
-                        `For other environments, implement: onAuthRequired: (needsAuth, sendEmailWithOtp, verifyOtp, reject) => { /* your UI logic */ }`
-                );
+            // If there's already an initialization in progress, wait for it
+            if (this._initializationPromise) {
+                await this._initializationPromise;
+                return this.config.clientTEEConnection!;
             }
-            throw new Error("Handshake parent not initialized");
+
+            // Start initialization and store the promise to prevent concurrent initializations
+            this._initializationPromise = this.initializeTEEConnection();
+
+            try {
+                await this._initializationPromise;
+            } finally {
+                // Clear the promise after completion (success or failure)
+                this._initializationPromise = null;
+            }
+        }
+
+        return this.config.clientTEEConnection!;
+    }
+
+    private async initializeTEEConnection(): Promise<void> {
+        console.warn("TEE connection is not initialized, initializing now...");
+
+        const parsedAPIKey = validateAPIKey(this.config.crossmint.apiKey);
+        if (!parsedAPIKey.isValid) {
+            throw new Error("Invalid API key");
+        }
+        const iframeManager = new NcsIframeManager({ environment: parsedAPIKey.environment });
+        this.config.clientTEEConnection = await iframeManager.initialize();
+
+        if (this.config.clientTEEConnection == null) {
+            throw new Error("Failed to initialize TEE connection");
+        }
+
+        console.log("TEE connection initialized successfully");
+    }
+
+    protected async handleAuthRequired() {
+        const clientTEEConnection = await this.getTEEConnection();
+
+        if (this.config.onAuthRequired == null) {
+            throw new Error(
+                `${this.type} signer requires the onAuthRequired callback to handle OTP verification. ` +
+                    `This callback manages the authentication flow (sending OTP and verifying user input). ` +
+                    `If using our React/React Native SDK, this is handled automatically by the provider. ` +
+                    `For other environments, implement: onAuthRequired: (needsAuth, sendEmailWithOtp, verifyOtp, reject) => { /* your UI logic */ }`
+            );
         }
 
         // Determine if we need to authenticate the user via OTP or not
-        const signerResponse = await this.config.clientTEEConnection?.sendAction({
+        const signerResponse = await clientTEEConnection.sendAction({
             event: "request:get-status",
             responseEvent: "response:get-status",
             data: {
@@ -64,7 +103,10 @@ export abstract class NonCustodialSigner implements Signer {
                     apiKey: this.config.crossmint.apiKey,
                 },
             },
-            options: DEFAULT_EVENT_OPTIONS,
+            options: {
+                ...DEFAULT_EVENT_OPTIONS,
+                maxRetries: 5,
+            },
         });
 
         if (signerResponse?.status !== "success") {
@@ -134,11 +176,7 @@ export abstract class NonCustodialSigner implements Signer {
     }
 
     private async sendMessageWithOtp() {
-        if (this.config.clientTEEConnection == null) {
-            throw new Error("Handshake parent not initialized");
-        }
-
-        const handshakeParent = this.config.clientTEEConnection;
+        const handshakeParent = await this.getTEEConnection();
         const authId = this.getAuthId();
         const response = await handshakeParent.sendAction({
             event: "request:start-onboarding",
@@ -150,7 +188,10 @@ export abstract class NonCustodialSigner implements Signer {
                 },
                 data: { authId },
             },
-            options: DEFAULT_EVENT_OPTIONS,
+            options: {
+                ...DEFAULT_EVENT_OPTIONS,
+                maxRetries: 3,
+            },
         });
 
         if (response?.status === "success" && response.signerStatus === "ready") {
@@ -172,11 +213,7 @@ export abstract class NonCustodialSigner implements Signer {
     }
 
     private async verifyOtp(encryptedOtp: string) {
-        if (this.config.clientTEEConnection == null) {
-            throw new Error("Handshake parent not initialized");
-        }
-
-        const handshakeParent = this.config.clientTEEConnection;
+        const handshakeParent = await this.getTEEConnection();
         try {
             const response = await handshakeParent.sendAction({
                 event: "request:complete-onboarding",
@@ -190,7 +227,10 @@ export abstract class NonCustodialSigner implements Signer {
                         onboardingAuthentication: { encryptedOtp },
                     },
                 },
-                options: DEFAULT_EVENT_OPTIONS,
+                options: {
+                    ...DEFAULT_EVENT_OPTIONS,
+                    maxRetries: 3,
+                },
             });
 
             if (response?.status === "success") {


### PR DESCRIPTION
## Description

Motivation: while doing chaos testing and injecting errors saw how a network failure could lead to an event never properly managed and kept retried forever, casing the user to reach rate limits. This issue motivated these changes

Some improvements
- Detect when the connection is undefined and warn about it
- Add timestamp to logs from the WebView
- Add finite number of retries for failed events, optionally

## Test plan

Will be tested with a sample application

## Package updates

<!-- 
  List any package updates and ensure you've added the necessary changesets, running `pnpm change:add` to do so.
-->