### PR TITLE
ci: pin peter-evans/repository-dispatch to v4 SHA

### DIFF
--- a/.github/workflows/sdk-docs-generate.yml
+++ b/.github/workflows/sdk-docs-generate.yml
@@ -137,7 +137,7 @@ jobs:
                   repositories: crossbit-main
 
             - name: Dispatch to crossbit-main
-              uses: peter-evans/repository-dispatch@ce57bf9958701f3a8aa0f5e7fe00d698f32de22a  # v3.0.0
+              uses: peter-evans/repository-dispatch@v4
               with:
                   token: ${{ steps.generate_app_token.outputs.token }}
                   repository: Paella-Labs/crossbit-main

--- a/.github/workflows/sdk-docs-generate.yml
+++ b/.github/workflows/sdk-docs-generate.yml
@@ -137,7 +137,7 @@ jobs:
                   repositories: crossbit-main
 
             - name: Dispatch to crossbit-main
-              uses: peter-evans/repository-dispatch@v4
+              uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697  # v4
               with:
                   token: ${{ steps.generate_app_token.outputs.token }}
                   repository: Paella-Labs/crossbit-main


### PR DESCRIPTION
## Description

Updates `peter-evans/repository-dispatch` from v3 (SHA-pinned) to v4 (semver tag) in the `sdk-docs-generate.yml` workflow, per user request.

## Test plan

* CI-only change — no runtime code affected
* Will be validated during the SDK docs pipeline testing phase (DVRL-1195)

## Package updates

No package updates — workflow file only.

Link to Devin session: https://crossmint.devinenterprise.com/sessions/1ad4df88ea094db29927cec47c321071
Requested by: @jmderby