### PR TITLE
feat(wallets): add serialized transaction support for Solana

### DIFF
--- a/.changeset/lazy-pandas-burn.md
+++ b/.changeset/lazy-pandas-burn.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": minor
+---
+
+Add serialized transaction support for Solana wallets

--- a/packages/wallets/src/wallets/solana.ts
+++ b/packages/wallets/src/wallets/solana.ts
@@ -50,22 +50,18 @@ export class SolanaWallet extends Wallet<SolanaChain> {
             } as Transaction<T extends PrepareOnly<true> ? true : false>;
         }
 
-        let _additionalSigners: SolanaExternalWalletSigner[] | undefined;
-
-        if ("transaction" in params && params.additionalSigners) {
-            _additionalSigners = params.additionalSigners.map(
-                (signer) =>
-                    new SolanaExternalWalletSigner({
-                        type: "external-wallet",
-                        address: signer.publicKey.toString(),
-                        locator: `external-wallet:${signer.publicKey.toString()}`,
-                        onSignTransaction: (transaction: VersionedTransaction) => {
-                            transaction.sign([signer]);
-                            return Promise.resolve(transaction);
-                        },
-                    })
-            );
-        }
+        const _additionalSigners = params.additionalSigners?.map(
+            (signer) =>
+                new SolanaExternalWalletSigner({
+                    type: "external-wallet",
+                    address: signer.publicKey.toString(),
+                    locator: `external-wallet:${signer.publicKey.toString()}`,
+                    onSignTransaction: (transaction: VersionedTransaction) => {
+                        transaction.sign([signer]);
+                        return Promise.resolve(transaction);
+                    },
+                })
+        );
 
         const options: ApproveOptions = {
             additionalSigners: _additionalSigners,

--- a/packages/wallets/src/wallets/solana.ts
+++ b/packages/wallets/src/wallets/solana.ts
@@ -1,6 +1,5 @@
 import bs58 from "bs58";
 import { isValidSolanaAddress } from "@crossmint/common-sdk-base";
-import type { VersionedTransaction } from "@solana/web3.js";
 import type { Chain, SolanaChain } from "../chains/chains";
 import type {
     ApproveOptions,
@@ -56,7 +55,7 @@ export class SolanaWallet extends Wallet<SolanaChain> {
                     type: "external-wallet",
                     address: signer.publicKey.toString(),
                     locator: `external-wallet:${signer.publicKey.toString()}`,
-                    onSignTransaction: (transaction: VersionedTransaction) => {
+                    onSignTransaction: (transaction) => {
                         transaction.sign([signer]);
                         return Promise.resolve(transaction);
                     },

--- a/packages/wallets/src/wallets/solana.ts
+++ b/packages/wallets/src/wallets/solana.ts
@@ -1,5 +1,6 @@
 import bs58 from "bs58";
 import { isValidSolanaAddress } from "@crossmint/common-sdk-base";
+import type { VersionedTransaction } from "@solana/web3.js";
 import type { Chain, SolanaChain } from "../chains/chains";
 import type {
     ApproveOptions,
@@ -49,18 +50,22 @@ export class SolanaWallet extends Wallet<SolanaChain> {
             } as Transaction<T extends PrepareOnly<true> ? true : false>;
         }
 
-        const _additionalSigners = params.additionalSigners?.map(
-            (signer) =>
-                new SolanaExternalWalletSigner({
-                    type: "external-wallet",
-                    address: signer.publicKey.toString(),
-                    locator: `external-wallet:${signer.publicKey.toString()}`,
-                    onSignTransaction: (transaction) => {
-                        transaction.sign([signer]);
-                        return Promise.resolve(transaction);
-                    },
-                })
-        );
+        let _additionalSigners: SolanaExternalWalletSigner[] | undefined;
+
+        if ("transaction" in params && params.additionalSigners) {
+            _additionalSigners = params.additionalSigners.map(
+                (signer) =>
+                    new SolanaExternalWalletSigner({
+                        type: "external-wallet",
+                        address: signer.publicKey.toString(),
+                        locator: `external-wallet:${signer.publicKey.toString()}`,
+                        onSignTransaction: (transaction: VersionedTransaction) => {
+                            transaction.sign([signer]);
+                            return Promise.resolve(transaction);
+                        },
+                    })
+            );
+        }
 
         const options: ApproveOptions = {
             additionalSigners: _additionalSigners,
@@ -69,14 +74,20 @@ export class SolanaWallet extends Wallet<SolanaChain> {
         return await this.approveTransactionAndWait(createdTransaction.id, options);
     }
 
-    private async createTransaction({
-        transaction,
-        options,
-    }: SolanaTransactionInput): Promise<CreateTransactionSuccessResponse> {
-        const signer = options?.experimental_signer ?? this.signer.locator();
+    private async createTransaction(params: SolanaTransactionInput): Promise<CreateTransactionSuccessResponse> {
+        const signer = params.options?.experimental_signer ?? this.signer.locator();
+
+        let serializedTransaction: string;
+
+        if ("serializedTransaction" in params) {
+            serializedTransaction = params.serializedTransaction;
+        } else {
+            serializedTransaction = bs58.encode(params.transaction.serialize());
+        }
+
         const transactionCreationResponse = await this.apiClient.createTransaction(this.walletLocator, {
             params: {
-                transaction: bs58.encode(transaction.serialize()),
+                transaction: serializedTransaction,
                 signer,
             },
         });

--- a/packages/wallets/src/wallets/types.ts
+++ b/packages/wallets/src/wallets/types.ts
@@ -68,12 +68,12 @@ export type StellarTransactionInput = (
 export type SolanaTransactionInput = (
     | {
           transaction: VersionedTransaction;
-          additionalSigners?: Keypair[];
       }
     | {
           serializedTransaction: string;
       }
 ) & {
+    additionalSigners?: Keypair[];
     options?: TransactionInputOptions;
 };
 

--- a/packages/wallets/src/wallets/types.ts
+++ b/packages/wallets/src/wallets/types.ts
@@ -65,9 +65,15 @@ export type StellarTransactionInput = (
     options?: TransactionInputOptions;
 };
 
-export type SolanaTransactionInput = {
-    transaction: VersionedTransaction;
-    additionalSigners?: Keypair[];
+export type SolanaTransactionInput = (
+    | {
+          transaction: VersionedTransaction;
+          additionalSigners?: Keypair[];
+      }
+    | {
+          serializedTransaction: string;
+      }
+) & {
     options?: TransactionInputOptions;
 };
 


### PR DESCRIPTION
## Description

Adds support for serialized transaction input to Solana wallets, following the pattern recently established for Stellar wallets. This enables users to pass either a `VersionedTransaction` object (existing behavior) or a pre-serialized base58 string (new behavior), maintaining full backward compatibility.

**Key changes:**
- Updated `SolanaTransactionInput` type to accept a union of `{ transaction: VersionedTransaction }` or `{ serializedTransaction: string }`
- Modified `createTransaction` method to conditionally handle serialization based on input format
- Moved `additionalSigners` to be available for both transaction variants (per reviewer feedback that serialized transactions may also need additional signing)
- Added changeset for minor version bump

This addresses use cases where transactions are pre-serialized by external systems (e.g., Fireblocks, other wallets) or when working with Solana smart wallets where input transactions get wrapped in additional metalogic.

**⚠️ Critical Review Points:**
- **Union type safety**: Verify the discriminated union correctly handles both input variants without TypeScript/runtime errors
- **API compatibility**: Confirm both paths produce identical backend API calls (base58 encoded transaction string)
- **Additional signers logic**: Validate that `additionalSigners` works correctly for both `VersionedTransaction` and `serializedTransaction` variants
- **Backward compatibility**: Test that existing code using `VersionedTransaction` continues to work unchanged
- **End-to-end flow**: Manual testing required since no automated tests were added for the serialized path

## Test plan

* Manual testing required for both transaction input formats
* Verify existing `VersionedTransaction` usage remains functional (backward compatibility)
* Test `serializedTransaction` input with base58 encoded strings
* Validate `additionalSigners` functionality for both variants
* No automated tests added - **manual verification critical**

## Package updates

* `@crossmint/wallets-sdk`: minor version bump
* Changeset added: `.changeset/lazy-pandas-burn.md`

---
*Requested by: @guilleasz-crossmint*  
*Devin session: https://app.devin.ai/sessions/0f0e00406d634a9c97cb74d3eabcb70b*