### PR TITLE
feat: persist identity key in native Keychain via postMessage bridge

### DIFF
--- a/.changeset/persist-identity-key-native.md
+++ b/.changeset/persist-identity-key-native.md
@@ -1,0 +1,11 @@
+---
+"@crossmint/client-sdk-rn-window": patch
+"@crossmint/client-sdk-react-native-ui": patch
+---
+
+Persist TEE identity key in native Keychain/Keystore via postMessage bridge to prevent IndexedDB data loss from WebKit storage eviction on iOS.
+
+- Extended `AllowedGlobalsSchema` to accept `__CROSSMINT_IDENTITY_KEY_BACKUP` JWK global
+- Load identity key backup from `expo-secure-store` before mounting WebView
+- Handle `identity-key-backup` messages from frame and persist to SecureStore
+- Include backup in `secureGlobals` for injection via `injectedJavaScriptBeforeContentLoaded`

--- a/packages/client/rn-window/src/rn-webview/RNWebView.tsx
+++ b/packages/client/rn-window/src/rn-webview/RNWebView.tsx
@@ -114,6 +114,7 @@ const INJECTED_BRIDGE_JS = `
 const AllowedGlobalsSchema = z
     .object({
         crossmintAppId: z.string().optional(),
+        __CROSSMINT_IDENTITY_KEY_BACKUP: z.record(z.unknown()).optional(),
     })
     .strict();
 export type SafeInjectableGlobals = z.infer<typeof AllowedGlobalsSchema>;

--- a/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
@@ -281,6 +281,7 @@ function CrossmintWalletProviderInternal({
 
                 if (
                     parsed?.type === "identity-key-backup" &&
+                    parsed.jwk != null &&
                     typeof parsed.jwk === "object" &&
                     !Array.isArray(parsed.jwk)
                 ) {

--- a/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
@@ -279,7 +279,7 @@ function CrossmintWalletProviderInternal({
             try {
                 const parsed = JSON.parse(rawData);
 
-                if (parsed?.type === "identity-key-backup" && typeof parsed.jwk === "object" && parsed.jwk != null) {
+                if (parsed?.type === "identity-key-backup" && typeof parsed.jwk === "object" && !Array.isArray(parsed.jwk)) {
                     const backupKey = `crossmint_identity_key_backup_${parsedAPIKey.environment}`;
                     SecureStore.setItemAsync(backupKey, JSON.stringify(parsed.jwk))
                         .then(() => logger.info("react-native.wallet.identity-key-backup.saved"))

--- a/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
@@ -268,7 +268,12 @@ function CrossmintWalletProviderInternal({
             // so the identity key survives WebKit IndexedDB eviction.
             try {
                 const parsed = JSON.parse(rawData);
-                if (parsed?.type === "identity-key-backup" && parsed.jwk != null && typeof parsed.jwk === "object" && !Array.isArray(parsed.jwk)) {
+                if (
+                    parsed?.type === "identity-key-backup" &&
+                    parsed.jwk != null &&
+                    typeof parsed.jwk === "object" &&
+                    !Array.isArray(parsed.jwk)
+                ) {
                     const backupKey = `crossmint_identity_key_backup_${parsedAPIKey.environment}`;
                     SecureStore.setItemAsync(backupKey, JSON.stringify(parsed.jwk))
                         .then(() => logger.info("react-native.wallet.identity-key-backup.saved"))

--- a/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
@@ -279,7 +279,11 @@ function CrossmintWalletProviderInternal({
             try {
                 const parsed = JSON.parse(rawData);
 
-                if (parsed?.type === "identity-key-backup" && typeof parsed.jwk === "object" && !Array.isArray(parsed.jwk)) {
+                if (
+                    parsed?.type === "identity-key-backup" &&
+                    typeof parsed.jwk === "object" &&
+                    !Array.isArray(parsed.jwk)
+                ) {
                     const backupKey = `crossmint_identity_key_backup_${parsedAPIKey.environment}`;
                     SecureStore.setItemAsync(backupKey, JSON.stringify(parsed.jwk))
                         .then(() => logger.info("react-native.wallet.identity-key-backup.saved"))

--- a/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
@@ -379,9 +379,6 @@ function CrossmintWalletProviderInternal({
     const initializeWebView = async () => {
         logger.info("react-native.wallet.webview.init.start");
 
-        // Load identity key backup from native before mounting the WebView.
-        // React 18+ batches both setState calls into one render, so the WebView
-        // always mounts with the backup already injected as a global.
         const backupKey = `crossmint_identity_key_backup_${parsedAPIKey.environment}`;
         try {
             const raw = await SecureStore.getItemAsync(backupKey);

--- a/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
@@ -1,8 +1,10 @@
 import { type ReactNode, useCallback, useRef, useMemo, useEffect, useState, useContext, type RefObject } from "react";
 import { Platform, View } from "react-native";
 import type { WebView, WebViewMessageEvent } from "react-native-webview";
+import * as SecureStore from "expo-secure-store";
 
 import { RNWebView, WebViewParent } from "@crossmint/client-sdk-rn-window";
+import type { SafeInjectableGlobals } from "@crossmint/client-sdk-rn-window";
 import {
     environmentUrlConfig,
     signerInboundEvents,
@@ -133,17 +135,22 @@ function CrossmintWalletProviderInternal({
     );
 
     const [needsWebView, setNeedsWebView] = useState<boolean>(false);
+    const [identityKeyBackup, setIdentityKeyBackup] = useState<Record<string, unknown> | null>(null);
     const handshakeTriggeredRef = useRef<boolean>(false);
     const handshakeInProgressRef = useRef<boolean>(false);
     const handshakeGenerationRef = useRef<number>(0);
     const handshakeStartTimeRef = useRef<number>(0);
 
     const secureGlobals = useMemo(() => {
+        const globals: SafeInjectableGlobals = {};
         if (appId != null) {
-            return { crossmintAppId: appId };
+            globals.crossmintAppId = appId;
         }
-        return {};
-    }, [appId]);
+        if (identityKeyBackup != null) {
+            globals.__CROSSMINT_IDENTITY_KEY_BACKUP = identityKeyBackup;
+        }
+        return globals;
+    }, [appId, identityKeyBackup]);
 
     const performHandshake = useCallback(
         async (trigger: "frame-ready" | "onLoadEnd" | "eager") => {
@@ -257,6 +264,24 @@ function CrossmintWalletProviderInternal({
 
             const rawData = event.nativeEvent.data;
 
+            // Handle identity key backup from the frame — persists the JWK in native SecureStore
+            // so the identity key survives WebKit IndexedDB eviction.
+            try {
+                const parsed = JSON.parse(rawData);
+                if (parsed?.type === "identity-key-backup" && parsed.jwk != null) {
+                    const backupKey = `crossmint_identity_key_backup_${parsedAPIKey.environment}`;
+                    SecureStore.setItemAsync(backupKey, JSON.stringify(parsed.jwk)).catch((e) =>
+                        logger.warn("react-native.wallet.identity-key-backup.save-failed", {
+                            error: String(e),
+                        })
+                    );
+                    logger.info("react-native.wallet.identity-key-backup.saved");
+                    return;
+                }
+            } catch {
+                // Not JSON or not a backup message — fall through
+            }
+
             // Handle "frame-ready" signal from child — child is ready to handshake.
             // With eager handshake, the parent is already polling, so the handshake
             // should already be in progress or complete. Log for diagnostics.
@@ -322,7 +347,7 @@ function CrossmintWalletProviderInternal({
 
             parent.handleMessage(event);
         },
-        [logger, performHandshake]
+        [logger, performHandshake, parsedAPIKey.environment]
     );
 
     const getClientTEEConnection = () => {
@@ -346,6 +371,21 @@ function CrossmintWalletProviderInternal({
 
     const initializeWebView = async () => {
         logger.info("react-native.wallet.webview.init.start");
+
+        // Load identity key backup from native before mounting the WebView.
+        // React 18+ batches both setState calls into one render, so the WebView
+        // always mounts with the backup already injected as a global.
+        const backupKey = `crossmint_identity_key_backup_${parsedAPIKey.environment}`;
+        try {
+            const raw = await SecureStore.getItemAsync(backupKey);
+            if (raw != null) {
+                setIdentityKeyBackup(JSON.parse(raw));
+                logger.info("react-native.wallet.identity-key-backup.loaded");
+            }
+        } catch (e) {
+            logger.warn("react-native.wallet.identity-key-backup.load-failed", { error: String(e) });
+        }
+
         setNeedsWebView(true);
 
         let attempts = 0;

--- a/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
@@ -286,7 +286,9 @@ function CrossmintWalletProviderInternal({
                     !Array.isArray(parsed.jwk)
                 ) {
                     const backupKey = `crossmint_identity_key_backup_${parsedAPIKey.environment}`;
-                    SecureStore.setItemAsync(backupKey, JSON.stringify(parsed.jwk))
+                    SecureStore.setItemAsync(backupKey, JSON.stringify(parsed.jwk), {
+                        keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY,
+                    })
                         .then(() => logger.info("react-native.wallet.identity-key-backup.saved"))
                         .catch((e) =>
                             logger.warn("react-native.wallet.identity-key-backup.save-failed", {
@@ -372,7 +374,9 @@ function CrossmintWalletProviderInternal({
 
         const backupKey = `crossmint_identity_key_backup_${parsedAPIKey.environment}`;
         try {
-            const raw = await SecureStore.getItemAsync(backupKey);
+            const raw = await SecureStore.getItemAsync(backupKey, {
+                keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY,
+            });
             if (raw != null) {
                 const parsed = JSON.parse(raw);
                 if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {

--- a/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
@@ -268,7 +268,7 @@ function CrossmintWalletProviderInternal({
             // so the identity key survives WebKit IndexedDB eviction.
             try {
                 const parsed = JSON.parse(rawData);
-                if (parsed?.type === "identity-key-backup" && parsed.jwk != null) {
+                if (parsed?.type === "identity-key-backup" && parsed.jwk != null && typeof parsed.jwk === "object" && !Array.isArray(parsed.jwk)) {
                     const backupKey = `crossmint_identity_key_backup_${parsedAPIKey.environment}`;
                     SecureStore.setItemAsync(backupKey, JSON.stringify(parsed.jwk))
                         .then(() => logger.info("react-native.wallet.identity-key-backup.saved"))

--- a/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
@@ -386,8 +386,13 @@ function CrossmintWalletProviderInternal({
         try {
             const raw = await SecureStore.getItemAsync(backupKey);
             if (raw != null) {
-                setIdentityKeyBackup(JSON.parse(raw));
-                logger.info("react-native.wallet.identity-key-backup.loaded");
+                const parsed = JSON.parse(raw);
+                if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+                    setIdentityKeyBackup(parsed);
+                    logger.info("react-native.wallet.identity-key-backup.loaded");
+                } else {
+                    logger.warn("react-native.wallet.identity-key-backup.invalid-format");
+                }
             }
         } catch (e) {
             logger.warn("react-native.wallet.identity-key-backup.load-failed", { error: String(e) });

--- a/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
@@ -270,12 +270,14 @@ function CrossmintWalletProviderInternal({
                 const parsed = JSON.parse(rawData);
                 if (parsed?.type === "identity-key-backup" && parsed.jwk != null) {
                     const backupKey = `crossmint_identity_key_backup_${parsedAPIKey.environment}`;
-                    SecureStore.setItemAsync(backupKey, JSON.stringify(parsed.jwk)).catch((e) =>
-                        logger.warn("react-native.wallet.identity-key-backup.save-failed", {
-                            error: String(e),
-                        })
-                    );
-                    logger.info("react-native.wallet.identity-key-backup.saved");
+                    SecureStore.setItemAsync(backupKey, JSON.stringify(parsed.jwk))
+                        .then(() => logger.info("react-native.wallet.identity-key-backup.saved"))
+                        .catch((e) =>
+                            logger.warn("react-native.wallet.identity-key-backup.save-failed", {
+                                error: String(e),
+                            })
+                        );
+                    setIdentityKeyBackup(parsed.jwk);
                     return;
                 }
             } catch {

--- a/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
@@ -264,34 +264,6 @@ function CrossmintWalletProviderInternal({
 
             const rawData = event.nativeEvent.data;
 
-            // Handle identity key backup from the frame — persists the JWK in native SecureStore
-            // so the identity key survives WebKit IndexedDB eviction.
-            try {
-                const parsed = JSON.parse(rawData);
-                if (
-                    parsed?.type === "identity-key-backup" &&
-                    parsed.jwk != null &&
-                    typeof parsed.jwk === "object" &&
-                    !Array.isArray(parsed.jwk)
-                ) {
-                    const backupKey = `crossmint_identity_key_backup_${parsedAPIKey.environment}`;
-                    SecureStore.setItemAsync(backupKey, JSON.stringify(parsed.jwk))
-                        .then(() => logger.info("react-native.wallet.identity-key-backup.saved"))
-                        .catch((e) =>
-                            logger.warn("react-native.wallet.identity-key-backup.save-failed", {
-                                error: String(e),
-                            })
-                        );
-                    setIdentityKeyBackup(parsed.jwk);
-                    return;
-                }
-            } catch {
-                // Not JSON or not a backup message — fall through
-            }
-
-            // Handle "frame-ready" signal from child — child is ready to handshake.
-            // With eager handshake, the parent is already polling, so the handshake
-            // should already be in progress or complete. Log for diagnostics.
             if (rawData === "frame-ready") {
                 logger.info("react-native.wallet.webview.frame-ready.received", {
                     handshakeInProgress: handshakeInProgressRef.current,
@@ -305,10 +277,24 @@ function CrossmintWalletProviderInternal({
             }
 
             try {
-                const messageData = JSON.parse(rawData);
-                if (messageData && typeof messageData.type === "string" && messageData.type.startsWith("console.")) {
-                    const consoleMethod = messageData.type.split(".")[1];
-                    const args = (messageData.data || []).map((argStr: string) => {
+                const parsed = JSON.parse(rawData);
+
+                if (parsed?.type === "identity-key-backup" && typeof parsed.jwk === "object" && parsed.jwk != null) {
+                    const backupKey = `crossmint_identity_key_backup_${parsedAPIKey.environment}`;
+                    SecureStore.setItemAsync(backupKey, JSON.stringify(parsed.jwk))
+                        .then(() => logger.info("react-native.wallet.identity-key-backup.saved"))
+                        .catch((e) =>
+                            logger.warn("react-native.wallet.identity-key-backup.save-failed", {
+                                error: String(e),
+                            })
+                        );
+                    setIdentityKeyBackup(parsed.jwk);
+                    return;
+                }
+
+                if (typeof parsed?.type === "string" && parsed.type.startsWith("console.")) {
+                    const consoleMethod = parsed.type.split(".")[1];
+                    const args = (parsed.data || []).map((argStr: string) => {
                         try {
                             if (
                                 argStr === "[Function]" ||


### PR DESCRIPTION
## Description

On iOS 17+, WebKit can aggressively evict IndexedDB storage from a hidden 1×1 WKWebView, even while the host app remains in the foreground. When this happens mid-onboarding, the frame generates a new ECDH identity key with a different `deviceId`, causing `complete-onboarding` to fail with `"Authentication for device ... is not pending"` (TEE 400).

This PR adds the **native (SDK) side** of a backup/restore mechanism that persists the identity key JWK in `expo-secure-store` (iOS Keychain / Android Keystore), so the frame can recover its identity if IndexedDB is wiped.

**How it works:**

1. **On WebView init** (`initializeWebView`): loads any existing backup from SecureStore and injects it as a `window.__CROSSMINT_IDENTITY_KEY_BACKUP` global via `injectedJavaScriptBeforeContentLoaded`.
2. **On message from frame** (`handleMessage`): intercepts `{ type: "identity-key-backup", jwk }` postMessages, persists the JWK to SecureStore (scoped by environment), and updates React state so mid-session WebView reloads also inject the backup.
3. **Schema** (`RNWebView.tsx`): extends `AllowedGlobalsSchema` to accept the new backup global.

**Companion PR:** [Crossmint/open-signer#200](https://github.com/Crossmint/open-signer/pull/200) — frame-side changes that make the identity key extractable, send the backup message on key generation, and restore from the injected global when IDB is empty.

### Updates since initial revision

- **Fixed: in-session WebView reload now injects the backup.** `handleMessage` now calls `setIdentityKeyBackup(parsed.jwk)` alongside the SecureStore write, so `secureGlobals` stays in sync and `onContentProcessDidTerminate` / `onRenderProcessGone` reloads will include the backup global.
- **Fixed: "saved" log timing.** Moved the success log into `.then()` on `setItemAsync` so it only fires after the write actually completes, not optimistically.
- **Fixed: JWK shape validation on both write and read paths.** `handleMessage` now guards with `typeof parsed.jwk === "object" && !Array.isArray(parsed.jwk)` before accepting the JWK. `initializeWebView` applies the same guard when loading from SecureStore, so a corrupted/non-object value in SecureStore cannot crash the component tree via `AllowedGlobalsSchema.parse()`.

## Test plan

- This feature requires end-to-end testing on a real iOS device to simulate the WebKit IDB eviction scenario (start onboarding → trigger eviction → complete onboarding should recover the original deviceId from the backup)
- Manual verification that the `identity-key-backup` message is correctly intercepted and persisted in SecureStore
- Manual verification that on subsequent WebView init, the backup is loaded and injected as a global before the frame content loads
- Manual verification that a mid-session WebView process termination + reload still injects the backup (covers the `setIdentityKeyBackup` fix)

**Review checklist for humans:**

- [ ] **State batching in `initializeWebView`**: After `await SecureStore.getItemAsync()`, both `setIdentityKeyBackup` and `setNeedsWebView` are called synchronously. Verify React 18+ batches them so the WebView always mounts with the backup already set.
- [ ] **Fire-and-forget save**: `SecureStore.setItemAsync` failure is only logged as a warning. Confirm this is acceptable (vs. retrying or surfacing the error).
- [ ] **Permissive schema**: `z.record(z.unknown())` accepts any object shape. The JWK typeof/Array guards in `handleMessage` and `initializeWebView` add runtime narrowing, but there is no deep JWK field validation. Verify this passthrough approach is intentional.
- [ ] **Double JSON.parse in `handleMessage`**: `rawData` may be parsed once in the new backup handler and again in the existing console-message handler below. This is safe (first is in try/catch) but is a minor inefficiency to be aware of.

## Package updates

- `@crossmint/client-sdk-rn-window`: patch
- `@crossmint/client-sdk-react-native-ui`: patch

Changeset added via `.changeset/persist-identity-key-native.md`.

Link to Devin session: https://crossmint.devinenterprise.com/sessions/ead2b09763054a279d1682972c1f3ea0
Requested by: @albertoelias-crossmint
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/crossmint-sdk/pull/1824" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->