### PR TITLE
ci: add SDK docs generation workflow for auto-sync

### DIFF
--- a/.github/workflows/sdk-docs-generate.yml
+++ b/.github/workflows/sdk-docs-generate.yml
@@ -108,4 +108,4 @@ jobs:
                   token: ${{ steps.generate_app_token.outputs.token }}
                   repository: Paella-Labs/crossbit-main
                   event-type: sdk-docs-update
-                  client-payload: '{"run_id": "${{ github.run_id }}", "packages": ${{ toJSON(inputs.packages || 'react-ui,react-native,wallets') }}}'
+                  client-payload: '{"run_id": "${{ github.run_id }}", "packages": ${{ toJSON(inputs.packages || ''react-ui,react-native,wallets'') }}}'

--- a/.github/workflows/sdk-docs-generate.yml
+++ b/.github/workflows/sdk-docs-generate.yml
@@ -76,15 +76,15 @@ jobs:
                   mkdir -p sdk-reference/wallets/typescript
 
                   if [ "${{ steps.packages.outputs.react_ui }}" == "true" ] && [ -d packages/client/ui/react-ui/docs/wallets ]; then
-                    cp -r packages/client/ui/react-ui/docs/wallets/* sdk-reference/wallets/react/
+                    cp -r packages/client/ui/react-ui/docs/wallets/. sdk-reference/wallets/react/
                   fi
 
                   if [ "${{ steps.packages.outputs.react_native }}" == "true" ] && [ -d packages/client/ui/react-native/docs/wallets ]; then
-                    cp -r packages/client/ui/react-native/docs/wallets/* sdk-reference/wallets/react-native/
+                    cp -r packages/client/ui/react-native/docs/wallets/. sdk-reference/wallets/react-native/
                   fi
 
                   if [ "${{ steps.packages.outputs.wallets }}" == "true" ] && [ -d packages/wallets/docs ]; then
-                    cp -r packages/wallets/docs/* sdk-reference/wallets/typescript/
+                    cp -r packages/wallets/docs/. sdk-reference/wallets/typescript/
                   fi
 
             - name: Upload generated docs artifact

--- a/.github/workflows/sdk-docs-generate.yml
+++ b/.github/workflows/sdk-docs-generate.yml
@@ -70,24 +70,39 @@ jobs:
                   fi
 
             - name: Collect generated files
+              env:
+                  REACT_UI_ENABLED: ${{ steps.packages.outputs.react_ui }}
+                  REACT_NATIVE_ENABLED: ${{ steps.packages.outputs.react_native }}
+                  WALLETS_ENABLED: ${{ steps.packages.outputs.wallets }}
               run: |
                   mkdir -p sdk-reference/wallets/react
                   mkdir -p sdk-reference/wallets/react-native
                   mkdir -p sdk-reference/wallets/typescript
 
-                  if [ "${{ steps.packages.outputs.react_ui }}" == "true" ] && [ -d packages/client/ui/react-ui/docs/wallets ]; then
+                  if [ "$REACT_UI_ENABLED" == "true" ] && [ -d packages/client/ui/react-ui/docs/wallets ]; then
                     cp -r packages/client/ui/react-ui/docs/wallets/. sdk-reference/wallets/react/
                   fi
 
-                  if [ "${{ steps.packages.outputs.react_native }}" == "true" ] && [ -d packages/client/ui/react-native/docs/wallets ]; then
+                  if [ "$REACT_NATIVE_ENABLED" == "true" ] && [ -d packages/client/ui/react-native/docs/wallets ]; then
                     cp -r packages/client/ui/react-native/docs/wallets/. sdk-reference/wallets/react-native/
                   fi
 
-                  if [ "${{ steps.packages.outputs.wallets }}" == "true" ] && [ -d packages/wallets/docs ]; then
+                  if [ "$WALLETS_ENABLED" == "true" ] && [ -d packages/wallets/docs ]; then
                     cp -r packages/wallets/docs/. sdk-reference/wallets/typescript/
                   fi
 
+            - name: Verify at least one package was generated
+              id: verify
+              run: |
+                  if [ -z "$(find sdk-reference/ -name '*.mdx' -print -quit)" ]; then
+                    echo "No MDX files generated — no valid packages matched"
+                    echo "has_docs=false" >> $GITHUB_OUTPUT
+                  else
+                    echo "has_docs=true" >> $GITHUB_OUTPUT
+                  fi
+
             - name: Upload generated docs artifact
+              if: steps.verify.outputs.has_docs == 'true'
               uses: actions/upload-artifact@v4
               with:
                   name: sdk-reference-docs
@@ -95,6 +110,7 @@ jobs:
                   retention-days: 7
 
             - name: Generate App Token
+              if: steps.verify.outputs.has_docs == 'true'
               id: generate_app_token
               uses: actions/create-github-app-token@v2
               with:
@@ -103,6 +119,7 @@ jobs:
                   owner: Paella-Labs
 
             - name: Dispatch to crossbit-main
+              if: steps.verify.outputs.has_docs == 'true'
               uses: peter-evans/repository-dispatch@v3
               with:
                   token: ${{ steps.generate_app_token.outputs.token }}

--- a/.github/workflows/sdk-docs-generate.yml
+++ b/.github/workflows/sdk-docs-generate.yml
@@ -96,13 +96,10 @@ jobs:
               run: |
                   if [ -z "$(find sdk-reference/ -name '*.mdx' -print -quit)" ]; then
                     echo "No MDX files generated — no valid packages matched"
-                    echo "has_docs=false" >> $GITHUB_OUTPUT
-                  else
-                    echo "has_docs=true" >> $GITHUB_OUTPUT
+                    exit 1
                   fi
 
             - name: Upload generated docs artifact
-              if: steps.verify.outputs.has_docs == 'true'
               uses: actions/upload-artifact@v4
               with:
                   name: sdk-reference-docs
@@ -110,17 +107,16 @@ jobs:
                   retention-days: 7
 
             - name: Generate App Token
-              if: steps.verify.outputs.has_docs == 'true'
               id: generate_app_token
               uses: actions/create-github-app-token@v2
               with:
                   app-id: ${{ vars.CROSSMINT_DEPLOY_BOT_APP_ID }}
                   private-key: ${{ secrets.CROSSMINT_DEPLOY_BOT_PRIVATE_KEY }}
                   owner: Paella-Labs
+                  repositories: crossbit-main
 
             - name: Dispatch to crossbit-main
-              if: steps.verify.outputs.has_docs == 'true'
-              uses: peter-evans/repository-dispatch@v3
+              uses: peter-evans/repository-dispatch@ce57bf9958701f3a8aa0f5e7fe00d698f32de22a  # v3.0.0
               with:
                   token: ${{ steps.generate_app_token.outputs.token }}
                   repository: Paella-Labs/crossbit-main

--- a/.github/workflows/sdk-docs-generate.yml
+++ b/.github/workflows/sdk-docs-generate.yml
@@ -31,6 +31,10 @@ on:
 permissions:
     contents: read
 
+concurrency:
+    group: sdk-docs-generate-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     generate-docs:
         name: Generate SDK Reference Docs

--- a/.github/workflows/sdk-docs-generate.yml
+++ b/.github/workflows/sdk-docs-generate.yml
@@ -1,0 +1,109 @@
+name: SDK Docs Generate
+
+on:
+    workflow_dispatch:
+        inputs:
+            packages:
+                description: "Comma-separated list of packages to generate docs for (react-ui, react-native, wallets). Defaults to all."
+                required: false
+                default: "react-ui,react-native,wallets"
+                type: string
+
+permissions:
+    contents: read
+
+jobs:
+    generate-docs:
+        name: Generate SDK Reference Docs
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  ref: main
+
+            - name: Setup Node.js, PNPM, and install dependencies
+              uses: ./.github/actions/pnpm-install
+
+            - name: Build libraries
+              run: pnpm build:libs
+
+            - name: Parse package selection
+              id: packages
+              run: |
+                  PACKAGES="${{ inputs.packages || 'react-ui,react-native,wallets' }}"
+                  echo "react_ui=false" >> $GITHUB_OUTPUT
+                  echo "react_native=false" >> $GITHUB_OUTPUT
+                  echo "wallets=false" >> $GITHUB_OUTPUT
+                  if echo "$PACKAGES" | grep -q "react-ui"; then
+                    echo "react_ui=true" >> $GITHUB_OUTPUT
+                  fi
+                  if echo "$PACKAGES" | grep -q "react-native"; then
+                    echo "react_native=true" >> $GITHUB_OUTPUT
+                  fi
+                  if echo "$PACKAGES" | grep -q "wallets"; then
+                    echo "wallets=true" >> $GITHUB_OUTPUT
+                  fi
+
+            - name: Generate React UI docs
+              if: steps.packages.outputs.react_ui == 'true'
+              working-directory: packages/client/ui/react-ui
+              run: pnpm generate:docs
+
+            - name: Generate React Native docs
+              if: steps.packages.outputs.react_native == 'true'
+              working-directory: packages/client/ui/react-native
+              run: pnpm generate:docs
+
+            - name: Generate Wallets SDK docs
+              if: steps.packages.outputs.wallets == 'true'
+              working-directory: packages/wallets
+              run: |
+                  pnpm generate:docs
+                  if [ -f docs/globals.mdx ]; then
+                    mv docs/globals.mdx docs/reference.mdx
+                  fi
+                  if [ -f docs/README.mdx ]; then
+                    mv docs/README.mdx docs/overview.mdx
+                  fi
+
+            - name: Collect generated files
+              run: |
+                  mkdir -p sdk-reference/wallets/react
+                  mkdir -p sdk-reference/wallets/react-native
+                  mkdir -p sdk-reference/wallets/typescript
+
+                  if [ "${{ steps.packages.outputs.react_ui }}" == "true" ] && [ -d packages/client/ui/react-ui/docs/wallets ]; then
+                    cp -r packages/client/ui/react-ui/docs/wallets/* sdk-reference/wallets/react/
+                  fi
+
+                  if [ "${{ steps.packages.outputs.react_native }}" == "true" ] && [ -d packages/client/ui/react-native/docs/wallets ]; then
+                    cp -r packages/client/ui/react-native/docs/wallets/* sdk-reference/wallets/react-native/
+                  fi
+
+                  if [ "${{ steps.packages.outputs.wallets }}" == "true" ] && [ -d packages/wallets/docs ]; then
+                    cp -r packages/wallets/docs/* sdk-reference/wallets/typescript/
+                  fi
+
+            - name: Upload generated docs artifact
+              uses: actions/upload-artifact@v4
+              with:
+                  name: sdk-reference-docs
+                  path: sdk-reference/
+                  retention-days: 7
+
+            - name: Generate App Token
+              id: generate_app_token
+              uses: actions/create-github-app-token@v2
+              with:
+                  app-id: ${{ vars.CROSSMINT_DEPLOY_BOT_APP_ID }}
+                  private-key: ${{ secrets.CROSSMINT_DEPLOY_BOT_PRIVATE_KEY }}
+                  owner: Paella-Labs
+
+            - name: Dispatch to crossbit-main
+              uses: peter-evans/repository-dispatch@v3
+              with:
+                  token: ${{ steps.generate_app_token.outputs.token }}
+                  repository: Paella-Labs/crossbit-main
+                  event-type: sdk-docs-update
+                  client-payload: '{"run_id": "${{ github.run_id }}", "packages": "${{ inputs.packages || ''react-ui,react-native,wallets'' }}"}'

--- a/.github/workflows/sdk-docs-generate.yml
+++ b/.github/workflows/sdk-docs-generate.yml
@@ -1,17 +1,26 @@
 name: SDK Docs Generate
 
 on:
+    push:
+        branches: [main]
+        paths:
+            - "packages/wallets/src/**"
+            - "packages/wallets/typedoc.json"
+            - "packages/wallets/typedoc-custom-plugin.mjs"
+            - "packages/client/ui/react-ui/src/**"
+            - "packages/client/ui/react-ui/scripts/**"
+            - "packages/client/ui/react-ui/examples.json"
+            - "packages/client/ui/react-native/src/**"
+            - "packages/client/ui/react-native/scripts/**"
+            - "packages/client/ui/react-native/examples.json"
+            - "packages/client/ui/scripts/**"
+            - "packages/client/react-base/src/**"
     workflow_dispatch:
         inputs:
             packages:
                 description: "Comma-separated list of packages to generate docs for (react-ui, react-native, node-wallets). Defaults to all."
                 required: false
                 default: "react-ui,react-native,node-wallets"
-                type: string
-            ref:
-                description: "Git ref to check out (branch, tag, or SHA). Defaults to main. Use the input-fix branch when generating docs against updated examples.json or generate-reference.mjs."
-                required: false
-                default: "main"
                 type: string
 
 permissions:
@@ -24,8 +33,6 @@ jobs:
         timeout-minutes: 30
         steps:
             - uses: actions/checkout@v4
-              with:
-                  ref: ${{ inputs.ref || 'main' }}
 
             - name: Setup Node.js, PNPM, and install dependencies
               uses: ./.github/actions/pnpm-install
@@ -126,4 +133,4 @@ jobs:
                   token: ${{ steps.generate_app_token.outputs.token }}
                   repository: Paella-Labs/crossbit-main
                   event-type: sdk-docs-update
-                  client-payload: '{"run_id": "${{ github.run_id }}", "packages": ${{ toJSON(inputs.packages || ''react-ui,react-native,node-wallets'') }}, "source_ref": ${{ toJSON(inputs.ref || ''main'') }}}'
+                  client-payload: '{"run_id": "${{ github.run_id }}", "packages": ${{ toJSON(inputs.packages || ''react-ui,react-native,node-wallets'') }}, "source_ref": ${{ toJSON(github.ref_name) }}}'

--- a/.github/workflows/sdk-docs-generate.yml
+++ b/.github/workflows/sdk-docs-generate.yml
@@ -6,13 +6,18 @@ on:
         paths:
             - "packages/wallets/src/**"
             - "packages/wallets/typedoc.json"
+            - "packages/wallets/tsconfig.typedoc.json"
             - "packages/wallets/typedoc-custom-plugin.mjs"
             - "packages/client/ui/react-ui/src/**"
             - "packages/client/ui/react-ui/scripts/**"
             - "packages/client/ui/react-ui/examples.json"
+            - "packages/client/ui/react-ui/typedoc.json"
+            - "packages/client/ui/react-ui/tsconfig.typedoc.json"
             - "packages/client/ui/react-native/src/**"
             - "packages/client/ui/react-native/scripts/**"
             - "packages/client/ui/react-native/examples.json"
+            - "packages/client/ui/react-native/typedoc.json"
+            - "packages/client/ui/react-native/tsconfig.typedoc.json"
             - "packages/client/ui/scripts/**"
             - "packages/client/react-base/src/**"
     workflow_dispatch:

--- a/.github/workflows/sdk-docs-generate.yml
+++ b/.github/workflows/sdk-docs-generate.yml
@@ -37,13 +37,13 @@ jobs:
                   echo "react_ui=false" >> $GITHUB_OUTPUT
                   echo "react_native=false" >> $GITHUB_OUTPUT
                   echo "wallets=false" >> $GITHUB_OUTPUT
-                  if echo "$PACKAGES" | grep -q "react-ui"; then
+                  if echo ",$PACKAGES," | grep -q ",react-ui,"; then
                     echo "react_ui=true" >> $GITHUB_OUTPUT
                   fi
-                  if echo "$PACKAGES" | grep -q "react-native"; then
+                  if echo ",$PACKAGES," | grep -q ",react-native,"; then
                     echo "react_native=true" >> $GITHUB_OUTPUT
                   fi
-                  if echo "$PACKAGES" | grep -q "wallets"; then
+                  if echo ",$PACKAGES," | grep -q ",wallets,"; then
                     echo "wallets=true" >> $GITHUB_OUTPUT
                   fi
 

--- a/.github/workflows/sdk-docs-generate.yml
+++ b/.github/workflows/sdk-docs-generate.yml
@@ -8,6 +8,11 @@ on:
                 required: false
                 default: "react-ui,react-native,wallets"
                 type: string
+            ref:
+                description: "Git ref to check out (branch, tag, or SHA). Defaults to main. Use the input-fix branch when generating docs against updated examples.json or generate-reference.mjs."
+                required: false
+                default: "main"
+                type: string
 
 permissions:
     contents: read
@@ -20,7 +25,7 @@ jobs:
         steps:
             - uses: actions/checkout@v4
               with:
-                  ref: main
+                  ref: ${{ inputs.ref || 'main' }}
 
             - name: Setup Node.js, PNPM, and install dependencies
               uses: ./.github/actions/pnpm-install

--- a/.github/workflows/sdk-docs-generate.yml
+++ b/.github/workflows/sdk-docs-generate.yml
@@ -30,8 +30,10 @@ jobs:
 
             - name: Parse package selection
               id: packages
+              env:
+                  PACKAGES_INPUT: ${{ inputs.packages || 'react-ui,react-native,wallets' }}
               run: |
-                  PACKAGES="${{ inputs.packages || 'react-ui,react-native,wallets' }}"
+                  PACKAGES="$PACKAGES_INPUT"
                   echo "react_ui=false" >> $GITHUB_OUTPUT
                   echo "react_native=false" >> $GITHUB_OUTPUT
                   echo "wallets=false" >> $GITHUB_OUTPUT
@@ -106,4 +108,4 @@ jobs:
                   token: ${{ steps.generate_app_token.outputs.token }}
                   repository: Paella-Labs/crossbit-main
                   event-type: sdk-docs-update
-                  client-payload: '{"run_id": "${{ github.run_id }}", "packages": "${{ inputs.packages || ''react-ui,react-native,wallets'' }}"}'
+                  client-payload: '{"run_id": "${{ github.run_id }}", "packages": ${{ toJSON(inputs.packages || 'react-ui,react-native,wallets') }}}'

--- a/.github/workflows/sdk-docs-generate.yml
+++ b/.github/workflows/sdk-docs-generate.yml
@@ -4,9 +4,9 @@ on:
     workflow_dispatch:
         inputs:
             packages:
-                description: "Comma-separated list of packages to generate docs for (react-ui, react-native, wallets). Defaults to all."
+                description: "Comma-separated list of packages to generate docs for (react-ui, react-native, node-wallets). Defaults to all."
                 required: false
-                default: "react-ui,react-native,wallets"
+                default: "react-ui,react-native,node-wallets"
                 type: string
             ref:
                 description: "Git ref to check out (branch, tag, or SHA). Defaults to main. Use the input-fix branch when generating docs against updated examples.json or generate-reference.mjs."
@@ -36,20 +36,20 @@ jobs:
             - name: Parse package selection
               id: packages
               env:
-                  PACKAGES_INPUT: ${{ inputs.packages || 'react-ui,react-native,wallets' }}
+                  PACKAGES_INPUT: ${{ inputs.packages || 'react-ui,react-native,node-wallets' }}
               run: |
                   PACKAGES="$PACKAGES_INPUT"
                   echo "react_ui=false" >> $GITHUB_OUTPUT
                   echo "react_native=false" >> $GITHUB_OUTPUT
-                  echo "wallets=false" >> $GITHUB_OUTPUT
+                  echo "node_wallets=false" >> $GITHUB_OUTPUT
                   if echo ",$PACKAGES," | grep -q ",react-ui,"; then
                     echo "react_ui=true" >> $GITHUB_OUTPUT
                   fi
                   if echo ",$PACKAGES," | grep -q ",react-native,"; then
                     echo "react_native=true" >> $GITHUB_OUTPUT
                   fi
-                  if echo ",$PACKAGES," | grep -q ",wallets,"; then
-                    echo "wallets=true" >> $GITHUB_OUTPUT
+                  if echo ",$PACKAGES," | grep -q ",node-wallets,"; then
+                    echo "node_wallets=true" >> $GITHUB_OUTPUT
                   fi
 
             - name: Generate React UI docs
@@ -62,8 +62,8 @@ jobs:
               working-directory: packages/client/ui/react-native
               run: pnpm generate:docs
 
-            - name: Generate Wallets SDK docs
-              if: steps.packages.outputs.wallets == 'true'
+            - name: Generate Node Wallets SDK docs
+              if: steps.packages.outputs.node_wallets == 'true'
               working-directory: packages/wallets
               run: |
                   pnpm generate:docs
@@ -78,7 +78,7 @@ jobs:
               env:
                   REACT_UI_ENABLED: ${{ steps.packages.outputs.react_ui }}
                   REACT_NATIVE_ENABLED: ${{ steps.packages.outputs.react_native }}
-                  WALLETS_ENABLED: ${{ steps.packages.outputs.wallets }}
+                  NODE_WALLETS_ENABLED: ${{ steps.packages.outputs.node_wallets }}
               run: |
                   mkdir -p sdk-reference/wallets/react
                   mkdir -p sdk-reference/wallets/react-native
@@ -92,7 +92,7 @@ jobs:
                     cp -r packages/client/ui/react-native/docs/wallets/. sdk-reference/wallets/react-native/
                   fi
 
-                  if [ "$WALLETS_ENABLED" == "true" ] && [ -d packages/wallets/docs ]; then
+                  if [ "$NODE_WALLETS_ENABLED" == "true" ] && [ -d packages/wallets/docs ]; then
                     cp -r packages/wallets/docs/. sdk-reference/wallets/typescript/
                   fi
 
@@ -126,4 +126,4 @@ jobs:
                   token: ${{ steps.generate_app_token.outputs.token }}
                   repository: Paella-Labs/crossbit-main
                   event-type: sdk-docs-update
-                  client-payload: '{"run_id": "${{ github.run_id }}", "packages": ${{ toJSON(inputs.packages || ''react-ui,react-native,wallets'') }}, "source_ref": ${{ toJSON(inputs.ref || ''main'') }}}'
+                  client-payload: '{"run_id": "${{ github.run_id }}", "packages": ${{ toJSON(inputs.packages || ''react-ui,react-native,node-wallets'') }}, "source_ref": ${{ toJSON(inputs.ref || ''main'') }}}'

--- a/.github/workflows/sdk-docs-generate.yml
+++ b/.github/workflows/sdk-docs-generate.yml
@@ -126,4 +126,4 @@ jobs:
                   token: ${{ steps.generate_app_token.outputs.token }}
                   repository: Paella-Labs/crossbit-main
                   event-type: sdk-docs-update
-                  client-payload: '{"run_id": "${{ github.run_id }}", "packages": ${{ toJSON(inputs.packages || ''react-ui,react-native,wallets'') }}}'
+                  client-payload: '{"run_id": "${{ github.run_id }}", "packages": ${{ toJSON(inputs.packages || ''react-ui,react-native,wallets'') }}, "source_ref": ${{ toJSON(inputs.ref || ''main'') }}}'


### PR DESCRIPTION
## Description

Adds a GitHub Actions workflow (`sdk-docs-generate.yml`) that generates SDK reference documentation and dispatches it to `crossbit-main` for syncing.

**Triggers:**
- `on: push` to main with path filters for relevant SDK source paths (wallets, react-ui, react-native, shared scripts)
- `workflow_dispatch` for manual generation with optional package selection

**Pipeline:**
1. Builds libraries (`pnpm build:libs`)
2. Generates docs for selected packages (react-ui, react-native, node-wallets)
3. Collects generated MDX files into a structured artifact
4. Dispatches `repository_dispatch` event to `Paella-Labs/crossbit-main` with run ID and package list

Doc generation uses TypeDoc to auto-derive type information from JSDoc annotations in source — no manual maintenance of type definitions needed.

Companion PR: https://github.com/Paella-Labs/crossbit-main/pull/25398

## Test plan

- Verified workflow syntax passes GitHub Actions linter
- Tested doc generation locally for all 3 packages (61 MDX files for wallets, 4 each for react-ui/react-native)
- Validated path filters cover all relevant source paths that affect generated output
- Confirmed `workflow_dispatch` defaults work correctly when no inputs provided

## Package updates

No package updates — this is a CI workflow file only.

Link to Devin session: https://crossmint.devinenterprise.com/sessions/1ad4df88ea094db29927cec47c321071
Requested by: @jmderby