### PR TITLE
Security: Override axios to 1.12.0 to fix DoS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     },
     "pnpm": {
         "overrides": {
-            "axios@0": "0.30.0",
+            "axios@0": "1.12.0",
             "elliptic@6": "6.6.1",
             "form-data@3": "3.0.4",
             "form-data@4": "4.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  axios@0: 0.30.0
+  axios@0: 1.12.0
   elliptic@6: 6.6.1
   form-data@3: 3.0.4
   form-data@4: 4.0.4


### PR DESCRIPTION
## Description

This PR addresses a Dependabot security alert for axios by updating the package override from version 0.30.0 to 1.12.0. The DoS vulnerability in older axios versions is resolved by this upgrade.

**Dependabot Alert**: https://github.com/Crossmint/crossmint-sdk/security/dependabot/364

The change updates the pnpm override for `axios@0` in package.json and regenerates the lock file accordingly.

**⚠️ Important**: This is a major version jump from axios 0.x to 1.x, which may introduce breaking changes in packages that depend on axios@0.

## Test plan

- [ ] **Critical**: Run full test suite (`pnpm test:vitest`) to verify no functionality is broken
- [ ] **Critical**: Manual testing of key workflows that use HTTP requests/axios
- [ ] Verify that all packages using axios@0 override still function correctly
- [ ] Check for any runtime errors in applications after the upgrade

## Package updates

- Updated `axios@0` override from `0.30.0` to `1.12.0` in package.json
- Regenerated pnpm-lock.yaml to reflect the override change

**Human Review Checklist**:
- [ ] Test suite passes completely
- [ ] No breaking changes in packages that depend on axios@0  
- [ ] HTTP functionality works as expected across all applications
- [ ] No new runtime errors introduced

---
**Link to Devin run**: https://app.devin.ai/sessions/bf609251d888444a94f5721a1ad5292c  
**Requested by**: @soinclined