### PR TITLE
Add DeepWiki badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ pnpm install
 4. A "Release packages" PR will be created automatically
 5. Merge the release PR to publish to NPM
 
-## Documentation
+## Documentation <a href="https://deepwiki.com/Crossmint/crossmint-sdk"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
 
 For detailed documentation and guides, visit our [official documentation](https://docs.crossmint.com/).
 


### PR DESCRIPTION
Updated documentation section with a badge link to auto update documentation on deepwiki.

## Description
Add a badge to auto update the documentation on deepwiki

## Test plan

Visit https://deepwiki.com/Crossmint/crossmint-sdk to verify the date of the most recent update.
<img width="598" height="292" alt="image" src="https://github.com/user-attachments/assets/7ccf2e18-b02d-4ff1-8089-d76bcfd56e45" />


## Package updates
README.md