### PR TITLE
fix(react-ui): resolve OAuth URL on demand to fix race with prefetch

### DIFF
--- a/.changeset/chatty-emus-smash.md
+++ b/.changeset/chatty-emus-smash.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-window": patch
+---
+
+Adds a `PopupWindow.initEmpty()` helper to open about:blank synchronously.

--- a/.changeset/social-houses-wink.md
+++ b/.changeset/social-houses-wink.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+---
+
+Fix race when loading crossmint OAuth frame

--- a/apps/auth/nextjs-ssr/tsconfig.json
+++ b/apps/auth/nextjs-ssr/tsconfig.json
@@ -19,7 +19,8 @@
         ],
         "paths": {
             "@/*": ["./src/*"]
-        }
+        },
+        "target": "ES2017"
     },
     "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
     "exclude": ["node_modules"]

--- a/apps/payments/nextjs/next-env.d.ts
+++ b/apps/payments/nextjs/next-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/client/ui/react-ui/src/hooks/useOAuthWindowListener.ts
+++ b/packages/client/ui/react-ui/src/hooks/useOAuthWindowListener.ts
@@ -34,17 +34,18 @@ export const useOAuthWindowListener = (oauthUrlMap: OAuthUrlMap, setError: (erro
             setActiveOAuthProvider(provider);
             setError(null);
 
-            // Open the popup synchronously with a blank URL so it isn't blocked by the popup blocker,
-            // then resolve the OAuth URL (using the prefetched value if present) and navigate the popup.
-            const popup = PopupWindow.initEmpty<IncomingEvents, OutgoingEvents>({
-                crossOrigin: true,
-                width: 400,
-                height: 700,
-                incomingEvents,
-            });
-
+            let popup: PopupWindow<IncomingEvents, OutgoingEvents>;
             let baseUrl: URL;
             try {
+                // Open the popup synchronously with a blank URL so it isn't blocked by the popup blocker,
+                // then resolve the OAuth URL (using the prefetched value if present) and navigate the popup.
+                popup = PopupWindow.initEmpty<IncomingEvents, OutgoingEvents>({
+                    crossOrigin: true,
+                    width: 400,
+                    height: 700,
+                    incomingEvents,
+                });
+
                 const prefetchedUrl = oauthUrlMap[provider];
                 const resolvedUrl = prefetchedUrl || (await crossmintAuth?.getOAuthUrl(provider));
                 if (!resolvedUrl) {
@@ -52,7 +53,6 @@ export const useOAuthWindowListener = (oauthUrlMap: OAuthUrlMap, setError: (erro
                 }
                 baseUrl = new URL(resolvedUrl);
             } catch (e) {
-                popup.window?.close();
                 setActiveOAuthProvider(null);
                 setError(e instanceof Error ? e.message : "Failed to start OAuth login");
                 return;

--- a/packages/client/ui/react-ui/src/hooks/useOAuthWindowListener.ts
+++ b/packages/client/ui/react-ui/src/hooks/useOAuthWindowListener.ts
@@ -48,7 +48,7 @@ export const useOAuthWindowListener = (oauthUrlMap: OAuthUrlMap, setError: (erro
 
                 const prefetchedUrl = oauthUrlMap[provider];
                 const resolvedUrl = prefetchedUrl || (await crossmintAuth?.getOAuthUrl(provider));
-                if (!resolvedUrl) {
+                if (resolvedUrl == null) {
                     throw new Error("Failed to resolve OAuth URL");
                 }
                 baseUrl = new URL(resolvedUrl);

--- a/packages/client/ui/react-ui/src/hooks/useOAuthWindowListener.ts
+++ b/packages/client/ui/react-ui/src/hooks/useOAuthWindowListener.ts
@@ -34,7 +34,7 @@ export const useOAuthWindowListener = (oauthUrlMap: OAuthUrlMap, setError: (erro
             setActiveOAuthProvider(provider);
             setError(null);
 
-            let popup: PopupWindow<IncomingEvents, OutgoingEvents>;
+            let popup: PopupWindow<IncomingEvents, OutgoingEvents> | undefined;
             let baseUrl: URL;
             try {
                 // Open the popup synchronously with a blank URL so it isn't blocked by the popup blocker,
@@ -53,6 +53,7 @@ export const useOAuthWindowListener = (oauthUrlMap: OAuthUrlMap, setError: (erro
                 }
                 baseUrl = new URL(resolvedUrl);
             } catch (e) {
+                popup?.window?.close();
                 setActiveOAuthProvider(null);
                 setError(e instanceof Error ? e.message : "Failed to start OAuth login");
                 return;

--- a/packages/client/ui/react-ui/src/hooks/useOAuthWindowListener.ts
+++ b/packages/client/ui/react-ui/src/hooks/useOAuthWindowListener.ts
@@ -34,11 +34,29 @@ export const useOAuthWindowListener = (oauthUrlMap: OAuthUrlMap, setError: (erro
             setActiveOAuthProvider(provider);
             setError(null);
 
-            console.log("createPopupAndSetupListeners", provider, providerLoginHint);
-            console.log("oauthUrlMap", oauthUrlMap);
-            console.log("oauthUrlMap[provider]", oauthUrlMap[provider]);
+            // Open the popup synchronously with a blank URL so it isn't blocked by the popup blocker,
+            // then resolve the OAuth URL (using the prefetched value if present) and navigate the popup.
+            const popup = PopupWindow.initEmpty<IncomingEvents, OutgoingEvents>({
+                crossOrigin: true,
+                width: 400,
+                height: 700,
+                incomingEvents,
+            });
 
-            const baseUrl = new URL(oauthUrlMap[provider]);
+            let baseUrl: URL;
+            try {
+                const prefetchedUrl = oauthUrlMap[provider];
+                const resolvedUrl = prefetchedUrl || (await crossmintAuth?.getOAuthUrl(provider));
+                if (!resolvedUrl) {
+                    throw new Error("Failed to resolve OAuth URL");
+                }
+                baseUrl = new URL(resolvedUrl);
+            } catch (e) {
+                popup.window?.close();
+                setActiveOAuthProvider(null);
+                setError(e instanceof Error ? e.message : "Failed to start OAuth login");
+                return;
+            }
 
             // The provider_login_hint is a parameter that can be used to pre-fill the email field of the OAuth provider to allow auto-login if session exists.
             // Stytch Docs: https://stytch.com/docs/api/oauth-google-start#additional-provider-parameters
@@ -58,12 +76,9 @@ export const useOAuthWindowListener = (oauthUrlMap: OAuthUrlMap, setError: (erro
                 });
             }
 
-            const popup = await PopupWindow.init(baseUrl.toString(), {
-                awaitToLoad: false,
-                crossOrigin: true,
-                width: 400,
-                height: 700,
-            });
+            if (popup.window != null) {
+                popup.window.location.href = baseUrl.toString();
+            }
 
             const handleAuthMaterial = async (data: { oneTimeSecret: string }) => {
                 await crossmintAuth?.handleRefreshAuthMaterial(data.oneTimeSecret);

--- a/packages/client/window/src/windows/Popup.ts
+++ b/packages/client/window/src/windows/Popup.ts
@@ -50,6 +50,22 @@ export class PopupWindow<IncomingEvents extends EventMap, OutgoingEvents extends
             options
         );
     }
+
+    // Opens an empty popup synchronously so it's not blocked by the popup blocker, then lets the
+    // caller navigate it once an async URL resolves. Use `window.location.href = url` to navigate.
+    static initEmpty<IncomingEvents extends EventMap, OutgoingEvents extends EventMap>(
+        options: PopupWindowOptions & EventEmitterWithHandshakeOptions<IncomingEvents, OutgoingEvents>
+    ) {
+        const _window = window.open(
+            "about:blank",
+            "popupWindow",
+            createPopupString(options.width, options.height, options?.crossOrigin || false)
+        );
+        if (!_window) {
+            throw new Error("Failed to open popup window");
+        }
+        return new PopupWindow<IncomingEvents, OutgoingEvents>(_window, options.targetOrigin || "*", options);
+    }
 }
 
 function createPopupSync(url: string, options: PopupWindowOptions) {

--- a/packages/client/window/src/windows/Popup.ts
+++ b/packages/client/window/src/windows/Popup.ts
@@ -61,7 +61,7 @@ export class PopupWindow<IncomingEvents extends EventMap, OutgoingEvents extends
             "popupWindow",
             createPopupString(options.width, options.height, options?.crossOrigin || false)
         );
-        if (!_window) {
+        if (_window == null) {
             throw new Error("Failed to open popup window");
         }
         return new PopupWindow<IncomingEvents, OutgoingEvents>(_window, options.targetOrigin || "*", options);


### PR DESCRIPTION
## Description

`createPopupAndSetupListeners` now opens an empty popup synchronously on click (avoiding popup-blocker issues), then resolves the OAuth URL — preferring the prefetched value, falling back to crossmintAuth.getOAuthUrl(provider) on demand — and navigates the popup once the URL is ready. Prefetch becomes a pure latency optimization rather than a correctness requirement.

Adds a `PopupWindow.initEmpty()` helper in `@crossmint/client-sdk-window` to open about:blank synchronously (the existing initSync rejects non-http(s) URLs via safeUrl).

Fixes this error 
<img width="1532" height="624" alt="image" src="https://github.com/user-attachments/assets/f63c28bb-d1d9-4ed7-8e08-37bbfa382e40" />


## Test plan

Tested manually in playground react app and issue was no longer reproducible.  

## Package updates

@crossmint/client-sdk-react-ui
@crossmint/client-sdk-window