### PR TITLE
Fix/e2e stellar prepared transaction

### DIFF
--- a/apps/wallets/quickstart-devkit/components/approval-test.tsx
+++ b/apps/wallets/quickstart-devkit/components/approval-test.tsx
@@ -8,12 +8,13 @@ import { isAddress } from "viem";
 export function ApprovalTest() {
     const { wallet } = useWallet();
 
-    const isEVMWallet = wallet?.chain !== "solana";
+    const isStellarWallet = wallet?.chain === "stellar";
     const isSolanaWallet = wallet?.chain === "solana";
+    const isEVMWallet = !isStellarWallet && !isSolanaWallet;
 
     // State for creating transactions that need approval
     const [prepareTransfer, setPrepareTransfer] = useState({
-        token: (isEVMWallet ? "eth" : "sol") as "eth" | "usdc" | "sol" | "usdxm",
+        token: (isEVMWallet ? "eth" : isSolanaWallet ? "sol" : "usdxm") as "eth" | "usdc" | "sol" | "usdxm",
         recipient: "",
         amount: "",
     });
@@ -41,6 +42,9 @@ export function ApprovalTest() {
             } catch {
                 return false;
             }
+        } else if (isStellarWallet) {
+            // Stellar addresses start with G or C and are 56 characters (base32)
+            return /^[GC][A-Z0-9]{55}$/.test(address);
         }
         return false;
     };
