### PR TITLE
fix: backport WebView keyboard scroll fix to 0.x.x (#1754)

### DIFF
--- a/.changeset/backport-keyboard-scroll-fix.md
+++ b/.changeset/backport-keyboard-scroll-fix.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-native-ui": patch
+---
+
+fix: enable WebView scrolling so keyboard no longer covers inputs in embedded checkout

--- a/packages/client/ui/react-native/src/components/embed/v3/EmbeddedCheckoutV3WebView.tsx
+++ b/packages/client/ui/react-native/src/components/embed/v3/EmbeddedCheckoutV3WebView.tsx
@@ -94,7 +94,7 @@ export function EmbeddedCheckoutV3WebView(props: CrossmintEmbeddedCheckoutV3Prop
                     minWidth: "100%",
                     height,
                     backgroundColor: "transparent",
-                    overflow: "hidden",
+                    overflow: undefined,
                     opacity: 1,
                     padding: 0,
                     boxShadow: "none",
@@ -105,7 +105,7 @@ export function EmbeddedCheckoutV3WebView(props: CrossmintEmbeddedCheckoutV3Prop
                 mediaPlaybackRequiresUserAction={false}
                 allowsBackForwardNavigationGestures={false}
                 allowsLinkPreview={false}
-                scrollEnabled={false}
+                scrollEnabled={true}
                 bounces={false}
                 showsHorizontalScrollIndicator={false}
                 showsVerticalScrollIndicator={false}


### PR DESCRIPTION
## Summary

- Backports #1754 to the `0.x.x` branch for release as `0.13.30` (legacy dist-tag)
- `scrollEnabled={false}` → `scrollEnabled={true}` and `overflow: "hidden"` → `overflow: undefined` on the embedded checkout WebView
- Fixes iOS keyboard covering input fields in embedded checkout

## Test plan

- [ ] Verify on iOS simulator with software keyboard (Cmd+Shift+K) that inputs scroll into view
- [ ] Verify no double-scrolling regression in bottom-sheet embeddings
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/crossmint-sdk/pull/1795" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
