### PR TITLE
fix: prevent false device signer error on server-side wallet creation

### DIFF
--- a/.changeset/fix-device-signer-server.md
+++ b/.changeset/fix-device-signer-server.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+Fix false "Device signer key storage is required" error when creating wallets server-side with a client-created device signer

--- a/apps/wallets/quickstart-devkit/e2e/helpers/auth.ts
+++ b/apps/wallets/quickstart-devkit/e2e/helpers/auth.ts
@@ -31,9 +31,10 @@ export async function performEmailOTPLogin(page: Page, email: string): Promise<v
         const otpInput = page.locator('input[data-input-otp="true"]').first();
         await otpInput.waitFor({ timeout: 10000 });
         await page.waitForTimeout(1000);
-        await otpInput.fill(otpCode);
 
-        const response = await page.waitForResponse(
+        // Set up the response listener BEFORE filling the OTP to avoid a race condition
+        // where auto-submit fires the request before waitForResponse is registered.
+        const responsePromise = page.waitForResponse(
             (response) => {
                 const url = response.url();
                 return (
@@ -41,8 +42,12 @@ export async function performEmailOTPLogin(page: Page, email: string): Promise<v
                     url.includes("signinAuthenticationMethod=email")
                 );
             },
-            { timeout: 10000 }
+            { timeout: 30000 }
         );
+
+        await otpInput.fill(otpCode);
+
+        const response = await responsePromise;
         if (response.status() >= 400) {
             throw new Error(`Email OTP authentication failed with status ${response.status()}`);
         }

--- a/packages/wallets/src/wallets/wallet.test.ts
+++ b/packages/wallets/src/wallets/wallet.test.ts
@@ -2175,6 +2175,69 @@ describe("Wallet - recover()", () => {
     });
 });
 
