### PR TITLE
fix: make addSigner idempotent by resuming pending operations on retry

### DIFF
--- a/.changeset/shiny-camels-drive.md
+++ b/.changeset/shiny-camels-drive.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+fix: make addSigner idempotent by resuming pending operations on retry

--- a/packages/wallets/src/wallets/wallet.test.ts
+++ b/packages/wallets/src/wallets/wallet.test.ts
@@ -792,6 +792,156 @@ describe("Wallet - addSigner()", () => {
             );
         });
     });
+
+    describe("retry / idempotency", () => {
+        it("should resume pending EVM signature instead of re-registering", async () => {
+            // First call: getSigner returns a pending signer with awaiting-approval signature
+            mockApiClient.getSigner.mockResolvedValueOnce({
+                type: "external-wallet",
+                address: "0x456",
+                locator: "external-wallet:0x456",
+                chains: {
+                    "base-sepolia": { id: "sig-pending", status: "awaiting-approval" },
+                },
+            } as any);
+
+            const mockSignatureResponse = {
+                id: "sig-pending",
+                status: "success",
+                outputSignature: "0xsigned",
+            };
+            mockApiClient.getSignature.mockResolvedValue(mockSignatureResponse as any);
+
+            const addPromise = evmWallet.addSigner({ type: "external-wallet", address: "0x456" });
+            await vi.runAllTimersAsync();
+            const result = await addPromise;
+
+            // Should NOT have called registerSigner — resumed the pending operation instead
+            expect(mockApiClient.registerSigner).not.toHaveBeenCalled();
+            expect(result.status).toBe("success");
+            expect(result.type).toBe("external-wallet");
+        });
+
+        it("should resume pending Solana transaction instead of re-registering", async () => {
+            // getSigner returns a pending signer with a pending transaction
+            mockApiClient.getSigner.mockResolvedValueOnce({
+                type: "external-wallet",
+                address: "ABC123",
+                locator: "external-wallet:ABC123",
+                transaction: { id: "txn-pending", status: "pending" },
+            } as any);
+
+            const mockTransactionResponse = {
+                id: "txn-pending",
+                status: "success",
+                onChain: {
+                    txId: "sol-tx-hash",
+                    explorerLink: "https://explorer.solana.com/tx/sol-tx-hash",
+                },
+            };
+            mockApiClient.getTransaction.mockResolvedValue(mockTransactionResponse as any);
+
+            const addPromise = solanaWallet.addSigner({ type: "external-wallet", address: "ABC123" });
+            await vi.runAllTimersAsync();
+            const result = await addPromise;
+
+            expect(mockApiClient.registerSigner).not.toHaveBeenCalled();
+            expect(result.status).toBe("success");
+        });
+
+        it("should return early without registering when signer is already approved", async () => {
+            mockApiClient.getSigner.mockResolvedValueOnce({
+                type: "external-wallet",
+                address: "0x456",
+                locator: "external-wallet:0x456",
+                chains: {
+                    "base-sepolia": { id: "sig-done", status: "success" },
+                },
+            } as any);
+
+            const result = await evmWallet.addSigner({ type: "external-wallet", address: "0x456" });
+
+            expect(mockApiClient.registerSigner).not.toHaveBeenCalled();
+            expect(result.status).toBe("success");
+        });
+
+        it("should be idempotent — calling addSigner twice yields the same result", async () => {
+            // First addSigner call: signer not found → fresh registration
+            mockApiClient.getSigner.mockResolvedValueOnce({ error: { message: "not found" } } as any);
+            mockApiClient.registerSigner.mockResolvedValueOnce({
+                type: "external-wallet",
+                address: "0x456",
+                locator: "external-wallet:0x456",
+                chains: {
+                    "base-sepolia": { id: "sig-123", status: "success" },
+                },
+            } as any);
+
+            const result1 = await evmWallet.addSigner({ type: "external-wallet", address: "0x456" });
+
+            // Second addSigner call: signer already approved → early return
+            mockApiClient.getSigner.mockResolvedValueOnce({
+                type: "external-wallet",
+                address: "0x456",
+                locator: "external-wallet:0x456",
+                chains: {
+                    "base-sepolia": { id: "sig-123", status: "success" },
+                },
+            } as any);
+
+            const result2 = await evmWallet.addSigner({ type: "external-wallet", address: "0x456" });
+
+            expect(mockApiClient.registerSigner).toHaveBeenCalledTimes(1);
+            expect(result1.status).toBe("success");
+            expect(result2.status).toBe("success");
+            expect(result1.type).toBe(result2.type);
+        });
+
+        it("should return prepareOnly result when resuming a pending operation", async () => {
+            mockApiClient.getSigner.mockResolvedValueOnce({
+                type: "external-wallet",
+                address: "0x456",
+                locator: "external-wallet:0x456",
+                chains: {
+                    "base-sepolia": { id: "sig-pending", status: "awaiting-approval" },
+                },
+            } as any);
+
+            const result = await evmWallet.addSigner(
+                { type: "external-wallet", address: "0x456" },
+                { prepareOnly: true }
+            );
+
+            expect(mockApiClient.registerSigner).not.toHaveBeenCalled();
+            expect(result.signatureId).toBe("sig-pending");
+        });
+
+        it("should fall through to fresh registration when signer is in failed state", async () => {
+            // getSigner returns a signer with failed status and no pending op
+            mockApiClient.getSigner.mockResolvedValueOnce({
+                type: "external-wallet",
+                address: "0x456",
+                locator: "external-wallet:0x456",
+                chains: {
+                    "base-sepolia": { id: "sig-old", status: "failed" },
+                },
+            } as any);
+
+            mockApiClient.registerSigner.mockResolvedValue({
+                type: "external-wallet",
+                address: "0x456",
+                locator: "external-wallet:0x456",
+                chains: {
+                    "base-sepolia": { id: "sig-new", status: "success" },
+                },
+            } as any);
+
+            const result = await evmWallet.addSigner({ type: "external-wallet", address: "0x456" });
+
+            expect(mockApiClient.registerSigner).toHaveBeenCalled();
+            expect(result.status).toBe("success");
+        });
+    });
 });
 
 describe("Wallet - removeSigner()", () => {
@@ -1975,6 +2125,9 @@ describe("Wallet - recover()", () => {
                 publicKey: { x: "0x01", y: "0x02" },
                 chains: { "base-sepolia": { status: "success" } },
             } as any);
+            // addSigner's getSignerState check — signer not yet registered
+            mockApiClient.getSigner.mockResolvedValueOnce({ error: { message: "not found" } } as any);
+            // assembleFullSigner's getSignerState — signer now approved after registration
             mockGetSignerApproved("base-sepolia", "device:mockNewKey");
 
             await wallet.recover();
@@ -2150,7 +2303,10 @@ describe("Wallet - recover()", () => {
                 chains: { "base-sepolia": { status: "failed" } },
             } as any);
 
-            // Second getSigner call (for assembleFullSigner after createDeviceSigner)
+            // Second getSigner call (addSigner's getSignerState check — signer not yet registered)
+            mockApiClient.getSigner.mockResolvedValueOnce({ error: { message: "not found" } } as any);
+
+            // Third getSigner call (for assembleFullSigner after createDeviceSigner)
             mockApiClient.getSigner.mockResolvedValueOnce({
                 type: "device",
                 locator: "device:mockNewKey",

--- a/packages/wallets/src/wallets/wallet.test.ts
+++ b/packages/wallets/src/wallets/wallet.test.ts
@@ -2157,6 +2157,8 @@ describe("Wallet - recover()", () => {
                 error: true,
                 message: "Delegated signer is already 'approved'",
             } as any);
+            // addSigner's upfront getSigner check — signer not yet found
+            mockApiClient.getSigner.mockResolvedValueOnce({ error: { message: "not found" } } as any);
             // assembleFullSigner after the catch still needs getSigner
             mockGetSignerApproved("base-sepolia", "device:mockNewKey");
 

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -752,23 +752,39 @@ export class Wallet<C extends Chain> {
             if (pendingOperation == null) {
                 return { ...signer } as AddSignerReturnType<C>;
             }
-            const operationId =
-                pendingOperation.type === "transaction"
-                    ? { transactionId: pendingOperation.id }
-                    : { signatureId: pendingOperation.id };
-            walletsLogger.info("wallet.addSigner.prepared", operationId);
-            return { ...signer, ...operationId } as AddSignerReturnType<C>;
+            switch (pendingOperation.type) {
+                case "transaction": {
+                    const operationId = { transactionId: pendingOperation.id };
+                    walletsLogger.info("wallet.addSigner.prepared", operationId);
+                    return { ...signer, ...operationId } as AddSignerReturnType<C>;
+                }
+                case "signature": {
+                    const operationId = { signatureId: pendingOperation.id };
+                    walletsLogger.info("wallet.addSigner.prepared", operationId);
+                    return { ...signer, ...operationId } as AddSignerReturnType<C>;
+                }
+                default: {
+                    const _exhaustive: never = pendingOperation.type;
+                    throw new Error(`Unknown pending operation type: ${_exhaustive}`);
+                }
+            }
         }
 
         if (pendingOperation != null) {
-            if (pendingOperation.type === "transaction") {
-                await this.approveTransactionAndWait(pendingOperation.id);
-            } else {
-                await this.approveSignatureAndWait(pendingOperation.id);
+            switch (pendingOperation.type) {
+                case "transaction":
+                    await this.approveTransactionAndWait(pendingOperation.id);
+                    walletsLogger.info("wallet.addSigner.success", { transactionId: pendingOperation.id });
+                    break;
+                case "signature":
+                    await this.approveSignatureAndWait(pendingOperation.id);
+                    walletsLogger.info("wallet.addSigner.success", { signatureId: pendingOperation.id });
+                    break;
+                default: {
+                    const _exhaustive: never = pendingOperation.type;
+                    throw new Error(`Unknown pending operation type: ${_exhaustive}`);
+                }
             }
-            walletsLogger.info("wallet.addSigner.success", {
-                [pendingOperation.type === "transaction" ? "transactionId" : "signatureId"]: pendingOperation.id,
-            });
         } else {
             walletsLogger.info("wallet.addSigner.success");
         }

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -657,7 +657,7 @@ export class Wallet<C extends Chain> {
                 // Signer already fully approved — return immediately (idempotent)
                 if (this.isApprovedSignerStatus(existingState.signer.status)) {
                     walletsLogger.info("wallet.addSigner.alreadyApproved");
-                    return { ...existingState.signer, status: "success" as const } as WalletSigner;
+                    return this.completeSignerRegistration(existingState.signer, null, options);
                 }
 
                 // Pending operation from a previous attempt — resume instead of re-registering

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -749,10 +749,13 @@ export class Wallet<C extends Chain> {
         options?: AddSignerOptions
     ): Promise<AddSignerReturnType<C> | WalletSigner> {
         if (options?.prepareOnly) {
+            if (pendingOperation == null) {
+                return { ...signer } as AddSignerReturnType<C>;
+            }
             const operationId =
-                pendingOperation?.type === "transaction"
+                pendingOperation.type === "transaction"
                     ? { transactionId: pendingOperation.id }
-                    : { signatureId: pendingOperation?.id };
+                    : { signatureId: pendingOperation.id };
             walletsLogger.info("wallet.addSigner.prepared", operationId);
             return { ...signer, ...operationId } as AddSignerReturnType<C>;
         }

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -648,6 +648,33 @@ export class Wallet<C extends Chain> {
                 : signer;
 
         return this.withRecoverySigner(async () => {
+            // Check for an existing signer registration (e.g. from a previous interrupted attempt)
+            const signerLocator =
+                typeof resolvedSigner === "string" ? resolvedSigner : getSignerLocator(resolvedSigner);
+            const existingState = await this.getSignerState(signerLocator);
+
+            if (existingState.signer != null) {
+                // Signer already fully approved — return immediately (idempotent)
+                if (this.isApprovedSignerStatus(existingState.signer.status)) {
+                    walletsLogger.info("wallet.addSigner.alreadyApproved");
+                    return { ...existingState.signer, status: "success" as const } as WalletSigner;
+                }
+
+                // Pending operation from a previous attempt — resume instead of re-registering
+                if (existingState.pendingOperation != null) {
+                    walletsLogger.info("wallet.addSigner.resuming", {
+                        operationType: existingState.pendingOperation.type,
+                        operationId: existingState.pendingOperation.id,
+                    });
+                    return this.completeSignerRegistration(
+                        existingState.signer,
+                        existingState.pendingOperation,
+                        options
+                    );
+                }
+            }
+
+            // --- Fresh registration ---
             // For server signers, resolvedSigner is already a locator string.
             // For passkeys, always pass the full config so the API receives the publicKey.
             // For everything else, convert to a locator string via getSignerLocator.
@@ -680,6 +707,13 @@ export class Wallet<C extends Chain> {
 
             const registeredSigner = mapApiSignerToSigner(response, this.chain);
 
+            if (registeredSigner == null) {
+                throw new Error(`No approval found for chain ${this.chain} in register signer response`);
+            }
+
+            // Extract the pending operation from the registration response
+            let pendingOperation: { type: "signature" | "transaction"; id: string } | null = null;
+
             if (this.chain === "solana" || this.chain === "stellar") {
                 if (!("transaction" in response) || response.transaction == null) {
                     walletsLogger.error("wallet.addSigner.error", {
@@ -687,25 +721,7 @@ export class Wallet<C extends Chain> {
                     });
                     throw new Error("Expected transaction in response for Solana/Stellar chain");
                 }
-
-                const transactionId = response.transaction.id;
-
-                if (registeredSigner == null) {
-                    throw new Error(`No approval found for chain ${this.chain} in register signer response`);
-                }
-
-                if (options?.prepareOnly) {
-                    walletsLogger.info("wallet.addSigner.prepared", {
-                        transactionId,
-                    });
-                    return { ...registeredSigner, transactionId } as AddSignerReturnType<C>;
-                }
-
-                await this.approveTransactionAndWait(transactionId);
-                walletsLogger.info("wallet.addSigner.success", {
-                    transactionId,
-                });
-                return { ...registeredSigner, status: "success" } as WalletSigner;
+                pendingOperation = { type: "transaction", id: response.transaction.id };
             } else {
                 if (!("chains" in response)) {
                     walletsLogger.error("wallet.addSigner.error", {
@@ -713,37 +729,48 @@ export class Wallet<C extends Chain> {
                     });
                     throw new Error("Expected chains in response for EVM chain");
                 }
-
-                const chainResponse = response.chains?.[this.chain];
-
-                if (registeredSigner == null) {
-                    throw new Error(`No approval found for chain ${this.chain} in register signer response`);
-                }
-
-                const pendingOperation = getPendingSignerOperation(response, this.chain);
-                const signatureId = pendingOperation?.type === "signature" ? pendingOperation.id : undefined;
-
-                if (options?.prepareOnly) {
-                    walletsLogger.info("wallet.addSigner.prepared", {
-                        signatureId,
-                    });
-                    return { ...registeredSigner, signatureId } as AddSignerReturnType<C>;
-                }
-
-                if (pendingOperation?.type === "signature") {
-                    await this.approveSignatureAndWait(pendingOperation.id);
-                    walletsLogger.info("wallet.addSigner.success", {
-                        signatureId: pendingOperation.id,
-                    });
-                } else if (chainResponse?.status === "failed") {
+                if (response.chains?.[this.chain]?.status === "failed") {
                     throw new Error(`Signer registration failed for chain ${this.chain}`);
-                } else {
-                    walletsLogger.info("wallet.addSigner.success");
                 }
-
-                return { ...registeredSigner, status: "success" as const } as WalletSigner;
+                pendingOperation = getPendingSignerOperation(response, this.chain);
             }
+
+            return this.completeSignerRegistration(registeredSigner, pendingOperation, options);
         }) as Promise<T extends PrepareOnly<true> ? AddSignerReturnType<C> : WalletSigner>;
+    }
+
+    /**
+     * Complete a signer registration by approving the pending operation (if any).
+     * Shared by both fresh registrations and resumed pending ones.
+     */
+    private async completeSignerRegistration(
+        signer: WalletSigner,
+        pendingOperation: { type: "signature" | "transaction"; id: string } | null,
+        options?: AddSignerOptions
+    ): Promise<AddSignerReturnType<C> | WalletSigner> {
+        if (options?.prepareOnly) {
+            const operationId =
+                pendingOperation?.type === "transaction"
+                    ? { transactionId: pendingOperation.id }
+                    : { signatureId: pendingOperation?.id };
+            walletsLogger.info("wallet.addSigner.prepared", operationId);
+            return { ...signer, ...operationId } as AddSignerReturnType<C>;
+        }
+
+        if (pendingOperation != null) {
+            if (pendingOperation.type === "transaction") {
+                await this.approveTransactionAndWait(pendingOperation.id);
+            } else {
+                await this.approveSignatureAndWait(pendingOperation.id);
+            }
+            walletsLogger.info("wallet.addSigner.success", {
+                [pendingOperation.type === "transaction" ? "transactionId" : "signatureId"]: pendingOperation.id,
+            });
+        } else {
+            walletsLogger.info("wallet.addSigner.success");
+        }
+
+        return { ...signer, status: "success" as const } as WalletSigner;
     }
 
     /**


### PR DESCRIPTION
## Description

Fixes [WAL-9383](https://linear.app/crossmint/issue/WAL-9383/addsigner-retry-shouldnt-fail).

When `addSigner` is called and the approval step (step 2) fails mid-flight (network error, timeout, etc.), the signer is left in a pending state on the backend. On retry, `addSigner` would blindly call `registerSigner` again, which fails because the signer already exists.

This PR makes `addSigner` idempotent by checking for existing signer state before registration:
- **Already approved** → return immediately (no-op)
- **Pending operation** → resume the pending approval (transaction or signature) instead of re-registering
- **Failed / not found** → proceed with fresh registration as before

The approval logic (handling transactions for Solana/Stellar and signatures for EVM) is extracted into a shared `completeSignerRegistration` helper, used by both the fresh registration path and the resume path. This reuses the existing `getSignerState` / `getPendingSignerOperation` infrastructure that `recover()` already relies on.

### Things for reviewer to check
- Every `addSigner` call now makes an extra `getSigner` API call upfront to check existing state — confirm this latency tradeoff is acceptable
- Verify `isApprovedSignerStatus` (checks for `"success"` / `"active"`) covers all terminal approved states
- Race condition edge case: if a signer transitions from pending → approved between the upfront check and the approval attempt, the approval call should still be safe (idempotent on the backend), but worth confirming

## Test plan

- 6 new unit tests covering addSigner retry/idempotency:
  - Resume pending EVM signature instead of re-registering
  - Resume pending Solana transaction instead of re-registering
  - Early return when signer is already approved
  - True idempotency: calling `addSigner` twice with the same signer yields the same result (only one `registerSigner` call)
  - `prepareOnly` mode returns operation ID when resuming a pending operation
  - Fall through to fresh registration when signer is in failed state
- 3 existing `recover()` tests updated to account for the additional `getSigner` call from `addSigner`
- All 293 tests pass locally, lint passes

## Package updates

- `@crossmint/wallets-sdk`: patch bump (changeset added)

Link to Devin session: https://crossmint.devinenterprise.com/sessions/408fbed01afa4dae9266b753cae9bc78
Requested by: @albertoelias-crossmint
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/crossmint-sdk/pull/1782" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