@@ -229,8 +233,11 @@ export function ApprovalTest() {
                         <label className="text-sm font-medium block mb-1">Recipient</label>
                         <input
                             type="text"
+                            data-testid="prepare-recipient"
                             className="w-full px-3 py-2 border rounded-md text-sm"
-                            placeholder={isEVMWallet ? "0x..." : "Base58 address"}
+                            placeholder={
+                                isEVMWallet ? "0x..." : isSolanaWallet ? "Base58 address" : "G... or C... (Stellar)"
+                            }
                             value={prepareTransfer.recipient}
                             onChange={(e) =>
                                 setPrepareTransfer((prev) => ({

--- a/apps/wallets/quickstart-devkit/components/approval-test.tsx
+++ b/apps/wallets/quickstart-devkit/components/approval-test.tsx
@@ -44,7 +44,7 @@ export function ApprovalTest() {
             }
         } else if (isStellarWallet) {
             // Stellar addresses start with G or C and are 56 characters (base32)
-            return /^[GC][A-Z0-9]{55}$/.test(address);
+            return /^[GC][A-Z2-7]{55}$/.test(address);
         }
         return false;
     };

--- a/apps/wallets/quickstart-devkit/components/approval-test.tsx
+++ b/apps/wallets/quickstart-devkit/components/approval-test.tsx
@@ -14,7 +14,7 @@ export function ApprovalTest() {
 
     // State for creating transactions that need approval
     const [prepareTransfer, setPrepareTransfer] = useState({
-        token: (isEVMWallet ? "eth" : isSolanaWallet ? "sol" : "usdxm") as "eth" | "usdc" | "sol" | "usdxm",
+        token: "usdxm" as "eth" | "usdc" | "sol" | "usdxm",
         recipient: "",
         amount: "",
     });

--- a/apps/wallets/quickstart-devkit/e2e/helpers/auth.ts
+++ b/apps/wallets/quickstart-devkit/e2e/helpers/auth.ts
@@ -116,7 +116,10 @@ async function handleEmailPhoneSignerFlow(page: Page, signerType: SignerType): P
                     (url.includes("/api/") && url.includes("/confirm") && method === "POST")
                 );
             },
-            { timeout: 30000 }
+            // Use a short timeout: this pattern reliably matches for email but not for phone
+            // (the phone OTP send endpoint uses a different URL). We catch the timeout and
+            // continue regardless, so a long timeout only wastes time on phone signers.
+            { timeout: 10000 }
         );
 
         await sendCodeButton.click();
@@ -136,11 +139,12 @@ async function handleEmailPhoneSignerFlow(page: Page, signerType: SignerType): P
         await page.waitForTimeout(2000);
 
         // Wait for UI confirmation instead of network response - more reliable and works for both client-side and server-side requests
+        // Use a generous timeout (90s) to accommodate slow SMS delivery on phone signers, especially on retries.
         console.log("⏳ Waiting for 'Check your email/phone' message...");
         if (signerType === "email") {
-            await page.locator("text=/Check your email/i").waitFor({ timeout: 60000 });
+            await page.locator("text=/Check your email/i").waitFor({ timeout: 90000 });
         } else if (signerType === "phone") {
-            await page.locator("text=/Check your phone/i").first().waitFor({ timeout: 60000 });
+            await page.locator("text=/Check your phone/i").first().waitFor({ timeout: 90000 });
         }
         console.log("✅ 'Check your email/phone' message appeared");
 

--- a/apps/wallets/quickstart-devkit/e2e/helpers/wallet.ts
+++ b/apps/wallets/quickstart-devkit/e2e/helpers/wallet.ts
@@ -276,7 +276,7 @@ export async function createPreparedTransaction(
 
         const recipientInput = approvalSection
             .locator("..")
-            .locator('input[placeholder*="0x" i], input[placeholder*="Base58" i]')
+            .locator('[data-testid="prepare-recipient"], input[placeholder*="0x" i], input[placeholder*="Base58" i]')
             .first();
         await recipientInput.waitFor({ timeout: 30000 });
         await recipientInput.fill(recipientAddress);

--- a/apps/wallets/quickstart-devkit/playwright.config.ts
+++ b/apps/wallets/quickstart-devkit/playwright.config.ts
@@ -12,6 +12,9 @@ export default defineConfig({
     maxFailures: undefined, // Don't stop after a certain number of failures - run all tests
     reporter: process.env.CI ? [["json", { outputFile: "test-results/playwright-results.json" }], ["list"]] : "html",
     timeout: 180000, // 3 minutes — phone OTP confirmation can take 90s+ on retries (slow SMS delivery)
+    expect: {
+        timeout: 15000, // webkit + phone configs can be slow to render on CI
+    },
     use: {
         baseURL: process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3000",
         trace: "on-first-retry",

--- a/apps/wallets/quickstart-devkit/playwright.config.ts
+++ b/apps/wallets/quickstart-devkit/playwright.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
     workers: 1,
     maxFailures: undefined, // Don't stop after a certain number of failures - run all tests
     reporter: process.env.CI ? [["json", { outputFile: "test-results/playwright-results.json" }], ["list"]] : "html",
-    timeout: 120000, // 2 minutes for tests that may take longer (e.g., wallet address retrieval, funding)
+    timeout: 180000, // 3 minutes — phone OTP confirmation can take 90s+ on retries (slow SMS delivery)
     use: {
         baseURL: process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3000",
         trace: "on-first-retry",


### PR DESCRIPTION
## Description

 - Stellar prepared transaction always failing: approval-test.tsx used wallet?.chain !== "solana" to detect EVM      
  wallets, which incorrectly treated Stellar as EVM. This caused viem's isAddress() to reject all Stellar addresses   
  (G.../C...) with "Invalid recipient address" — the prepared transaction was never created and the test timed out    
  waiting for an element that never appeared. Fixed chain detection, added Stellar regex validation, and added a      
  stable data-testid="prepare-recipient" to the recipient input.                                                      
  - Phone OTP transfer test failing on retries: The sendCodePromise URL pattern (/signers/, /approvals,
  /transactions/, /confirm) never matches the phone OTP send endpoint, so it always burned 30s waiting for a response
  that never comes. On later retries with slow SMS delivery, the remaining budget wasn't enough. Reduced that wasted
  wait to 10s, extended the "Check your phone" message wait to 90s, and raised the global test timeout to 3 minutes.
  - webkit + phone authenticate tests failing on all retries: The toContainText("Wallets Quickstart") assertion uses
  Playwright's default 5s expect timeout. webkit on CI renders more slowly for phone signer configs, consistently
  timing out. Raised the global expect.timeout to 15s.

## Test plan

Tests should pass in CI - Example execution: https://github.com/Crossmint/crossmint-sdk/actions/runs/24347855334/job/71093624854

## Package updates

<!-- 
  List any package updates and ensure you've added the necessary changesets, running `pnpm change:add` to do so.
-->