+describe("Wallet - initDefaultSigner() server-side device signer", () => {
+    it("should not attempt to auto-assemble device signer when deviceSignerKeyStorage is unavailable", async () => {
+        const mockApiClient = createMockApiClient();
+
+        // Simulate server-side: wallet has a device signer in initialSigners but no deviceSignerKeyStorage
+        const wallet = new Wallet(
+            {
+                chain: "base-sepolia",
+                address: "0x1234567890123456789012345678901234567890",
+                recovery: { type: "email", email: "test@example.com" } as any,
+                signers: [{ type: "device", locator: "device:testkey123", publicKey: { x: "0x1", y: "0x2" } }] as any,
+                // No options.deviceSignerKeyStorage — simulates server-side
+            },
+            mockApiClient as unknown as ApiClient
+        );
+
+        // Wait for constructor's initDefaultSigner to complete
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        // The signer should be undefined (not auto-assembled) and no error should have been thrown
+        expect(wallet.signer).toBeUndefined();
+    });
+
+    it("should auto-assemble device signer when deviceSignerKeyStorage is available", async () => {
+        const mockApiClient = createMockApiClient();
+        const mockStorage = {
+            generateKey: vi.fn().mockResolvedValue("mockPublicKeyBase64"),
+            getKey: vi.fn().mockResolvedValue("testkey123"),
+            hasKey: vi.fn().mockResolvedValue(true),
+            mapAddressToKey: vi.fn().mockResolvedValue(undefined),
+            deleteKey: vi.fn().mockResolvedValue(undefined),
+            signMessage: vi.fn().mockResolvedValue({ r: "0x1", s: "0x2" }),
+            getDeviceName: vi.fn().mockReturnValue("Test Device"),
+            apiKey: "test-api-key",
+        };
+
+        // Mock getSigner for assembleFullSigner call
+        mockApiClient.getSigner.mockResolvedValue({
+            type: "device",
+            locator: "device:testkey123",
+            publicKey: { x: "0x1", y: "0x2" },
+            chains: { "base-sepolia": { status: "success" } },
+        } as any);
+
+        const wallet = new Wallet(
+            {
+                chain: "base-sepolia",
+                address: "0x1234567890123456789012345678901234567890",
+                recovery: { type: "email", email: "test@example.com" } as any,
+                options: { deviceSignerKeyStorage: mockStorage as any },
+            },
+            mockApiClient as unknown as ApiClient
+        );
+
+        // Wait for constructor's initDefaultSigner to complete
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        // The device signer should have been assembled
+        expect(wallet.signer).toBeDefined();
+        expect(wallet.signer?.type).toBe("device");
+    });
+});
+
 describe("Wallet - isSignerApproved()", () => {
     it("should return true only when signer status is success", async () => {
         const mockApiClient = createMockApiClient();

--- a/packages/wallets/src/wallets/wallet.test.ts
+++ b/packages/wallets/src/wallets/wallet.test.ts
@@ -2194,7 +2194,7 @@ describe("Wallet - initDefaultSigner() server-side device signer", () => {
         );
 
         // Wait for constructor's initDefaultSigner to complete
-        await new Promise((resolve) => setTimeout(resolve, 0));
+        await wallet.waitForInit();
 
         // The signer should be undefined (not auto-assembled) and no error should have been thrown
         expect(wallet.signer).toBeUndefined();
@@ -2234,9 +2234,9 @@ describe("Wallet - initDefaultSigner() server-side device signer", () => {
         );
 
         // Wait for constructor's initDefaultSigner to complete
-        await new Promise((resolve) => setTimeout(resolve, 50));
+        await wallet.waitForInit();
 
-        // The device signer should have been assembled via isAutoAssemblableSignerConfig
+        // The device signer should have been assembled (via initDeviceSigner)
         expect(wallet.signer).toBeDefined();
         expect(wallet.signer?.type).toBe("device");
     });

--- a/packages/wallets/src/wallets/wallet.test.ts
+++ b/packages/wallets/src/wallets/wallet.test.ts
@@ -2198,7 +2198,7 @@ describe("Wallet - initDefaultSigner() server-side device signer", () => {
         expect(wallet.signer).toBeUndefined();
     });
 
-    it("should auto-assemble device signer when deviceSignerKeyStorage is available", async () => {
+    it("should auto-assemble device signer via isAutoAssemblableSignerConfig when deviceSignerKeyStorage is available", async () => {
         const mockApiClient = createMockApiClient();
         const mockStorage = {
             generateKey: vi.fn().mockResolvedValue("mockPublicKeyBase64"),
@@ -2219,11 +2219,13 @@ describe("Wallet - initDefaultSigner() server-side device signer", () => {
             chains: { "base-sepolia": { status: "success" } },
         } as any);
 
+        // Include signers with device entry + deviceSignerKeyStorage to hit isAutoAssemblableSignerConfig("device") -> true
         const wallet = new Wallet(
             {
                 chain: "base-sepolia",
                 address: "0x1234567890123456789012345678901234567890",
                 recovery: { type: "email", email: "test@example.com" } as any,
+                signers: [{ type: "device", locator: "device:testkey123", publicKey: { x: "0x1", y: "0x2" } }] as any,
                 options: { deviceSignerKeyStorage: mockStorage as any },
             },
             mockApiClient as unknown as ApiClient
@@ -2232,7 +2234,7 @@ describe("Wallet - initDefaultSigner() server-side device signer", () => {
         // Wait for constructor's initDefaultSigner to complete
         await new Promise((resolve) => setTimeout(resolve, 50));
 
-        // The device signer should have been assembled
+        // The device signer should have been assembled via isAutoAssemblableSignerConfig
         expect(wallet.signer).toBeDefined();
         expect(wallet.signer?.type).toBe("device");
     });

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -1555,8 +1555,9 @@ export class Wallet<C extends Chain> {
             case "phone":
             case "passkey":
             case "api-key":
-            case "device":
                 return true;
+            case "device":
+                return this.#options?.deviceSignerKeyStorage != null;
             case "server":
                 return "secret" in config && typeof config.secret === "string";
             case "external-wallet":


### PR DESCRIPTION
## Description

Fixes [WAL-9625](https://linear.app/crossmint/issue/WAL-9625/server-side-wallet-creation-returns-false-device-signer-error).

When creating a wallet server-side with a device signer created client-side (`createDeviceSigner` on client → pass result to server → `walletFactory.createWallet`), the SDK logs a false error: `"Device signer key storage is required for device signers"`. The wallet is still created successfully, but the error is confusing and surfaces to the user.

**Root cause:** In `isAutoAssemblableSignerConfig`, the `device` case fell through with `email`/`phone`/`passkey`/`api-key` and unconditionally returned `true`. This caused `initDefaultSigner` to attempt auto-assembling the device signer even on the server side where `deviceSignerKeyStorage` is unavailable, which then threw in `assembleSigner`.

**Fix:** Separate `device` into its own case that returns `true` only when `deviceSignerKeyStorage` is available. On the server, the wallet is returned without a default signer (the device signer's private key lives on the client), which is the correct behavior.

### Key review points
- `initDeviceSigner()` already short-circuits when `deviceSignerKeyStorage` is null, so client-side device signer initialization is unaffected.
- The other callsite of `isAutoAssemblableSignerConfig` (in `requireSigner`) checks the recovery signer, and device signers cannot be recovery signers (see `isRecoverySigner` line 1331), so that path is unaffected.

### Additional fix: smoke test race condition

Fixed a flaky smoke test (`should authenticate and create wallet`) that was consistently timing out at `page.waitForResponse` after OTP entry. The `waitForResponse` listener was set up **after** `otpInput.fill()`, so if the OTP auto-submitted before the listener registered, the response was missed. Moved the listener setup before the fill (standard Playwright pattern) and increased timeout from 10s → 30s.

## Test plan

- All 291 existing + new unit tests pass (83 wallet tests, 32 wallet-factory tests)
- Added two unit tests for `initDefaultSigner` covering the device signer behavior:
  - **Negative (server-side):** Wallet with `signers: [{ type: "device", … }]` but no `deviceSignerKeyStorage` → signer is `undefined`, no error thrown
  - **Positive (client-side):** Same setup with `deviceSignerKeyStorage` provided → device signer is auto-assembled successfully
- Tests use `wallet.waitForInit()` for deterministic async initialization (consistent with existing test patterns)
- Smoke tests now pass in CI after the race condition fix

### Human review checklist
- [ ] Verify the `device` case separation in `isAutoAssemblableSignerConfig` doesn't affect any other caller
- [ ] Confirm the smoke test `waitForResponse`-before-`fill` reorder matches what we want (OTP auto-submits on fill)

## Package updates

- `@crossmint/wallets-sdk`: patch — changeset added via `.changeset/fix-device-signer-server.md`

Link to Devin session: https://crossmint.devinenterprise.com/sessions/95ffe12717ea426fbc37808f75777133
Requested by: @albertoelias-crossmint
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/crossmint-sdk/pull/1777" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
