### PR TITLE
wallets: fix needsRecovery race condition on init

### DIFF
--- a/.changeset/fix-needs-recovery-race.md
+++ b/.changeset/fix-needs-recovery-race.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+Fix `needsRecovery()` returning stale `false` after `getWallet()` by awaiting signer initialization in the wallet factory. Also fix `recover()` non-device signer early-return not clearing `needsRecovery`.

--- a/packages/wallets/src/wallets/wallet-factory.ts
+++ b/packages/wallets/src/wallets/wallet-factory.ts
@@ -172,10 +172,10 @@ export class WalletFactory {
         return await this.createWalletInstance(walletResponse, validatedArgs);
     }
 
-    private createWalletInstance<C extends Chain>(
+    private async createWalletInstance<C extends Chain>(
         walletResponse: GetWalletSuccessResponse,
         args: WalletArgsFor<C>
-    ): Wallet<C> {
+    ): Promise<Wallet<C>> {
         this.validateExistingWalletConfig(walletResponse, args);
 
         // For server and external-wallet signers, use the user-provided recovery config to preserve
@@ -199,7 +199,7 @@ export class WalletFactory {
             signers = createArgs.signers as SignerResponse[];
         }
 
-        return new Wallet(
+        const wallet = new Wallet(
             {
                 chain: args.chain,
                 address: walletResponse.address,
@@ -211,6 +211,12 @@ export class WalletFactory {
             },
             this.apiClient
         );
+
+        // Await signer initialization so that needsRecovery() returns the correct
+        // value immediately after getWallet() / createWallet() resolves.
+        await wallet.waitForInit();
+
+        return wallet;
     }
 
     private getWalletLocator<C extends Chain>(args: WalletArgsFor<C>): string {

--- a/packages/wallets/src/wallets/wallet.test.ts
+++ b/packages/wallets/src/wallets/wallet.test.ts
@@ -1517,7 +1517,7 @@ describe("Wallet - recover()", () => {
             expect(mockApiClient.getSigner).not.toHaveBeenCalled();
         });
 
-        it("should skip recovery when current signer is non-device type (email)", async () => {
+        it("should skip recovery and reset needsRecovery when current signer is non-device type (email)", async () => {
             const emailSigner: SignerAdapter = {
                 type: "email",
                 status: "success",
@@ -1539,6 +1539,8 @@ describe("Wallet - recover()", () => {
 
             // Should not call getSigner at all — non-device signer is skipped
             expect(mockApiClient.getSigner).not.toHaveBeenCalled();
+            // needsRecovery should be reset to false even on the non-device early-return path
+            expect(wallet.needsRecovery()).toBe(false);
         });
 
         it("should return silently when no deviceSignerKeyStorage and !needsRecovery", async () => {
@@ -2172,6 +2174,83 @@ describe("Wallet - recover()", () => {
             expect(mockApiClient.registerSigner).toHaveBeenCalled();
             expect(wallet.signer?.type).toBe("device");
         });
+    });
+});
+
+describe("Wallet - waitForInit()", () => {
+    let mockApiClient: MockedApiClient;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockApiClient = createMockApiClient();
+    });
+
+    it("should resolve needsRecovery accurately after waitForInit when no device key exists", async () => {
+        const mockStorage = {
+            generateKey: vi.fn().mockResolvedValue("mockPublicKeyBase64"),
+            getKey: vi.fn().mockResolvedValue(null),
+            hasKey: vi.fn().mockResolvedValue(false),
+            mapAddressToKey: vi.fn().mockResolvedValue(undefined),
+            deleteKey: vi.fn().mockResolvedValue(undefined),
+            signMessage: vi.fn().mockResolvedValue({ r: "0x1", s: "0x2" }),
+            getDeviceName: vi.fn().mockReturnValue("Test Device"),
+        };
+
+        // Mock signers() to return no device signers
+        mockApiClient.getWallet.mockResolvedValue({
+            type: "smart",
+            address: "0x1234567890123456789012345678901234567890",
+            config: {
+                adminSigner: { type: "api-key", locator: "api-key" },
+                delegatedSigners: [],
+            },
+        } as any);
+
+        const wallet = new Wallet(
+            {
+                chain: "base-sepolia",
+                address: "0x1234567890123456789012345678901234567890",
+                recovery: { type: "api-key" } as any,
+                options: { deviceSignerKeyStorage: mockStorage as any },
+            },
+            mockApiClient as unknown as ApiClient
+        );
+
+        // After waitForInit, needsRecovery should reflect the real state
+        await wallet.waitForInit();
+        expect(wallet.needsRecovery()).toBe(true);
+    });
+
+    it("should resolve needsRecovery as false after waitForInit when device key exists", async () => {
+        const mockStorage = {
+            generateKey: vi.fn().mockResolvedValue("mockPublicKeyBase64"),
+            getKey: vi.fn().mockResolvedValue("existingKeyBase64"),
+            hasKey: vi.fn().mockResolvedValue(true),
+            mapAddressToKey: vi.fn().mockResolvedValue(undefined),
+            deleteKey: vi.fn().mockResolvedValue(undefined),
+            signMessage: vi.fn().mockResolvedValue({ r: "0x1", s: "0x2" }),
+            getDeviceName: vi.fn().mockReturnValue("Test Device"),
+        };
+
+        mockApiClient.getSigner.mockResolvedValue({
+            type: "device",
+            locator: "device:existingKeyBase64",
+            publicKey: { x: "1", y: "2" },
+            chains: { "base-sepolia": { status: "success" } },
+        } as any);
+
+        const wallet = new Wallet(
+            {
+                chain: "base-sepolia",
+                address: "0x1234567890123456789012345678901234567890",
+                recovery: { type: "api-key" } as any,
+                options: { deviceSignerKeyStorage: mockStorage as any },
+            },
+            mockApiClient as unknown as ApiClient
+        );
+
+        await wallet.waitForInit();
+        expect(wallet.needsRecovery()).toBe(false);
     });
 });
 

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -118,6 +118,14 @@ export class Wallet<C extends Chain> {
     }
 
     /**
+     * Wait for the wallet's internal signer initialization to complete.
+     * After this resolves, `needsRecovery()` reflects the true state.
+     */
+    public async waitForInit(): Promise<void> {
+        await this.#signerInitialization;
+    }
+
+    /**
      * Initialize the device signer by resolving key availability.
      * If a device key is found locally, assembles the signer immediately.
      * If not, flags the wallet for recovery so a key is generated during the next transaction.
@@ -1000,6 +1008,7 @@ export class Wallet<C extends Chain> {
         // with email/passkey/server), skip device recovery to avoid overwriting their choice.
         if (this.#signer != null && this.#signer.type !== "device") {
             walletsLogger.warn("wallet.recover.skipped", { reason: "Recovery is only supported for device signers" });
+            this.#needsRecovery = false;
             return;
         }
 


### PR DESCRIPTION
## Description

Fixes [WAL-9631](https://linear.app/crossmint/issue/WAL-9631/walletneedsrecovery-changes-after-first-transaction).

`wallet.needsRecovery()` was returning a stale `false` immediately after `getWallet()` because the `Wallet` constructor fires `initDefaultSigner()` asynchronously without awaiting it. The private `#signerInitialization` promise was only awaited inside `preAuthIfNeeded()` (before signing operations), so consumers checking `needsRecovery()` right after `getWallet()` always saw the default `false` — even when recovery was actually needed.

**Changes:**

1. **`wallet.ts`** — Add public `waitForInit()` method that awaits the internal `#signerInitialization` promise. Also fix the `recover()` non-device signer early-return path (line ~1008) to reset `#needsRecovery = false` — previously this path returned without clearing the flag.

2. **`wallet-factory.ts`** — Make `createWalletInstance()` async and call `await wallet.waitForInit()` before returning. Since `getWallet()` and `createWallet()` already `await` this method, the change is transparent to consumers.

**Key review points:**
- `createWalletInstance` was already called with `await` at both call sites, so the sync→async change is safe
- The new `waitForInit()` is a public API addition — needed for consumers that instantiate `Wallet` directly (not through the factory)
- The `#needsRecovery = false` in the non-device early-return of `recover()`: if the user explicitly switched to a non-device signer, clearing `needsRecovery` is correct since that signer doesn't require device recovery

## Test plan

- Added 2 unit tests for `waitForInit()`: verifies `needsRecovery()` returns `true` when no device key exists and `false` when a device key is present
- Updated existing `recover()` test for the non-device signer path to assert `needsRecovery()` is `false` after recovery skips
- All 289 existing wallet tests pass (`pnpm test:vitest --filter @crossmint/wallets-sdk`)
- Lint passes (`pnpm lint`)

## Package updates

No new dependencies. Changeset may be needed for the new public `waitForInit()` API.

Link to Devin session: https://crossmint.devinenterprise.com/sessions/8d05dc8cbb044b0f8c456cb63e9b9e54
Requested by: @albertoelias-crossmint
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/crossmint-sdk/pull/1779" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
