### PR TITLE
Fix: OTP display not showing for email signers

### DIFF
--- a/.changeset/three-hornets-thank.md
+++ b/.changeset/three-hornets-thank.md
@@ -1,5 +1,0 @@
----
-"@crossmint/client-sdk-react-ui": patch
----
-
-Fix OTP modal not showing for bring your own auth

--- a/.changeset/two-masks-fetch.md
+++ b/.changeset/two-masks-fetch.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+---
+
+Fix: Modal OTP not showing under certain signer setups


### PR DESCRIPTION
## Description

This align the behavior of email and phone signers, as we were diverging in the email case and for external auth in which the email is not explicitly set, we were not showing the OTP modal. This fixes it

