### PR TITLE
feat: add key export event callback to SDK

### DIFF
--- a/.changeset/key-export-event.md
+++ b/.changeset/key-export-event.md
@@ -1,0 +1,7 @@
+---
+"@crossmint/client-sdk-react-ui": minor
+"@crossmint/wallets-sdk": minor
+"@crossmint/client-signers": minor
+---
+
+Add key export event reporting: new `onExport` callback prop on `ExportPrivateKeyButton`, `event:key-exported` outbound event schema, and listener wiring in NCS signer.

--- a/.changeset/key-export-event.md
+++ b/.changeset/key-export-event.md
@@ -1,7 +1,8 @@
 ---
 "@crossmint/client-sdk-react-ui": minor
+"@crossmint/client-sdk-react-native-ui": minor
 "@crossmint/wallets-sdk": minor
 "@crossmint/client-signers": minor
 ---
 
-Add key export event reporting: new `onExport` callback prop on `ExportPrivateKeyButton`, `event:key-exported` outbound event schema, and listener wiring in NCS signer.
+Add key export event reporting: new `onExport` callback prop on `ExportPrivateKeyButton` (React and React Native), `event:key-exported` outbound event schema, and listener wiring in NCS signer.

--- a/packages/client/signers/src/communications/events.ts
+++ b/packages/client/signers/src/communications/events.ts
@@ -1,4 +1,4 @@
-import type { z } from "zod";
+import { z } from "zod";
 
 import {
     GetStatusPayloadSchema,
@@ -38,6 +38,7 @@ export const exportSignerInboundEvents = {
 
 export const exportSignerOutboundEvents = {
     "response:export-signer": ExportSignerPayloadSchema.response,
+    "event:key-exported": z.object({}),
 } as const;
 
 export type ExportSignerInputEvent<E extends ExportSignerEventName> = z.infer<

--- a/packages/client/signers/src/communications/events.ts
+++ b/packages/client/signers/src/communications/events.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import type { z } from "zod";
 
 import {
     GetStatusPayloadSchema,
@@ -6,6 +6,7 @@ import {
     StartOnboardingPayloadSchema,
     CompleteOnboardingPayloadSchema,
     ExportSignerPayloadSchema,
+    KeyExportedPayloadSchema,
 } from "./schemas";
 
 export const SIGNER_EVENTS = ["start-onboarding", "complete-onboarding", "sign", "get-status"] as const;
@@ -38,7 +39,7 @@ export const exportSignerInboundEvents = {
 
 export const exportSignerOutboundEvents = {
     "response:export-signer": ExportSignerPayloadSchema.response,
-    "event:key-exported": z.object({}),
+    "event:key-exported": KeyExportedPayloadSchema.event,
 } as const;
 
 export type ExportSignerInputEvent<E extends ExportSignerEventName> = z.infer<

--- a/packages/client/signers/src/communications/schemas.ts
+++ b/packages/client/signers/src/communications/schemas.ts
@@ -110,6 +110,10 @@ export const SignPayloadSchema = {
     ),
 };
 
+export const KeyExportedPayloadSchema = {
+    event: ResultResponse(z.object({})),
+};
+
 export const ExportSignerPayloadSchema = {
     request: AuthenticatedEventRequest.extend({
         data: z

--- a/packages/client/ui/react-native/src/components/wallets/ExportPrivateKeyButton.tsx
+++ b/packages/client/ui/react-native/src/components/wallets/ExportPrivateKeyButton.tsx
@@ -27,7 +27,12 @@ export function ExportPrivateKeyButton({ appearance, onExport }: ExportPrivateKe
         typeof exportSignerOutboundEvents,
         typeof exportSignerInboundEvents
     > | null>(null);
+    const onExportRef = useRef(onExport);
     const [frameUrl, setFrameUrl] = useState<string>("");
+
+    useEffect(() => {
+        onExportRef.current = onExport;
+    }, [onExport]);
 
     useEffect(() => {
         if (crossmint != null) {
@@ -57,14 +62,14 @@ export function ExportPrivateKeyButton({ appearance, onExport }: ExportPrivateKe
                     });
                     connectionRef.current = connection;
                     await connection.handshakeWithChild();
-                    await wallet.signer._exportPrivateKey(connection, onExport);
+                    await wallet.signer._exportPrivateKey(connection, () => onExportRef.current?.());
                 }
             } catch (error) {
                 console.error("Failed to export private key:", error);
                 Alert.alert("Export Failed", "Failed to export private key. Please try again.");
             }
         },
-        [wallet, onExport]
+        [wallet]
     );
 
     const handleWebViewError = useCallback((syntheticEvent: { nativeEvent: unknown }) => {

--- a/packages/client/ui/react-native/src/components/wallets/ExportPrivateKeyButton.tsx
+++ b/packages/client/ui/react-native/src/components/wallets/ExportPrivateKeyButton.tsx
@@ -62,7 +62,10 @@ export function ExportPrivateKeyButton({ appearance, onExport }: ExportPrivateKe
                     });
                     connectionRef.current = connection;
                     await connection.handshakeWithChild();
-                    await wallet.signer._exportPrivateKey(connection, () => onExportRef.current?.());
+                    await wallet.signer._exportPrivateKey(
+                        connection,
+                        onExportRef.current != null ? () => onExportRef.current?.() : undefined
+                    );
                 }
             } catch (error) {
                 console.error("Failed to export private key:", error);

--- a/packages/client/ui/react-native/src/components/wallets/ExportPrivateKeyButton.tsx
+++ b/packages/client/ui/react-native/src/components/wallets/ExportPrivateKeyButton.tsx
@@ -11,13 +11,15 @@ import { WebViewParent, RNWebView } from "@crossmint/client-sdk-rn-window";
 export interface ExportPrivateKeyButtonProps {
     /** Optional appearance configuration for styling the export button. */
     appearance?: UIConfig;
+    /** Optional callback invoked after the user successfully exports (copies) their private key. */
+    onExport?: () => void | Promise<void>;
 }
 
 /**
  * Renders a button that allows the user to export their wallet's private key.
  * Only works with email and phone signers. Will not render for passkey or external wallet signers.
  */
-export function ExportPrivateKeyButton({ appearance }: ExportPrivateKeyButtonProps) {
+export function ExportPrivateKeyButton({ appearance, onExport }: ExportPrivateKeyButtonProps) {
     const { wallet } = useWallet();
     const { crossmint } = useCrossmint();
     const webViewRef = useRef<WebView>(null);
@@ -55,14 +57,14 @@ export function ExportPrivateKeyButton({ appearance }: ExportPrivateKeyButtonPro
                     });
                     connectionRef.current = connection;
                     await connection.handshakeWithChild();
-                    await wallet.signer._exportPrivateKey(connection);
+                    await wallet.signer._exportPrivateKey(connection, onExport);
                 }
             } catch (error) {
                 console.error("Failed to export private key:", error);
                 Alert.alert("Export Failed", "Failed to export private key. Please try again.");
             }
         },
-        [wallet]
+        [wallet, onExport]
     );
 
     const handleWebViewError = useCallback((syntheticEvent: { nativeEvent: unknown }) => {

--- a/packages/client/ui/react-ui/src/components/wallets/ExportPrivateKeyButton.tsx
+++ b/packages/client/ui/react-ui/src/components/wallets/ExportPrivateKeyButton.tsx
@@ -11,6 +11,8 @@ import { IFrameWindow, SignersWindowTransport } from "@crossmint/client-sdk-wind
 export interface ExportPrivateKeyButtonProps {
     /** Optional appearance configuration for styling the export button. */
     appearance?: UIConfig;
+    /** Optional callback invoked after the user successfully exports (copies) their private key. */
+    onExport?: () => void | Promise<void>;
 }
 
 const ExportFrame = styled.iframe<{ appearance?: UIConfig }>`
@@ -25,7 +27,7 @@ const ExportFrame = styled.iframe<{ appearance?: UIConfig }>`
     box-shadow: none;
 `;
 
-export function ExportPrivateKeyButton({ appearance }: ExportPrivateKeyButtonProps) {
+export function ExportPrivateKeyButton({ appearance, onExport }: ExportPrivateKeyButtonProps) {
     const { wallet } = useWallet();
     const { crossmint } = useCrossmint();
     const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -64,7 +66,7 @@ export function ExportPrivateKeyButton({ appearance }: ExportPrivateKeyButtonPro
                     SignersWindowTransport
                 );
                 await connection.handshakeWithChild();
-                await wallet.signer._exportPrivateKey(connection);
+                await wallet.signer._exportPrivateKey(connection, onExport);
             }
         } catch (error) {
             console.error("Failed to export private key:", error);

--- a/packages/client/ui/react-ui/src/components/wallets/ExportPrivateKeyButton.tsx
+++ b/packages/client/ui/react-ui/src/components/wallets/ExportPrivateKeyButton.tsx
@@ -71,7 +71,10 @@ export function ExportPrivateKeyButton({ appearance, onExport }: ExportPrivateKe
                     SignersWindowTransport
                 );
                 await connection.handshakeWithChild();
-                await wallet.signer._exportPrivateKey(connection, () => onExportRef.current?.());
+                await wallet.signer._exportPrivateKey(
+                    connection,
+                    onExportRef.current != null ? () => onExportRef.current?.() : undefined
+                );
             }
         } catch (error) {
             console.error("Failed to export private key:", error);

--- a/packages/client/ui/react-ui/src/components/wallets/ExportPrivateKeyButton.tsx
+++ b/packages/client/ui/react-ui/src/components/wallets/ExportPrivateKeyButton.tsx
@@ -71,7 +71,7 @@ export function ExportPrivateKeyButton({ appearance, onExport }: ExportPrivateKe
         } catch (error) {
             console.error("Failed to export private key:", error);
         }
-    }, [wallet, frameUrl]);
+    }, [wallet, frameUrl, onExport]);
 
     if (
         frameUrl.toString() === "" ||

--- a/packages/client/ui/react-ui/src/components/wallets/ExportPrivateKeyButton.tsx
+++ b/packages/client/ui/react-ui/src/components/wallets/ExportPrivateKeyButton.tsx
@@ -31,7 +31,12 @@ export function ExportPrivateKeyButton({ appearance, onExport }: ExportPrivateKe
     const { wallet } = useWallet();
     const { crossmint } = useCrossmint();
     const iframeRef = useRef<HTMLIFrameElement>(null);
+    const onExportRef = useRef(onExport);
     const [frameUrl, setFrameUrl] = useState<string>("");
+
+    useEffect(() => {
+        onExportRef.current = onExport;
+    }, [onExport]);
 
     useEffect(() => {
         if (crossmint != null) {
@@ -66,12 +71,12 @@ export function ExportPrivateKeyButton({ appearance, onExport }: ExportPrivateKe
                     SignersWindowTransport
                 );
                 await connection.handshakeWithChild();
-                await wallet.signer._exportPrivateKey(connection, onExport);
+                await wallet.signer._exportPrivateKey(connection, () => onExportRef.current?.());
             }
         } catch (error) {
             console.error("Failed to export private key:", error);
         }
-    }, [wallet, frameUrl, onExport]);
+    }, [wallet, frameUrl]);
 
     if (
         frameUrl.toString() === "" ||

--- a/packages/wallets/src/signers/non-custodial/ncs-signer.ts
+++ b/packages/wallets/src/signers/non-custodial/ncs-signer.ts
@@ -344,7 +344,8 @@ export abstract class NonCustodialSigner implements SignerAdapter {
         const { scheme, encoding } = this.getChainKeyParams();
 
         if (onExport != null) {
-            exportTEEConnection.on("event:key-exported", () => {
+            const listenerId = exportTEEConnection.on("event:key-exported", () => {
+                exportTEEConnection.off(listenerId);
                 Promise.resolve()
                     .then(() => onExport())
                     .catch((err) => {

--- a/packages/wallets/src/signers/non-custodial/ncs-signer.ts
+++ b/packages/wallets/src/signers/non-custodial/ncs-signer.ts
@@ -344,8 +344,9 @@ export abstract class NonCustodialSigner implements SignerAdapter {
         const { scheme, encoding } = this.getChainKeyParams();
 
         if (onExport != null) {
-            const listenerId = exportTEEConnection.on("event:key-exported", () => {
+            const listenerId = exportTEEConnection.on("event:key-exported", (data) => {
                 exportTEEConnection.off(listenerId);
+                if (data.status !== "success") return;
                 Promise.resolve()
                     .then(() => onExport())
                     .catch(() => {

--- a/packages/wallets/src/signers/non-custodial/ncs-signer.ts
+++ b/packages/wallets/src/signers/non-custodial/ncs-signer.ts
@@ -334,11 +334,26 @@ export abstract class NonCustodialSigner implements SignerAdapter {
      * Export the private key for this signer
      * @throws {Error} If signer is not authenticated
      */
-    async _exportPrivateKey(exportTEEConnection: ExportSignerTEEConnection): Promise<void> {
+    async _exportPrivateKey(
+        exportTEEConnection: ExportSignerTEEConnection,
+        onExport?: () => void | Promise<void>
+    ): Promise<void> {
         await this.handleAuthRequired();
         const jwt = this.getJwtOrThrow();
 
         const { scheme, encoding } = this.getChainKeyParams();
+
+        if (onExport != null) {
+            exportTEEConnection.on("event:key-exported", () => {
+                try {
+                    Promise.resolve(onExport()).catch((err) => {
+                        console.error("[NCS Signer] onExport callback error:", err);
+                    });
+                } catch (err) {
+                    console.error("[NCS Signer] onExport callback error:", err);
+                }
+            });
+        }
 
         const response = await exportTEEConnection.sendAction({
             event: "request:export-signer",

--- a/packages/wallets/src/signers/non-custodial/ncs-signer.ts
+++ b/packages/wallets/src/signers/non-custodial/ncs-signer.ts
@@ -345,13 +345,11 @@ export abstract class NonCustodialSigner implements SignerAdapter {
 
         if (onExport != null) {
             exportTEEConnection.on("event:key-exported", () => {
-                try {
-                    Promise.resolve(onExport()).catch((err) => {
+                Promise.resolve()
+                    .then(() => onExport())
+                    .catch((err) => {
                         console.error("[NCS Signer] onExport callback error:", err);
                     });
-                } catch (err) {
-                    console.error("[NCS Signer] onExport callback error:", err);
-                }
             });
         }
 

--- a/packages/wallets/src/signers/non-custodial/ncs-signer.ts
+++ b/packages/wallets/src/signers/non-custodial/ncs-signer.ts
@@ -348,8 +348,8 @@ export abstract class NonCustodialSigner implements SignerAdapter {
                 exportTEEConnection.off(listenerId);
                 Promise.resolve()
                     .then(() => onExport())
-                    .catch((err) => {
-                        console.error("[NCS Signer] onExport callback error:", err);
+                    .catch(() => {
+                        console.error("[NCS Signer] onExport callback error");
                     });
             });
         }

--- a/packages/wallets/src/signers/types.ts
+++ b/packages/wallets/src/signers/types.ts
@@ -226,7 +226,10 @@ export interface SignerAdapter<T extends keyof SignResultMap = keyof SignResultM
 }
 
 export interface ExportableSignerAdapter extends SignerAdapter {
-    _exportPrivateKey: (exportTEEConnection: ExportSignerTEEConnection) => Promise<void>;
+    _exportPrivateKey: (
+        exportTEEConnection: ExportSignerTEEConnection,
+        onExport?: () => void | Promise<void>
+    ) => Promise<void>;
 }
 
 export function isExportableSignerAdapter(signer: SignerAdapter): signer is ExportableSignerAdapter {


### PR DESCRIPTION
## Description

Adds an `onExport` callback prop to `ExportPrivateKeyButton` (React **and** React Native) so host applications can react when a user successfully exports (copies) their private key. The iframe sends an `event:key-exported` PostMessage after clipboard copy; the SDK listens for it and invokes the callback.

This is the SDK-side counterpart to the event reporting added in [open-signer#199](https://github.com/Crossmint/open-signer/pull/199).

### Changes

1. **`KeyExportedPayloadSchema`** (`packages/client/signers/…/schemas.ts`) — new schema using `ResultResponse(z.object({}))`, consistent with all other event schemas. Imported and referenced in `exportSignerOutboundEvents` in `events.ts`.
2. **`onExport` prop** (`ExportPrivateKeyButton.tsx`, both React and React Native) — optional `() => void | Promise<void>` callback. Uses a `useRef` pattern to keep the callback current without causing iframe/WebView reloads when the parent re-renders with a new function reference.
3. **Listener wiring** (`ncs-signer.ts`) — registers a **fire-once** `on("event:key-exported")` listener on the TEE connection before sending the export request. The listener deregisters itself via `off(listenerId)` after the first invocation, then guards on `data.status === "success"` before invoking the callback. Error handling uses `Promise.resolve().then().catch()` to handle both sync throws and async rejections without blocking the export flow.
4. **Interface update** (`types.ts`) — `ExportableSignerAdapter._exportPrivateKey` signature updated to accept the optional callback.
5. **Conditional registration** — UI components only pass the callback wrapper when `onExportRef.current != null`, so the `if (onExport != null)` guard in `ncs-signer` correctly skips listener registration when no callback is provided.

### ⚠️ Review focus / human checklist

- [ ] **Schema validation**: The iframe sends `{ status: "success" }`. Verify `ResultResponse(z.object({}))` accepts this payload (it should — the success branch is `z.object({ status: z.literal("success") }).and(z.object({}))`).
- [ ] **Status guard + fire-once interaction**: The listener deregisters after the *first* `event:key-exported` regardless of status. If the first event were an error, `onExport` would never fire. In practice, the iframe only sends the event on successful clipboard copy, so this should be fine — but worth confirming.
- [ ] **Event timing**: `event:key-exported` fires from the iframe *after* `response:export-signer` (which resolves `sendAction`). The listener must still be reachable when the event arrives.
- [ ] **Late `onExport` prop**: The `onExportRef.current != null` check runs when `handleIframeLoad`/`handleWebViewLoadEnd` fires. If `onExport` is `undefined` at iframe load time but provided later, the listener won't be registered.
- [ ] **Error objects not logged**: `catch` blocks use static strings only (no error object) per Alberto's review feedback about avoiding sensitive info leaks. Trade-off is reduced debuggability.

## Test plan

Manually verified lint passes (`pnpm lint`). CI build & test and lint checks pass. No new unit tests — the callback is a fire-and-forget hook that depends on the iframe PostMessage flow, which cannot be exercised in isolation without mocking the transport layer. Integration testing recommended once both PRs (this + open-signer#199) are merged and deployed together.

## Package updates

- `@crossmint/client-sdk-react-ui` — minor
- `@crossmint/client-sdk-react-native-ui` — minor
- `@crossmint/wallets-sdk` — minor
- `@crossmint/client-signers` — minor

Changeset added via `.changeset/key-export-event.md`.

Link to Devin session: https://crossmint.devinenterprise.com/sessions/d079cc2486724c0d9c11a45c7d953750
Requested by: @panosinthezone