### PR TITLE
Max/wal 9630 investigate multiple otp requests for spotpay

### DIFF
--- a/.changeset/brave-news-work.md
+++ b/.changeset/brave-news-work.md
@@ -1,0 +1,9 @@
+---
+"@crossmint/client-sdk-react-native-ui": patch
+"@crossmint/wallets-sdk": patch
+---
+
+Summary
+
+- Cache OTP auth state in ensureAuthenticated() to avoid calling get-status on the TEE every transaction
+- Fixes repeated OTP prompts in React Native when the WebView process is terminated by iOS and reloaded without prior session state

--- a/.changeset/brave-news-work.md
+++ b/.changeset/brave-news-work.md
@@ -1,9 +1,0 @@
----
-"@crossmint/client-sdk-react-native-ui": patch
-"@crossmint/wallets-sdk": patch
----
-
-Summary
-
-- Cache OTP auth state in ensureAuthenticated() to avoid calling get-status on the TEE every transaction
-- Fixes repeated OTP prompts in React Native when the WebView process is terminated by iOS and reloaded without prior session state

--- a/packages/client/ui/react-native/package.json
+++ b/packages/client/ui/react-native/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@crossmint/client-sdk-react-native-ui",
-    "version": "0.13.28",
+    "version": "0.13.29",
     "repository": "https://github.com/Crossmint/crossmint-sdk",
     "license": "Apache-2.0",
     "author": "Paella Labs Inc",

--- a/packages/wallets/package.json
+++ b/packages/wallets/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@crossmint/wallets-sdk",
-    "version": "0.20.3",
+    "version": "0.20.4",
     "repository": "https://github.com/Crossmint/crossmint-sdk",
     "license": "Apache-2.0",
     "author": "Paella Labs Inc",

--- a/packages/wallets/src/signers/non-custodial/ncs-signer.ts
+++ b/packages/wallets/src/signers/non-custodial/ncs-signer.ts
@@ -101,6 +101,9 @@ export abstract class NonCustodialSigner implements Signer {
         methodName: "handleAuthRequired",
     })
     protected async handleAuthRequired() {
+        if (!this._needsAuth) {
+            return;
+        }
         const clientTEEConnection = await this.getTEEConnection();
 
         if (this.config.onAuthRequired == null) {
@@ -190,9 +193,6 @@ export abstract class NonCustodialSigner implements Signer {
     }
 
     public async ensureAuthenticated(): Promise<void> {
-        if (!this._needsAuth) {
-            return;
-        }
         await this.handleAuthRequired();
     }
 

--- a/packages/wallets/src/signers/non-custodial/ncs-signer.ts
+++ b/packages/wallets/src/signers/non-custodial/ncs-signer.ts
@@ -190,6 +190,9 @@ export abstract class NonCustodialSigner implements Signer {
     }
 
     public async ensureAuthenticated(): Promise<void> {
+        if (!this._needsAuth) {
+            return;
+        }
         await this.handleAuthRequired();
     }
 


### PR DESCRIPTION
### Summary
- Cache OTP auth state in `handleAuthRequired()` to avoid calling `get-status` on the TEE every transaction
- Fixes repeated OTP prompts in React Native when the WebView process is terminated by iOS and reloaded without prior session state

### Problem

Every transaction calls `handleAuthRequired()` → `get-status` on the TEE, regardless of whether OTP was already verified. In React Native, the TEE runs inside a hidden WebView. When iOS kills the WebView process (e.g., app backgrounded briefly), `onContentProcessDidTerminate` reloads it — but the new instance has no memory of previous OTP verification, so `get-status` returns "not ready" and the user is prompted again.

The `_needsAuth` flag was already correctly set to `false` after successful OTP, but was never checked before hitting the TEE.

### Fix

Short-circuit `handleAuthRequired()` when `_needsAuth` is already `false`. The guard is placed in `handleAuthRequired()` rather than `ensureAuthenticated()` because all three concrete subclasses (EVM, Solana, Stellar) call `handleAuthRequired()` directly in their signing methods, bypassing `ensureAuthenticated()`. This ensures every signing path is covered.

The same signer instance is reused between transactions for email/phone signers (since `recover()` exits early for non-device signers), so the cached state is reliable for the lifetime of the wallet instance.

### Test plan
- [ ] Verify OTP is requested on first transaction with an email/phone signer
- [ ] Verify subsequent transactions on the same wallet instance do **not** re-trigger OTP
- [ ] Background the RN app, return, and confirm no OTP prompt on next transaction
- [ ] Verify that after a full app restart (new wallet instance), OTP is requested as expected
<!--
  Example:
   * Unit tests which cover functionality X, Y, Z
   * V was tested via UI tests
   * W was tested manually
-->

## Package updates

<!-- 
  List any package updates and ensure you've added the necessary changesets, running `pnpm change:add` to do so.
-->