### PR TITLE
feat(wallets): avoid loading webview until necessary for email/phone signers

### DIFF
--- a/.changeset/smart-islands-fail.md
+++ b/.changeset/smart-islands-fail.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-native-ui": patch
+---
+
+Optimize WebView loading to only initialize when email or phone signer is used, avoiding unnecessary background polling for passkey and external wallet signers

--- a/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
@@ -38,6 +38,9 @@ export interface CrossmintWalletProviderProps {
 export function CrossmintWalletProvider({ children, createOnLogin, callbacks }: CrossmintWalletProviderProps) {
     const { crossmint } = useCrossmint("CrossmintWalletProvider must be used within CrossmintProvider");
     const { apiKey, appId } = crossmint;
+
+    const needsWebView = createOnLogin?.signer.type === "email" || createOnLogin?.signer.type === "phone";
+
     const parsedAPIKey = useMemo(() => {
         const result = validateAPIKey(apiKey);
         if (!result.isValid) {
@@ -139,7 +142,6 @@ export function CrossmintWalletProvider({ children, createOnLogin, callbacks }: 
         parent.handleMessage(event);
     }, []);
 
-    // Get the handshake parent for email signer
     const getClientTEEConnection = () => {
         if (webViewParentRef.current == null) {
             throw new Error("WebView not ready or handshake incomplete");
@@ -173,48 +175,50 @@ export function CrossmintWalletProvider({ children, createOnLogin, callbacks }: 
         <CrossmintWalletBaseProvider
             createOnLogin={createOnLogin}
             onAuthRequired={onAuthRequired}
-            clientTEEConnection={getClientTEEConnection}
+            clientTEEConnection={needsWebView ? getClientTEEConnection : undefined}
             callbacks={callbacks}
         >
             <CrossmintWalletEmailSignerContext.Provider value={authContextValue}>
                 {children}
             </CrossmintWalletEmailSignerContext.Provider>
-            <View
-                style={{
-                    position: "absolute",
-                    width: 0,
-                    height: 0,
-                    overflow: "hidden",
-                }}
-            >
-                <RNWebView
-                    ref={webviewRef}
-                    source={{ uri: frameUrl }}
-                    globals={secureGlobals}
-                    onLoadEnd={onWebViewLoad}
-                    onMessage={handleMessage}
-                    onError={(syntheticEvent) => {
-                        console.error("[CrossmintWalletProvider] WebView error:", syntheticEvent.nativeEvent);
-                    }}
-                    onHttpError={(syntheticEvent) => {
-                        console.error("[CrossmintWalletProvider] WebView HTTP error:", syntheticEvent.nativeEvent);
-                    }}
-                    onContentProcessDidTerminate={() => webviewRef.current?.reload()}
-                    onRenderProcessGone={() => webviewRef.current?.reload()}
+            {needsWebView && (
+                <View
                     style={{
-                        width: 1,
-                        height: 1,
+                        position: "absolute",
+                        width: 0,
+                        height: 0,
+                        overflow: "hidden",
                     }}
-                    javaScriptCanOpenWindowsAutomatically={false}
-                    thirdPartyCookiesEnabled={false}
-                    sharedCookiesEnabled={false}
-                    incognito={false}
-                    setSupportMultipleWindows={false}
-                    originWhitelist={[environmentUrlConfig[parsedAPIKey.environment]]}
-                    cacheEnabled={true}
-                    cacheMode="LOAD_DEFAULT"
-                />
-            </View>
+                >
+                    <RNWebView
+                        ref={webviewRef}
+                        source={{ uri: frameUrl }}
+                        globals={secureGlobals}
+                        onLoadEnd={onWebViewLoad}
+                        onMessage={handleMessage}
+                        onError={(syntheticEvent) => {
+                            console.error("[CrossmintWalletProvider] WebView error:", syntheticEvent.nativeEvent);
+                        }}
+                        onHttpError={(syntheticEvent) => {
+                            console.error("[CrossmintWalletProvider] WebView HTTP error:", syntheticEvent.nativeEvent);
+                        }}
+                        onContentProcessDidTerminate={() => webviewRef.current?.reload()}
+                        onRenderProcessGone={() => webviewRef.current?.reload()}
+                        style={{
+                            width: 1,
+                            height: 1,
+                        }}
+                        javaScriptCanOpenWindowsAutomatically={false}
+                        thirdPartyCookiesEnabled={false}
+                        sharedCookiesEnabled={false}
+                        incognito={false}
+                        setSupportMultipleWindows={false}
+                        originWhitelist={[environmentUrlConfig[parsedAPIKey.environment]]}
+                        cacheEnabled={true}
+                        cacheMode="LOAD_DEFAULT"
+                    />
+                </View>
+            )}
         </CrossmintWalletBaseProvider>
     );
 }

--- a/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
@@ -142,6 +142,7 @@ export function CrossmintWalletProvider({ children, createOnLogin, callbacks }: 
         parent.handleMessage(event);
     }, []);
 
+    // Get the handshake parent for email signer
     const getClientTEEConnection = () => {
         if (webViewParentRef.current == null) {
             throw new Error("WebView not ready or handshake incomplete");


### PR DESCRIPTION
## Description

This PR optimizes WebView loading in the React Native SDK to avoid unnecessary initialization and background polling when the WebView is not needed for the selected signer type.

## Why Only React Native Needs Changes

### The Problem
Previously, the React Native `CrossmintWalletProvider` always rendered and initialized a WebView regardless of the signer type specified in `createOnLogin`. This caused unnecessary overhead and background polling for signer types that don't require TEE (Trusted Execution Environment) communication, specifically:
- Passkey signers
- External wallet signers  
- API key signers

Only **email** and **phone** signers actually need the WebView for OTP authentication flows.

### Why React Web Doesn't Need Changes

The React Web implementation already handles this correctly through a different architectural pattern. Here's the key difference:

**React Web (`packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx`)**:
- The provider component does NOT render any iframe at all
- It only renders UI dialogs for user interactions (EmailSignersDialog, PhoneSignersDialog, PasskeyPrompt)
- No `clientTEEConnection` prop is passed to `CrossmintWalletBaseProvider`
- The iframe is created **lazily** inside the signer implementation when actually needed

**React Native (`packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx`)**:
- Previously always rendered a WebView component regardless of signer type
- Passed `getClientTEEConnection` callback to `CrossmintWalletBaseProvider` unconditionally
- This PR fixes it to match React Web's lazy-loading behavior

### How Lazy Loading Works in React Web

When using email/phone signers in React Web, the iframe is created on-demand through this flow:

1. **`NonCustodialSigner` class** (`packages/wallets/src/signers/non-custodial/ncs-signer.ts`):
   - The constructor calls `initialize()` which checks if `clientTEEConnection` is null
   - If null, it creates an `NcsIframeManager` and initializes the iframe (lines 31-41)
   - Additionally, `getTEEConnection()` provides lazy initialization if the connection wasn't set up during construction (lines 45-82)

2. **`NcsIframeManager` class** (`packages/wallets/src/signers/non-custodial/ncs-iframe-manager.ts`):
   - The `initialize()` method creates an invisible iframe using `createInvisibleIFrame()` (lines 14-35)
   - The iframe is only created when the signer actually needs to communicate with the TEE
   - For passkey/external-wallet signers, this code path is never executed

### The Solution

This PR updates React Native to follow the same pattern:
- Added `needsWebView` check based on `createOnLogin.signer.type`
- Only render the WebView when `signer.type === "email"` or `signer.type === "phone"`
- Pass `undefined` as `clientTEEConnection` when WebView is not needed
- The `NonCustodialSigner` class already handles `undefined` clientTEEConnection gracefully with its lazy initialization logic

## Impact

- ✅ Eliminates unnecessary WebView initialization for passkey and external wallet signers in React Native
- ✅ Stops background polling between main app and WebView when not needed
- ✅ Maintains backward compatibility - email/phone signers work exactly as before
- ✅ Aligns React Native architecture with React Web's efficient lazy-loading pattern
- ✅ No changes needed to core signer logic - it already supports lazy initialization

## Test Plan

1. Test email signer still works correctly (WebView should be rendered)
2. Test phone signer still works correctly (WebView should be rendered)  
3. Test passkey signer works correctly (WebView should NOT be rendered)
4. Test external-wallet signer works correctly (WebView should NOT be rendered)
5. Verify no background polling occurs for passkey/external-wallet signers

## Related

Fixes WAL-5027

---

Link to Devin run: https://app.devin.ai/sessions/29bf52056e374ed2809ff8321f859455
Requested by: @guilleasz-crossmint
