### PR TITLE
Fix: EVM typed data signature type

### DIFF
--- a/.changeset/swift-countries-heal.md
+++ b/.changeset/swift-countries-heal.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+Fix a bug of typedData not being properly managed for smart wallets in EVM

--- a/packages/wallets/src/wallets/evm.ts
+++ b/packages/wallets/src/wallets/evm.ts
@@ -110,7 +110,6 @@ export class EVMWallet extends Wallet<EVMChain> {
                 },
                 signer: this.signer.locator(),
                 chain,
-                isSmartWalletSignature: false,
             },
         });
         if ("error" in signatureCreationResponse) {


### PR DESCRIPTION
## Description

This was not handled as a smart wallet signature but as a EOA instead, which was not correct

## Test plan

Nothing to test