### PR TITLE
feat(wallets): add prepareOnly support to addDelegatedSigner

### DIFF
--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -341,8 +341,15 @@ export class Wallet<C extends Chain> {
     /**
      * Add a delegated signer to the wallet
      * @param signer - The signer. For Solana, it must be a string. For EVM, it can be a string or a passkey.
+     * @param options - The options for the operation
+     * @param options.experimental_prepareOnly - If true, returns the transaction/signature ID without auto-approving
      */
-    public async addDelegatedSigner(params: { signer: string | RegisterSignerPasskeyParams }) {
+    public async addDelegatedSigner<T extends { experimental_prepareOnly?: boolean } | undefined = undefined>(params: {
+        signer: string | RegisterSignerPasskeyParams;
+        options?: T;
+    }): Promise<
+        T extends { experimental_prepareOnly: true } ? { transactionId?: string; signatureId?: string } : void
+    > {
         const response = await this.#apiClient.registerSigner(this.walletLocator, {
             signer: params.signer,
             chain: this.chain === "solana" || this.chain === "stellar" ? undefined : this.chain,
@@ -355,19 +362,35 @@ export class Wallet<C extends Chain> {
         if ("transaction" in response && response.transaction != null) {
             // Solana has "transaction" in response
             const transactionId = response.transaction.id;
+
+            if (params.options?.experimental_prepareOnly) {
+                return { transactionId } as any;
+            }
+
             await this.approveTransactionAndWait(transactionId);
-        } else if ("chains" in response) {
+            return undefined as any;
+        }
+
+        if ("chains" in response) {
             // EVM has "chains" in response
             const chainResponse = response.chains?.[this.chain];
+
+            if (params.options?.experimental_prepareOnly) {
+                const signatureId = chainResponse?.status !== "success" ? chainResponse?.id : undefined;
+                return { signatureId } as any;
+            }
+
             if (chainResponse?.status === "awaiting-approval") {
                 await this.approveSignatureAndWait(chainResponse.id);
-                return;
+                return undefined as any;
             }
             if (chainResponse?.status === "pending") {
                 await this.waitForSignature(chainResponse.id);
-                return;
+                return undefined as any;
             }
         }
+
+        return undefined as any;
     }
 
     public async delegatedSigners(): Promise<DelegatedSigner[]> {


### PR DESCRIPTION
## Description

Implements `prepareOnly` support for the `addDelegatedSigner` method to enable flexible, chain-agnostic approval workflows as requested in WAL-5527.

**Key changes:**
- Adds `experimental_prepareOnly` option to `addDelegatedSigner` method signature
- When `prepareOnly` is `true`, returns either `{ transactionId }` (Solana) or `{ signatureId }` (EVM) without auto-approval
- When `prepareOnly` is `false`/`undefined`, maintains existing auto-approval behavior
- Follows the same pattern as existing `send`, `signMessage`, and `signTypedData` methods

**Usage:**
```typescript
// Prepare only - returns ID for later approval
const result = await wallet.addDelegatedSigner({
    signer: "0x...",
    options: { experimental_prepareOnly: true }
});

// Approve later (automatically detects transaction vs signature)
await wallet.approve(result);
```

**⚠️ Review Focus Areas:**
1. **EVM status logic**: Line 379 has `chainResponse?.status !== "success" ? chainResponse?.id : undefined` - when would status be "success" and is returning `undefined` signatureId correct?
2. **Type safety**: Complex generic conditional types with `as any` assertions - are we handling all edge cases properly?
3. **Testing**: Should we add dedicated tests for the prepareOnly functionality?

Link to Devin run: https://app.devin.ai/sessions/27d0a95581af40ec95db715157a017d1  
Requested by: @guilleasz-crossmint

## Test plan

- Existing unit tests pass (21/21) - validates no regression in current functionality
- Build and lint checks pass
- Manual verification needed for:
  - EVM chain responses with different status values ("success", "pending", "awaiting-approval") 
  - Integration with existing `approve` method for both `transactionId` and `signatureId`
  - Type safety with TypeScript in consuming applications

## Package updates

No package dependencies changed. This is purely a feature addition to the existing `@crossmint/wallets-sdk` package.