### PR TITLE
wallets: pre-auth non-custodial signer before tx/signature creation to avoid OTP expiration

### DIFF
--- a/.changeset/nasty-islands-agree.md
+++ b/.changeset/nasty-islands-agree.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+Pre-initialize signer before creating a transaction

--- a/packages/wallets/src/signers/non-custodial/ncs-signer.ts
+++ b/packages/wallets/src/signers/non-custodial/ncs-signer.ts
@@ -155,6 +155,10 @@ export abstract class NonCustodialSigner implements Signer {
         }
     }
 
+    public async ensureAuthenticated(): Promise<void> {
+        await this.handleAuthRequired();
+    }
+
     protected getJwtOrThrow() {
         const jwt = this.config.crossmint.experimental_customAuth?.jwt;
         if (jwt == null) {

--- a/packages/wallets/src/wallets/evm.ts
+++ b/packages/wallets/src/wallets/evm.ts
@@ -41,6 +41,7 @@ export class EVMWallet extends Wallet<EVMChain> {
     public async sendTransaction<T extends EVMTransactionInput>(
         params: T
     ): Promise<Transaction<T["options"] extends PrepareOnly<true> ? true : false>> {
+        await this.preAuthIfNeeded();
         const builtTransaction = this.buildTransaction(params);
         const createdTransaction = await this.createTransaction(builtTransaction, params.options);
 
@@ -58,6 +59,7 @@ export class EVMWallet extends Wallet<EVMChain> {
     public async signMessage<T extends SignMessageInput>(
         params: T
     ): Promise<Signature<T["options"] extends PrepareOnly<true> ? true : false>> {
+        await this.preAuthIfNeeded();
         const signatureCreationResponse = await this.apiClient.createSignature(this.walletLocator, {
             type: "message",
             params: {
@@ -83,6 +85,7 @@ export class EVMWallet extends Wallet<EVMChain> {
     public async signTypedData<T extends SignTypedDataInput>(
         params: T
     ): Promise<Signature<T["options"] extends PrepareOnly<true> ? true : false>> {
+        await this.preAuthIfNeeded();
         const { domain, message, primaryType, types, chain } = params;
         if (!domain || !message || !types || !chain) {
             throw new InvalidTypedDataError("Invalid typed data");

--- a/packages/wallets/src/wallets/solana.ts
+++ b/packages/wallets/src/wallets/solana.ts
@@ -38,6 +38,7 @@ export class SolanaWallet extends Wallet<SolanaChain> {
     public async sendTransaction<T extends TransactionInputOptions | undefined = undefined>(
         params: SolanaTransactionInput
     ): Promise<Transaction<T extends PrepareOnly<true> ? true : false>> {
+        await this.preAuthIfNeeded();
         const createdTransaction = await this.createTransaction(params);
 
         if (params.options?.experimental_prepareOnly) {

--- a/packages/wallets/src/wallets/stellar.ts
+++ b/packages/wallets/src/wallets/stellar.ts
@@ -36,6 +36,7 @@ export class StellarWallet extends Wallet<StellarChain> {
     public async sendTransaction<T extends TransactionInputOptions | undefined = undefined>(
         params: StellarTransactionInput & { options?: T }
     ): Promise<Transaction<T extends PrepareOnly<true> ? true : false>> {
+        await this.preAuthIfNeeded();
         const createdTransaction = await this.createTransaction(params);
 
         if (params.options?.experimental_prepareOnly) {

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -249,6 +249,7 @@ export class Wallet<C extends Chain> {
         amount: string,
         options?: T
     ): Promise<Transaction<T extends PrepareOnly<true> ? true : false>> {
+        await this.preAuthIfNeeded();
         const recipient = toRecipientLocator(to);
         const tokenLocator = toTokenLocator(token, this.chain);
         const sendParams = {
@@ -384,6 +385,15 @@ export class Wallet<C extends Chain> {
                 return `me:solana:smart`;
             } else {
                 return `me:evm:smart`;
+            }
+        }
+    }
+
+    protected async preAuthIfNeeded(): Promise<void> {
+        const signerAny = this.signer as any;
+        if (this.signer.type === "email" || this.signer.type === "phone") {
+            if (typeof signerAny?.ensureAuthenticated === "function") {
+                await signerAny.ensureAuthenticated();
             }
         }
     }

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -42,6 +42,7 @@ import {
 import { STATUS_POLLING_INTERVAL_MS } from "../utils/constants";
 import type { Chain } from "../chains/chains";
 import type { Signer } from "../signers/types";
+import { NonCustodialSigner } from "@/signers/non-custodial";
 
 type WalletContructorType<C extends Chain> = {
     chain: C;
@@ -390,11 +391,8 @@ export class Wallet<C extends Chain> {
     }
 
     protected async preAuthIfNeeded(): Promise<void> {
-        const signerAny = this.signer as any;
-        if (this.signer.type === "email" || this.signer.type === "phone") {
-            if (typeof signerAny?.ensureAuthenticated === "function") {
-                await signerAny.ensureAuthenticated();
-            }
+        if (this.signer instanceof NonCustodialSigner) {
+            await this.signer.ensureAuthenticated();
         }
     }
 

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -42,7 +42,7 @@ import {
 import { STATUS_POLLING_INTERVAL_MS } from "../utils/constants";
 import type { Chain } from "../chains/chains";
 import type { Signer } from "../signers/types";
-import { NonCustodialSigner } from "@/signers/non-custodial";
+import { NonCustodialSigner } from "../signers/non-custodial";
 
 type WalletContructorType<C extends Chain> = {
     chain: C;


### PR DESCRIPTION
## Description

This PR fixes a timing issue with non-custodial signers (email/phone) where OTP authentication was happening after transaction creation, causing transactions to expire during the potentially slow OTP flow.

**Problem**: 
- `sendTransaction()` creates transaction first
- Then calls `signer.signTransaction()` which triggers `handleAuthRequired()` for OTP
- OTP flow can take minutes, causing the transaction to expire before approval

**Solution**:
- Added `ensureAuthenticated()` method to `NonCustodialSigner` that triggers OTP flow
- Added `preAuthIfNeeded()` guard in base `Wallet` class that calls authentication for email/phone signers
- Call pre-auth at the start of all transaction/signature creation methods before creating the transaction

This ensures OTP authentication completes before any network requests that create expiring transactions or signatures.

## Test plan

Ran the quickstart app and performed a transaction. Checked that the onboarding was completed before the transaction was created

## Key areas for review

* **Type safety**: Uses duck typing with `(signer as any).ensureAuthenticated()` - verify this approach is robust
* **Idempotency**: Confirm `handleAuthRequired()` is safe to call multiple times and before normal flow
* **Coverage**: Verify all transaction/signature creation paths include pre-auth (EVM signMessage/signTypedData, Solana/Stellar sendTransaction, base send)
* **Regressions**: Test that API key and other non-OTP signers aren't negatively impacted by the pre-auth check

## Package updates

No package updates required - this is an internal logic change only.

---

**Link to Devin run**: https://app.devin.ai/sessions/ea79dd228de2476683402d2928ec2ea8  
**Requested by**: Alberto García (@alberto-crossmint)