### PR TITLE
fix: verify JWT audience on legacy cookie refresh to prevent cross-project usage

### DIFF
--- a/.changeset/fix-legacy-cookie-migration.md
+++ b/.changeset/fix-legacy-cookie-migration.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-auth": patch
+---
+
+Fix legacy cookie fallback causing cross-project token usage. Legacy unscoped cookies are now migrated to scoped cookies on first use and then deleted, preventing a different project on the same domain from picking them up.

--- a/packages/client/auth/src/CrossmintAuthClient.ts
+++ b/packages/client/auth/src/CrossmintAuthClient.ts
@@ -96,9 +96,9 @@ export class CrossmintAuthClient extends CrossmintAuth {
         ]);
     }
 
-    public async logout() {
-        // Store the old refresh token to pass it to the logout route before deleting the storage
-        const oldRefreshToken = await this.storageProvider.get(REFRESH_TOKEN_PREFIX);
+    public async logout(knownRefreshToken?: string) {
+        // Use the provided refresh token (e.g. from audience-mismatch path) or read from storage
+        const oldRefreshToken = knownRefreshToken ?? (await this.storageProvider.get(REFRESH_TOKEN_PREFIX));
 
         // Even if there's a server error, we want to clear the storage and we do it first to load faster
         await Promise.all([
@@ -143,12 +143,14 @@ export class CrossmintAuthClient extends CrossmintAuth {
                 const audience = getJWTAudience(authMaterial.jwt);
                 const expectedProjectId = this.storageProvider.getProjectId();
                 if (audience != null && audience !== expectedProjectId) {
-                    // JWT is for a different project — don't store, clean up and logout
+                    // JWT is for a different project — don't store, clean up and logout.
+                    // Capture the refresh token before cleanup so logout() can revoke it server-side.
+                    const staleRefreshToken = refreshToken;
                     console.debug(
                         `[CrossmintAuthClient] JWT audience "${audience}" does not match current project "${expectedProjectId}". Logging out.`
                     );
                     this.storageProvider.deleteLegacyCookies();
-                    await this.logout();
+                    await this.logout(staleRefreshToken);
                     return null;
                 }
                 if (this.refreshRoute == null) {

--- a/packages/client/auth/src/CrossmintAuthClient.ts
+++ b/packages/client/auth/src/CrossmintAuthClient.ts
@@ -151,9 +151,10 @@ export class CrossmintAuthClient extends CrossmintAuth {
                     await this.logout();
                     return null;
                 }
-                // Audience matches (or is absent) — safe to store. Clean up legacy cookies.
-                this.storageProvider.deleteLegacyCookies();
-            }
+                if (this.refreshRoute == null) {
+                    // Audience matches (or is absent) — safe to store. Clean up legacy cookies.
+                    this.storageProvider.deleteLegacyCookies();
+                }
 
             // If a custom refresh route is set, storing in cookies is handled in the server
             if (this.refreshRoute == null) {

--- a/packages/client/auth/src/CrossmintAuthClient.ts
+++ b/packages/client/auth/src/CrossmintAuthClient.ts
@@ -11,8 +11,8 @@ import {
 } from "@crossmint/common-sdk-auth";
 import type { Crossmint, CrossmintApiClient } from "@crossmint/common-sdk-base";
 import { type CancellableTask, queueTask } from "@crossmint/client-sdk-base";
-import { getJWTExpiration, TIME_BEFORE_EXPIRING_JWT_IN_SECONDS } from "./utils";
-import { type StorageProvider, getScopedStorageProvider } from "./utils/storage";
+import { getJWTExpiration, getJWTAudience, TIME_BEFORE_EXPIRING_JWT_IN_SECONDS } from "./utils";
+import { type StorageProvider, ScopedCookieStorage, getScopedStorageProvider } from "./utils/storage";
 
 // Global flag to prevent multiple concurrent initial refresh calls across all instances
 let globalInitialRefreshInProgress = false;
@@ -136,6 +136,24 @@ export class CrossmintAuthClient extends CrossmintAuth {
 
             // Await the shared promise - this handles concurrent calls to the same refresh
             const authMaterial = await this.refreshPromise;
+
+            // If the refresh token came from a legacy unscoped cookie, verify that
+            // the returned JWT belongs to the current project before storing it.
+            if (this.storageProvider instanceof ScopedCookieStorage) {
+                const audience = getJWTAudience(authMaterial.jwt);
+                const expectedProjectId = this.storageProvider.getProjectId();
+                if (audience != null && audience !== expectedProjectId) {
+                    // JWT is for a different project — don't store, clean up and logout
+                    console.debug(
+                        `[CrossmintAuthClient] JWT audience "${audience}" does not match current project "${expectedProjectId}". Logging out.`
+                    );
+                    this.storageProvider.deleteLegacyCookies();
+                    await this.logout();
+                    return null;
+                }
+                // Audience matches (or is absent) — safe to store. Clean up legacy cookies.
+                this.storageProvider.deleteLegacyCookies();
+            }
 
             // If a custom refresh route is set, storing in cookies is handled in the server
             if (this.refreshRoute == null) {

--- a/packages/client/auth/src/CrossmintAuthClient.ts
+++ b/packages/client/auth/src/CrossmintAuthClient.ts
@@ -155,6 +155,7 @@ export class CrossmintAuthClient extends CrossmintAuth {
                     // Audience matches (or is absent) — safe to store. Clean up legacy cookies.
                     this.storageProvider.deleteLegacyCookies();
                 }
+            }
 
             // If a custom refresh route is set, storing in cookies is handled in the server
             if (this.refreshRoute == null) {

--- a/packages/client/auth/src/utils/jwt.ts
+++ b/packages/client/auth/src/utils/jwt.ts
@@ -4,3 +4,16 @@ export function getJWTExpiration(token: string) {
     const decoded = jwtDecode(token);
     return decoded.exp;
 }
+
+export function getJWTAudience(token: string): string | undefined {
+    try {
+        const decoded = jwtDecode(token);
+        const aud = decoded.aud;
+        if (Array.isArray(aud)) {
+            return aud[0];
+        }
+        return aud;
+    } catch {
+        return undefined;
+    }
+}

--- a/packages/client/auth/src/utils/storage.ts
+++ b/packages/client/auth/src/utils/storage.ts
@@ -1,5 +1,5 @@
 import { validateAPIKey } from "@crossmint/common-sdk-base";
-import { REFRESH_TOKEN_PREFIX } from "@crossmint/common-sdk-auth";
+import { REFRESH_TOKEN_PREFIX, SESSION_PREFIX } from "@crossmint/common-sdk-auth";
 import { deleteCookie, getCookie, setCookie } from "./cookies";
 
 export interface StorageProvider {
@@ -55,13 +55,13 @@ export function getProjectIdFromApiKey(apiKey: string | undefined | null): strin
  * Cookie storage that scopes cookies by project ID.
  * This prevents JWT conflicts when switching between different projects.
  *
- * For JWTs: Only reads from scoped cookies to prevent using wrong project's JWT.
- * For refresh tokens: Falls back to legacy cookies to allow migration.
- * If a legacy refresh token is used with the wrong project, the server will reject it
- * and the SDK will call logout(), cleaning up the legacy cookie.
+ * On first use, migrates any legacy unscoped cookies to the scoped format
+ * for the current project, then deletes the legacy cookies so they are
+ * never picked up by a different project on the same domain.
  */
 export class ScopedCookieStorage implements StorageProvider {
     private projectId: string;
+    private migrationDone = false;
 
     constructor(apiKey: string) {
         this.projectId = getProjectIdFromApiKey(apiKey);
@@ -71,24 +71,40 @@ export class ScopedCookieStorage implements StorageProvider {
         return `${key}-${this.projectId}`;
     }
 
+    /**
+     * One-time migration: if scoped cookies don't exist yet but legacy unscoped
+     * cookies do, copy them into the scoped keys and delete the legacy ones.
+     * This runs at most once per ScopedCookieStorage instance.
+     */
+    private migrateLegacyCookies(): void {
+        if (this.migrationDone || typeof document === "undefined") {
+            return;
+        }
+        this.migrationDone = true;
+
+        for (const key of [SESSION_PREFIX, REFRESH_TOKEN_PREFIX]) {
+            const scopedKey = this.getScopedKey(key);
+            const scopedValue = getCookie(scopedKey);
+            if (scopedValue != null) {
+                // Scoped cookie already exists — no migration needed for this key
+                continue;
+            }
+            const legacyValue = getCookie(key);
+            if (legacyValue != null) {
+                // Migrate: copy to scoped key, then remove legacy cookie
+                setCookie(scopedKey, legacyValue);
+                deleteCookie(key);
+            }
+        }
+    }
+
     async get(key: string): Promise<string | undefined> {
         if (typeof document === "undefined") {
             console.debug(`[ScopedCookieStorage] Skipping cookie read for "${key}" - document is undefined (SSR)`);
             return undefined;
         }
-        // First try the scoped cookie
-        const scopedValue = await getCookie(this.getScopedKey(key));
-        if (scopedValue != null) {
-            return scopedValue;
-        }
-        // Only fall back to legacy cookies for refresh tokens, not JWTs.
-        // This prevents using a JWT from the wrong project (which causes audience mismatch warnings).
-        // For refresh tokens, if the legacy token is for a different project, the server will reject
-        // the refresh attempt and the SDK will call logout(), cleaning up the legacy cookie.
-        if (key === REFRESH_TOKEN_PREFIX) {
-            return await getCookie(key);
-        }
-        return undefined;
+        this.migrateLegacyCookies();
+        return getCookie(this.getScopedKey(key));
     }
 
     async set(key: string, value: string, expiresAt?: string): Promise<void> {
@@ -103,7 +119,7 @@ export class ScopedCookieStorage implements StorageProvider {
         if (typeof document === "undefined") {
             return;
         }
-        // Remove scoped cookie (also remove legacy cookie for cleanup during logout)
+        // Remove scoped cookie (also remove legacy cookie for cleanup)
         await deleteCookie(this.getScopedKey(key));
         await deleteCookie(key);
     }

--- a/packages/client/auth/src/utils/storage.ts
+++ b/packages/client/auth/src/utils/storage.ts
@@ -59,8 +59,8 @@ export function getProjectIdFromApiKey(apiKey: string | undefined | null): strin
  * falls back to legacy unscoped cookies so the token can be sent to the
  * server for validation. The caller (CrossmintAuthClient) is responsible
  * for verifying the JWT audience after refresh and calling
- * `completeLegacyMigration()` to promote the legacy cookies to scoped
- * ones and delete the originals.
+ * `deleteLegacyCookies()` to clean up the legacy cookies once the
+ * audience has been verified.
  */
 export class ScopedCookieStorage implements StorageProvider {
     private projectId: string;

--- a/packages/client/auth/src/utils/storage.ts
+++ b/packages/client/auth/src/utils/storage.ts
@@ -55,47 +55,26 @@ export function getProjectIdFromApiKey(apiKey: string | undefined | null): strin
  * Cookie storage that scopes cookies by project ID.
  * This prevents JWT conflicts when switching between different projects.
  *
- * On first use, migrates any legacy unscoped cookies to the scoped format
- * for the current project, then deletes the legacy cookies so they are
- * never picked up by a different project on the same domain.
+ * For reads: scoped cookies are checked first. For refresh tokens only,
+ * falls back to legacy unscoped cookies so the token can be sent to the
+ * server for validation. The caller (CrossmintAuthClient) is responsible
+ * for verifying the JWT audience after refresh and calling
+ * `completeLegacyMigration()` to promote the legacy cookies to scoped
+ * ones and delete the originals.
  */
 export class ScopedCookieStorage implements StorageProvider {
     private projectId: string;
-    private migrationDone = false;
 
     constructor(apiKey: string) {
         this.projectId = getProjectIdFromApiKey(apiKey);
     }
 
-    private getScopedKey(key: string): string {
-        return `${key}-${this.projectId}`;
+    public getProjectId(): string {
+        return this.projectId;
     }
 
-    /**
-     * One-time migration: if scoped cookies don't exist yet but legacy unscoped
-     * cookies do, copy them into the scoped keys and delete the legacy ones.
-     * This runs at most once per ScopedCookieStorage instance.
-     */
-    private migrateLegacyCookies(): void {
-        if (this.migrationDone || typeof document === "undefined") {
-            return;
-        }
-        this.migrationDone = true;
-
-        for (const key of [SESSION_PREFIX, REFRESH_TOKEN_PREFIX]) {
-            const scopedKey = this.getScopedKey(key);
-            const scopedValue = getCookie(scopedKey);
-            if (scopedValue != null) {
-                // Scoped cookie already exists — no migration needed for this key
-                continue;
-            }
-            const legacyValue = getCookie(key);
-            if (legacyValue != null) {
-                // Migrate: copy to scoped key, then remove legacy cookie
-                setCookie(scopedKey, legacyValue);
-                deleteCookie(key);
-            }
-        }
+    private getScopedKey(key: string): string {
+        return `${key}-${this.projectId}`;
     }
 
     async get(key: string): Promise<string | undefined> {
@@ -103,8 +82,18 @@ export class ScopedCookieStorage implements StorageProvider {
             console.debug(`[ScopedCookieStorage] Skipping cookie read for "${key}" - document is undefined (SSR)`);
             return undefined;
         }
-        this.migrateLegacyCookies();
-        return getCookie(this.getScopedKey(key));
+        // First try the scoped cookie
+        const scopedValue = getCookie(this.getScopedKey(key));
+        if (scopedValue != null) {
+            return scopedValue;
+        }
+        // Only fall back to legacy cookies for refresh tokens, not JWTs.
+        // The refresh token is sent to the server, which returns a JWT whose
+        // audience is then verified by the caller before storing.
+        if (key === REFRESH_TOKEN_PREFIX) {
+            return getCookie(key);
+        }
+        return undefined;
     }
 
     async set(key: string, value: string, expiresAt?: string): Promise<void> {
@@ -122,6 +111,23 @@ export class ScopedCookieStorage implements StorageProvider {
         // Remove scoped cookie (also remove legacy cookie for cleanup)
         await deleteCookie(this.getScopedKey(key));
         await deleteCookie(key);
+    }
+
+    /**
+     * Delete legacy unscoped cookies after a successful, verified refresh.
+     * Called by CrossmintAuthClient once the JWT audience has been confirmed
+     * to match the current project.
+     */
+    deleteLegacyCookies(): void {
+        if (typeof document === "undefined") {
+            return;
+        }
+        for (const key of [SESSION_PREFIX, REFRESH_TOKEN_PREFIX]) {
+            // Only delete if the legacy cookie actually exists
+            if (getCookie(key) != null) {
+                deleteCookie(key);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Description

Follows up on #1546 (scoped JWT cookies). The previous implementation fell back to reading legacy unscoped `crossmint-refresh-token` cookies when no scoped cookie existed. This caused a bug when two apps with different Crossmint projects run on the same domain (common during local development): the second app would pick up the first app's unscoped refresh token, refresh successfully, and receive a JWT for the wrong project.

This PR keeps the legacy fallback for refresh tokens but adds **JWT audience verification** after refresh. When `handleRefreshAuthMaterial` receives a new JWT, it checks whether the `aud` claim matches the current project ID:

- **Audience matches** → store the scoped cookies normally, then delete legacy unscoped cookies (seamless migration, no logout)
- **Audience doesn't match** → don't store, delete legacy cookies, revoke the token server-side, and logout (prevents cross-project token usage)
- **No `aud` claim** → treated as a match (allows migration for JWTs issued before audience was added)

### Changes
- **`jwt.ts`**: Added `getJWTAudience(token)` helper — decodes the JWT and returns the `aud` claim (first element if array, string otherwise, `undefined` on decode failure)
- **`storage.ts`**: Added `getProjectId()` accessor and `deleteLegacyCookies()` method to `ScopedCookieStorage` — deletes legacy unscoped `crossmint-jwt` and `crossmint-refresh-token` cookies. Updated docstring to clarify that audience verification is the caller's responsibility.
- **`CrossmintAuthClient.ts`**:
  - After `refreshAuthMaterial()` resolves, verify JWT audience against the current project before storing
  - Legacy cookie cleanup on the happy path is gated behind `this.refreshRoute == null` — when a custom refresh route is used, the server writes unscoped cookies via `Set-Cookie` headers, so deleting them client-side would break auth
  - On audience mismatch, the refresh token is captured before cookie deletion and passed directly to `logout()` so the server can revoke it
  - `logout()` accepts an optional `knownRefreshToken` parameter for this purpose

### Human review checklist
- [ ] **`getJWTAudience` array handling**: For array-valued `aud` claims, only the first element is returned (`aud[0]`). If JWTs can legitimately have the project ID at a non-zero index, this would cause a false mismatch. Consider whether `jwtAudienceMatches(token, expected)` (checking `aud.includes(expected)`) would be more robust per RFC 7519 §4.1.3.
- [ ] **JWT without `aud` claim**: If `aud` is absent, `getJWTAudience` returns `undefined` and the audience check is skipped — legacy cookies are migrated. Verify this is acceptable for JWTs issued before audience was added.
- [ ] **`getJWTAudience` on decode failure**: A malformed token returns `undefined` (permissive — treated as "no audience"). In practice `storeAuthMaterial` would also fail for the same malformed token, but worth noting.
- [ ] **Token revocation targets the consumed credential**: On mismatch, `staleRefreshToken` is the token *sent to* the server, not the newly-issued one in `authMaterial.refreshToken`. If the server rotates tokens on use, the old one is already invalidated and the new one is never revoked. Confirm whether the server's rotation policy makes this acceptable.
- [ ] **`onLogout` callback errors propagate**: A throwing `onLogout` callback will propagate to the outer `catch` in `handleRefreshAuthMaterial`, which calls `logout()` again (double-logout). Consider wrapping `this.callbacks.onLogout?.()` in a try-catch if this is a concern.
- [ ] **`deleteLegacyCookies` scope**: Only deletes the two exact legacy unscoped keys (`crossmint-jwt`, `crossmint-refresh-token`). It does **not** clean up scoped cookies from other projects — those will accumulate if multiple projects run on the same domain.
- [ ] **Custom refresh route**: On the happy path, `deleteLegacyCookies()` is skipped when `refreshRoute != null` (server manages cookies). On the audience-mismatch path it still runs unconditionally — this is intentional since the user is being logged out entirely.
- [ ] **`logout()` signature change**: Now accepts an optional `knownRefreshToken` param. Backward compatible, but worth noting for any subclass overrides.
- [ ] **No new unit tests** for `getJWTAudience`, the audience verification block in `handleRefreshAuthMaterial`, or `deleteLegacyCookies` — existing tests pass but don't exercise these code paths.

## Test plan

- Existing unit tests pass (`pnpm test:vitest` — 29/29 in `@crossmint/client-sdk-auth`)
- Lint passes (`pnpm lint`)
- Manual testing recommended:
  1. App with existing legacy cookies → upgrade → verify session persists (audience matches → migration)
  2. Two apps on same domain with different projects → verify second app detects audience mismatch, logs out, and deletes legacy cookies
  3. App using custom refresh route (`refreshRoute != null`) → verify server-set unscoped cookies are not deleted after refresh

## Package updates

- `@crossmint/client-sdk-auth`: patch (changeset added)

Link to Devin session: https://crossmint.devinenterprise.com/sessions/6968e1f94b5643a1aa3a5b3498cac82e
Requested by: @albertoelias-crossmint
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/crossmint-sdk/pull/1773" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
