### PR TITLE
fix: require `status` in `wallet.transfers()` types

### DIFF
--- a/.changeset/require-status-transfers.md
+++ b/.changeset/require-status-transfers.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+fix: require `status` in `wallet.transfers()` types to match backend validation

--- a/packages/wallets/src/api/client.ts
+++ b/packages/wallets/src/api/client.ts
@@ -182,16 +182,14 @@ class ApiClient extends CrossmintApiClient {
 
     async getTransfers(
         walletLocator: WalletLocator,
-        params: { chain: Chain; tokens?: string; status?: "successful" | "failed" }
+        params: { chain: Chain; tokens?: string; status: "successful" | "failed" }
     ): Promise<GetTransfersResponse> {
         const queryParams = new URLSearchParams();
         queryParams.append("chain", params.chain.toString());
         if (params.tokens != null) {
             queryParams.append("tokens", params.tokens);
         }
-        if (params.status != null) {
-            queryParams.append("status", params.status);
-        }
+        queryParams.append("status", params.status);
         const response = await this.get(
             `${this.unstableApiPrefix}/${walletLocator}/transfers?${queryParams.toString()}`,
             {

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -446,12 +446,12 @@ export class Wallet<C extends Chain> {
      * @returns The transfers
      * @throws {Error} If the transfers cannot be retrieved
      */
-    public async transfers(params?: { tokens?: string; status?: "successful" | "failed" }): Promise<Transfers> {
+    public async transfers(params: { tokens?: string; status: "successful" | "failed" }): Promise<Transfers> {
         const resolvedChain = this.resolveChainForEnvironment();
         const response = await this.apiClient.getTransfers(this.walletLocator, {
             chain: resolvedChain,
-            tokens: params?.tokens,
-            status: params?.status,
+            tokens: params.tokens,
+            status: params.status,
         });
         if ("error" in response) {
             throw new Error(`Failed to get transfers: ${JSON.stringify(response.message)}`);


### PR DESCRIPTION
## Description

Resolves [WAL-9638](https://linear.app/crossmint/issue/WAL-9638/require-status-in-wallettransfers-types).

The backend's `WalletActivityQueryDTO` already requires `status` (a non-optional `z.enum(["successful", "failed"])`), but the SDK types marked it as optional. Calling `wallet.transfers()` without `status` would compile fine but fail at runtime with:

```json
{ "error": true, "message": "status: Invalid option: expected one of \"successful\"|\"failed\"" }
```

This PR makes `status` required in both:
- `Wallet.transfers()` (`params` is now required, `status` within it is required)
- `ApiClient.getTransfers()` (`status` is required in the params object)

The now-redundant `null` check on `status` in `getTransfers` is also removed since the value is guaranteed to be present.

**Note for reviewers:** This is a compile-time breaking change for SDK consumers who were calling `transfers()` without `status`. However, those calls were already failing at runtime, so this just surfaces the error earlier.

### Human review checklist
- [ ] Confirm this breaking change is acceptable (existing callers without `status` were already getting runtime errors)
- [ ] Note: the backend's `superRefine` currently rejects `"failed"` with _"You can only query successful transfers right now"_ — the SDK type (`"successful" | "failed"`) matches the backend's declared schema, but in practice only `"successful"` works today

## Test plan

- Existing unit tests pass (287 passed, 68 skipped)
- Lint passes via `pnpm lint`
- `pnpm build:libs` succeeds

## Package updates

Changeset added for `@crossmint/wallets-sdk` (patch).

Link to Devin session: https://crossmint.devinenterprise.com/sessions/bbbd2dfe0b10418dad6c5e22d0c74fa3
Requested by: @albertoelias-crossmint
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/crossmint-sdk/pull/1778" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
