### PR TITLE
wallets: preserve device key on OTP cancellation during recovery

### DIFF
--- a/.changeset/fix-otp-cancel-device-signer.md
+++ b/.changeset/fix-otp-cancel-device-signer.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+Fix: preserve local device key when user cancels OTP during recovery, preventing duplicate device signers on page refresh

--- a/packages/wallets/src/wallets/wallet.test.ts
+++ b/packages/wallets/src/wallets/wallet.test.ts
@@ -2055,7 +2055,8 @@ describe("Wallet - recover()", () => {
             );
             vi.spyOn(wallet, "signers").mockResolvedValue([] as any);
 
-            // registerSigner succeeds but approval triggers OTP which user cancels
+            // In production the error comes from approveSignatureAndWait (OTP dismissed),
+            // but we simulate it as a registerSigner rejection to exercise the catch block.
             mockApiClient.registerSigner.mockRejectedValue(new AuthRejectedError());
 
             await expect(wallet.recover()).rejects.toThrow(AuthRejectedError);

--- a/packages/wallets/src/wallets/wallet.test.ts
+++ b/packages/wallets/src/wallets/wallet.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Wallet } from "./wallet";
 import type { ApiClient, GetBalanceSuccessResponse, SendResponse, GetWalletSuccessResponse } from "../api";
 import type { SignerAdapter } from "../signers/types";
+import { AuthRejectedError } from "../signers/types";
 import {
     InvalidAddressError,
     InvalidTransferAmountError,
@@ -2038,6 +2039,30 @@ describe("Wallet - recover()", () => {
             await expect(wallet.recover()).rejects.toThrow("Failed to register signer");
 
             expect(mockStorage.deleteKey).toHaveBeenCalledWith("0x1234567890123456789012345678901234567890");
+        });
+
+        it("should preserve local key and rethrow when addSigner fails with AuthRejectedError", async () => {
+            const mockStorage = createMockDeviceKeyStorage();
+
+            const wallet = new Wallet(
+                {
+                    chain: "base-sepolia",
+                    address: "0x1234567890123456789012345678901234567890",
+                    recovery: { type: "api-key" } as any,
+                    options: { deviceSignerKeyStorage: mockStorage as any },
+                },
+                mockApiClient as unknown as ApiClient
+            );
+            vi.spyOn(wallet, "signers").mockResolvedValue([] as any);
+
+            // registerSigner succeeds but approval triggers OTP which user cancels
+            mockApiClient.registerSigner.mockRejectedValue(new AuthRejectedError());
+
+            await expect(wallet.recover()).rejects.toThrow(AuthRejectedError);
+
+            // Local key should NOT be deleted — it will be needed to match the
+            // server-side pending signer on the next recover() attempt
+            expect(mockStorage.deleteKey).not.toHaveBeenCalled();
         });
 
         it("should not false-positive on error containing 'already' and 'approved' without 'delegated signer'", async () => {

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -64,6 +64,7 @@ import type {
     SignerConfigForChain,
     SignerLocator,
 } from "../signers/types";
+import { AuthRejectedError } from "../signers/types";
 import { assembleSigner } from "../signers";
 import { NonCustodialSigner } from "../signers/non-custodial";
 import { deriveServerSignerDetails } from "../signers/server";
@@ -1055,6 +1056,13 @@ export class Wallet<C extends Chain> {
                     reason: "Device signer already approved",
                     signerLocator: newDeviceSigner.locator,
                 });
+            } else if (error instanceof AuthRejectedError) {
+                // User canceled OTP — keep the local key so findLocalDeviceSigner()
+                // can match the server-side pending signer on the next recover() attempt.
+                walletsLogger.info("wallet.recover.device.authRejected", {
+                    signerLocator: newDeviceSigner.locator,
+                });
+                throw error;
             } else {
                 walletsLogger.error("wallet.recover.device.error", { error });
                 await deviceSignerKeyStorage.deleteKey(this.address);

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -1056,7 +1056,10 @@ export class Wallet<C extends Chain> {
                     reason: "Device signer already approved",
                     signerLocator: newDeviceSigner.locator,
                 });
-            } else if (error instanceof AuthRejectedError) {
+            } else if (
+                error instanceof AuthRejectedError ||
+                (error instanceof Error && error.name === "AuthRejectedError")
+            ) {
                 // User canceled OTP — keep the local key so findLocalDeviceSigner()
                 // can match the server-side pending signer on the next recover() attempt.
                 walletsLogger.info("wallet.recover.device.authRejected", {


### PR DESCRIPTION
## Description

Fixes [WAL-9632](https://linear.app/crossmint/issue/WAL-9632/refreshing-after-canceled-otp-adds-another-device-signer).

When a user cancels the OTP popup during device signer recovery, `recover()` calls `addSigner()` which registers the new device signer server-side *before* the OTP approval step. On cancellation, the catch block was deleting the local key via `deleteKey(this.address)`, but the signer remained registered server-side in pending status. On page refresh, `findLocalDeviceSigner()` couldn't match the orphaned server-side signer (local key gone), so `recover()` generated a brand new key — accumulating duplicate device signers with each refresh+transaction cycle.

This PR adds an `AuthRejectedError` check in the catch block so that when the user cancels OTP, the local key is preserved and the error is re-thrown without cleanup. On the next `recover()` call, `findLocalDeviceSigner()` will match the local key to the pending server-side signer and resume approval via the existing `checkAndResumeDeviceSigner()` → `resumePendingDeviceSignerApproval()` path.

**Implementation notes:**
- The `instanceof` check includes a name-based fallback (`error.name === "AuthRejectedError"`) to guard against bundler module duplication silently breaking `instanceof`
- `AuthRejectedError` is imported as a separate value import (not inside the `import type` block) — this is intentional since it's a class used at runtime

### Human review checklist
- [ ] Confirm `AuthRejectedError` is the only error type that should skip key deletion (are there other user-initiated cancellation paths?)
- [ ] Confirm the `findLocalDeviceSigner` → resume path handles the preserved-key-with-pending-signer scenario end-to-end
- [ ] The unit test mocks `registerSigner` rejecting directly — the real propagation chain is longer (OTP popup → `signMessage` → `approveSignatureInternal` → `addSigner`). Manual testing of the full flow is recommended.

## Test plan

- All 288 wallet SDK unit tests pass (including 1 new test)
- New test: `should preserve local key and rethrow when addSigner fails with AuthRejectedError` — verifies `deleteKey` is NOT called and the error is re-thrown
- The `recover()` test suite covers early return paths, existing device signer paths, findLocalDeviceSigner path, and new key generation fallback — all continue to pass
- Manual verification of the OTP cancellation → refresh → duplicate signer scenario would be needed to fully validate

## Package updates

- `@crossmint/wallets-sdk`: patch (changeset added via `.changeset/fix-otp-cancel-device-signer.md`)

Link to Devin session: https://crossmint.devinenterprise.com/sessions/63deb75bdca143a4b414031bcefafe5a
Requested by: @albertoelias-crossmint
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/crossmint-sdk/pull/1781" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
