### PR TITLE
feat: optimize webview loading for react native wallets

### DIFF
--- a/.changeset/smart-islands-fail.md
+++ b/.changeset/smart-islands-fail.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-native-ui": patch
+---
+
+Optimize WebView loading to only initialize when email or phone signer is used, avoiding unnecessary background polling for passkey and external wallet signers

--- a/packages/client/react-base/src/providers/CrossmintWalletBaseProvider.tsx
+++ b/packages/client/react-base/src/providers/CrossmintWalletBaseProvider.tsx
@@ -38,6 +38,7 @@ export interface CrossmintWalletBaseProviderProps {
     };
     onAuthRequired?: EmailSignerConfig["onAuthRequired"] | PhoneSignerConfig["onAuthRequired"];
     clientTEEConnection?: () => HandshakeParent<typeof signerOutboundEvents, typeof signerInboundEvents>;
+    onWalletSignerSet?: (signerType: string) => void;
 }
 
 export function CrossmintWalletBaseProvider({
@@ -46,6 +47,7 @@ export function CrossmintWalletBaseProvider({
     callbacks,
     onAuthRequired,
     clientTEEConnection,
+    onWalletSignerSet,
 }: CrossmintWalletBaseProviderProps) {
     const { crossmint, experimental_customAuth } = useCrossmint(
         "CrossmintWalletBaseProvider must be used within CrossmintProvider"
@@ -59,6 +61,7 @@ export function CrossmintWalletBaseProvider({
                 return undefined;
             }
             if (wallet != null) {
+                onWalletSignerSet?.(wallet.signer.type);
                 return wallet;
             }
 
@@ -110,6 +113,8 @@ export function CrossmintWalletBaseProvider({
                     }
                     args.signer = signer as SignerConfigForChain<C>;
                 }
+
+                onWalletSignerSet?.(args.signer.type);
 
                 const wallet = await wallets.getOrCreateWallet<C>({
                     chain: args.chain,

--- a/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
@@ -155,6 +155,20 @@ export function CrossmintWalletProvider({ children, createOnLogin, callbacks }: 
         return webViewParentRef.current;
     };
 
+    const waitForClientTEEConnection = async () => {
+        let attempts = 0;
+        const maxAttempts = 100; // 5 seconds total with 50ms intervals
+        while (webViewParentRef.current == null && attempts < maxAttempts) {
+            await new Promise((resolve) => setTimeout(resolve, 50));
+            attempts++;
+        }
+
+        if (webViewParentRef.current == null) {
+            throw new Error("WebView not ready or handshake incomplete");
+        }
+        return webViewParentRef.current;
+    };
+
     const onAuthRequired = async (
         needsAuth: boolean,
         sendEmailWithOtp: () => Promise<void>,
@@ -178,17 +192,15 @@ export function CrossmintWalletProvider({ children, createOnLogin, callbacks }: 
     );
 
     const handleWalletSignerSet = (signerType: string) => {
-        console.log("handleWalletSignerSet", signerType);
         setNeedsWebView(signerType === "email" || signerType === "phone");
     };
-
-    console.log("render needsWebView", needsWebView);
 
     return (
         <CrossmintWalletBaseProvider
             createOnLogin={createOnLogin}
             onAuthRequired={onAuthRequired}
             clientTEEConnection={getClientTEEConnection}
+            getClientTEEConnection={waitForClientTEEConnection}
             callbacks={callbacks}
             onWalletSignerSet={handleWalletSignerSet}
         >

--- a/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
@@ -38,6 +38,9 @@ export interface CrossmintWalletProviderProps {
 export function CrossmintWalletProvider({ children, createOnLogin, callbacks }: CrossmintWalletProviderProps) {
     const { crossmint } = useCrossmint("CrossmintWalletProvider must be used within CrossmintProvider");
     const { apiKey, appId } = crossmint;
+
+    const needsWebView = createOnLogin?.signer.type === "email" || createOnLogin?.signer.type === "phone";
+
     const parsedAPIKey = useMemo(() => {
         const result = validateAPIKey(apiKey);
         if (!result.isValid) {
@@ -139,7 +142,6 @@ export function CrossmintWalletProvider({ children, createOnLogin, callbacks }: 
         parent.handleMessage(event);
     }, []);
 
-    // Get the handshake parent for email signer
     const getClientTEEConnection = () => {
         if (webViewParentRef.current == null) {
             throw new Error("WebView not ready or handshake incomplete");
@@ -173,48 +175,50 @@ export function CrossmintWalletProvider({ children, createOnLogin, callbacks }: 
         <CrossmintWalletBaseProvider
             createOnLogin={createOnLogin}
             onAuthRequired={onAuthRequired}
-            clientTEEConnection={getClientTEEConnection}
+            clientTEEConnection={needsWebView ? getClientTEEConnection : undefined}
             callbacks={callbacks}
         >
             <CrossmintWalletEmailSignerContext.Provider value={authContextValue}>
                 {children}
             </CrossmintWalletEmailSignerContext.Provider>
-            <View
-                style={{
-                    position: "absolute",
-                    width: 0,
-                    height: 0,
-                    overflow: "hidden",
-                }}
-            >
-                <RNWebView
-                    ref={webviewRef}
-                    source={{ uri: frameUrl }}
-                    globals={secureGlobals}
-                    onLoadEnd={onWebViewLoad}
-                    onMessage={handleMessage}
-                    onError={(syntheticEvent) => {
-                        console.error("[CrossmintWalletProvider] WebView error:", syntheticEvent.nativeEvent);
-                    }}
-                    onHttpError={(syntheticEvent) => {
-                        console.error("[CrossmintWalletProvider] WebView HTTP error:", syntheticEvent.nativeEvent);
-                    }}
-                    onContentProcessDidTerminate={() => webviewRef.current?.reload()}
-                    onRenderProcessGone={() => webviewRef.current?.reload()}
+            {needsWebView && (
+                <View
                     style={{
-                        width: 1,
-                        height: 1,
+                        position: "absolute",
+                        width: 0,
+                        height: 0,
+                        overflow: "hidden",
                     }}
-                    javaScriptCanOpenWindowsAutomatically={false}
-                    thirdPartyCookiesEnabled={false}
-                    sharedCookiesEnabled={false}
-                    incognito={false}
-                    setSupportMultipleWindows={false}
-                    originWhitelist={[environmentUrlConfig[parsedAPIKey.environment]]}
-                    cacheEnabled={true}
-                    cacheMode="LOAD_DEFAULT"
-                />
-            </View>
+                >
+                    <RNWebView
+                        ref={webviewRef}
+                        source={{ uri: frameUrl }}
+                        globals={secureGlobals}
+                        onLoadEnd={onWebViewLoad}
+                        onMessage={handleMessage}
+                        onError={(syntheticEvent) => {
+                            console.error("[CrossmintWalletProvider] WebView error:", syntheticEvent.nativeEvent);
+                        }}
+                        onHttpError={(syntheticEvent) => {
+                            console.error("[CrossmintWalletProvider] WebView HTTP error:", syntheticEvent.nativeEvent);
+                        }}
+                        onContentProcessDidTerminate={() => webviewRef.current?.reload()}
+                        onRenderProcessGone={() => webviewRef.current?.reload()}
+                        style={{
+                            width: 1,
+                            height: 1,
+                        }}
+                        javaScriptCanOpenWindowsAutomatically={false}
+                        thirdPartyCookiesEnabled={false}
+                        sharedCookiesEnabled={false}
+                        incognito={false}
+                        setSupportMultipleWindows={false}
+                        originWhitelist={[environmentUrlConfig[parsedAPIKey.environment]]}
+                        cacheEnabled={true}
+                        cacheMode="LOAD_DEFAULT"
+                    />
+                </View>
+            )}
         </CrossmintWalletBaseProvider>
     );
 }


### PR DESCRIPTION
## Description

This PR optimizes React Native WebView loading performance by implementing conditional initialization. Previously, the WebView component was always rendered and loaded in the background, causing unnecessary resource usage and polling for users who only use passkey or external wallet signers.

The optimization introduces a `needsWebView` state that conditionally renders the WebView only when email or phone signers are detected during wallet creation. This eliminates background WebView polling for users who don't require the Trusted Execution Environment (TEE) connection that email/phone signers depend on.

**Key changes:**
- Added conditional WebView rendering based on signer type detection
- Implemented async WebView initialization with polling mechanism
- Extended the base provider interface to support WebView initialization callback
- Maintained backward compatibility with optional interface additions

## Test plan

- [ ] Test wallet creation with email signer to verify WebView initializes correctly
- [ ] Test wallet creation with phone signer to verify WebView initializes correctly  
- [ ] Test wallet creation with passkey signer to verify WebView is NOT loaded
- [ ] Test wallet creation with external wallet signer to verify WebView is NOT loaded
- [ ] Test error scenarios when WebView fails to initialize within timeout
- [ ] Verify no performance regressions in existing email/phone flows
- [ ] Test in both development and production React Native environments

**Critical areas to review:**
- The polling mechanism in `initializeWebView` (5 second timeout with 50ms intervals)
- Error handling when WebView initialization fails
- useEffect dependency array changes that could cause re-renders
- Conditional rendering logic for WebView component

## Package updates

- `@crossmint/client-sdk-react-native-ui`: patch version bump via changeset
- Added changeset: `.changeset/smart-islands-fail.md`

---
**Link to Devin run:** https://app.devin.ai/sessions/9aa4928b3768493ea27e7c00964caa59  
**Requested by:** @guilleasz-crossmint