### PR TITLE
feat: append chain suffix to user locators in transfer function

### DIFF
--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -275,7 +275,7 @@ export class Wallet<C extends Chain> {
         options?: T
     ): Promise<Transaction<T extends PrepareOnly<true> ? true : false>> {
         await this.preAuthIfNeeded();
-        const recipient = toRecipientLocator(to);
+        const recipient = toRecipientLocator(to, this.chain);
         const tokenLocator = toTokenLocator(token, this.chain);
         const sendParams = {
             recipient,
@@ -692,24 +692,24 @@ export class Wallet<C extends Chain> {
     }
 }
 
-function toRecipientLocator(to: string | UserLocator): string {
+function toRecipientLocator(to: string | UserLocator, chain: string): string {
     if (typeof to === "string") {
         return to;
     }
     if ("email" in to) {
-        return `email:${to.email}`;
+        return `email:${to.email}:${chain}`;
     }
     if ("x" in to) {
-        return `x:${to.x}`;
+        return `x:${to.x}:${chain}`;
     }
     if ("twitter" in to) {
-        return `twitter:${to.twitter}`;
+        return `twitter:${to.twitter}:${chain}`;
     }
     if ("phone" in to) {
-        return `phoneNumber:${to.phone}`;
+        return `phoneNumber:${to.phone}:${chain}`;
     }
     if ("userId" in to) {
-        return `userId:${to.userId}`;
+        return `userId:${to.userId}:${chain}`;
     }
     throw new Error("Invalid recipient locator");
 }


### PR DESCRIPTION
## Description

This change updates the SDK's `toRecipientLocator` function to append chain suffixes for user-based locators (email, Twitter, phone, etc.) to match the API's expected format for cross-chain recipient targeting.

**Background:** The backend API already supports sending to email and Twitter recipients but expects locators in the format `email:user@example.com:chain` and `twitter:@handle:chain`. The SDK was previously generating locators without the chain suffix, potentially causing routing issues.

**Changes:**
- Modified `toRecipientLocator` to accept a `chain` parameter
- Updated all user-based locator types to append `:${chain}` suffix
- Updated the `send` method to pass `this.chain` to the locator function
- String addresses (wallet addresses) remain unchanged

## Test plan

* Existing wallet tests should continue to pass
* Manual testing recommended with email and Twitter recipients across different chains
* Verify string address recipients still work unchanged
* **Note:** Pre-existing TypeScript build errors in signer modules are unrelated to this change

## Package updates

* `@crossmint/wallets-sdk` - Function signature change for internal `toRecipientLocator` helper
* No public API changes - this is an internal function modification

---

**Human review checklist:**
- [ ] Verify the backend API expects exactly `type:value:chain` format for user locators
- [ ] Confirm `this.chain` is always defined when `send()` is called
- [ ] Test that string address recipients continue working unchanged
- [ ] Check no other callers of `toRecipientLocator` exist beyond the `send` method

Link to Devin run: https://app.devin.ai/sessions/820a413673804a0e92bd249b75ac7be7  
Requested by: @guilleasz-crossmint