### PR TITLE
feat: add chain-specific token balance schemas for WAL-6426

### DIFF
--- a/packages/wallets/src/wallets/types.ts
+++ b/packages/wallets/src/wallets/types.ts
@@ -111,19 +111,22 @@ export type WalletArgsFor<C extends Chain> = {
     delegatedSigners?: Array<DelegatedSigner>;
 };
 
-export type TokenBalance = {
+export type TokenBalance<C extends Chain = Chain> = {
     symbol: "sol" | "eth" | "usdc" | string;
     name: string;
     amount: string;
-    contractAddress?: string;
     decimals?: number;
     rawAmount?: string;
-};
+} & (C extends "solana"
+    ? { mintHash?: string }
+    : C extends "stellar"
+      ? { contractId?: string }
+      : { contractAddress?: string });
 
-export type Balances = {
-    nativeToken: TokenBalance;
-    usdc: TokenBalance;
-    tokens: TokenBalance[];
+export type Balances<C extends Chain = Chain> = {
+    nativeToken: TokenBalance<C>;
+    usdc: TokenBalance<C>;
+    tokens: TokenBalance<C>[];
 };
 
 export type UserLocator =


### PR DESCRIPTION
## Description

This PR implements chain-specific token balance schemas to properly handle different token identification fields across blockchain networks, addressing issue WAL-6426.

**Problem**: The SDK was incorrectly assuming all chains use `contractAddress` for token identification, causing Solana tokens to lose their `mintHash` and Stellar tokens to lose their `contractId`.

**Solution**: 
- Made `TokenBalance` and `Balances` types generic with chain-specific fields
- Updated the balance transformation logic to extract the correct field based on chain type:
  - Solana: `mintHash`
  - Stellar: `contractId` 
  - Other chains: `contractAddress`

**Key Changes**:
- `TokenBalance<C extends Chain = Chain>` with conditional types for chain-specific fields
- `Balances<C extends Chain = Chain>` to use the generic TokenBalance
- Updated `Wallet.balances()` method signature to return `Promise<Balances<C>>`
- Rewrote `transformBalanceResponse` logic to properly extract chain-specific fields
- Updated `createDefaultToken` to initialize correct fields per chain

## Test plan

⚠️ **Testing Limitation**: Local build failed due to pre-existing environment issues (missing imports, chain definitions). The changes passed linting but couldn't be fully tested locally.

**Recommended testing**:
- [ ] Verify types compile correctly in CI
- [ ] Test Solana wallet balance calls return `mintHash` field
- [ ] Test Stellar wallet balance calls return `contractId` field  
- [ ] Test EVM wallet balance calls return `contractAddress` field
- [ ] Verify backward compatibility for existing integrations

## Package updates

This is a breaking change to the `@crossmint/wallets-sdk` types. Consumers will need to update their code if they're using `TokenBalance` or `Balances` types directly.

---

**Human Review Checklist**:
- [ ] Verify the conditional type logic handles all supported chains correctly
- [ ] Check that the `transformTokenBalance` function extracts fields properly for each chain
- [ ] Review the type casting with `as TokenBalance<C>` for type safety
- [ ] Confirm `createDefaultToken` initializes the correct fields for each chain type
- [ ] Validate that this doesn't break existing wallet integrations

Link to Devin run: https://app.devin.ai/sessions/5af76bd32d254a8a8a8b4b8a80532933
Requested by: @guilleasz-crossmint