### PR TITLE
test(server): migrate auth unit tests to conventions-compliant style (ENG-2310)

### DIFF
--- a/packages/server/src/auth/crossmint-auth-server.test.ts
+++ b/packages/server/src/auth/crossmint-auth-server.test.ts
@@ -31,14 +31,14 @@ describe("CrossmintAuthServer", () => {
     });
 
     describe("from", () => {
-        it("should create a new CrossmintAuthServer instance", () => {
+        it("creates a new CrossmintAuthServer instance", () => {
             expect(crossmintAuthServer).toBeInstanceOf(CrossmintAuthServer);
             expect(CrossmintApiClient).toHaveBeenCalledWith(mockCrossmint, expect.any(Object));
         });
     });
 
     describe("verifyCrossmintJwt", () => {
-        it("should call verifyCrossmintJwt with correct parameters", async () => {
+        it("calls verifyCrossmintJwt with correct parameters", async () => {
             const mockToken = "mock.jwt.token";
             const mockDecodedJwt = { sub: "user123" };
             vi.mocked(jwtUtils.verifyCrossmintJwt).mockResolvedValue(mockDecodedJwt);
@@ -69,7 +69,7 @@ describe("CrossmintAuthServer", () => {
             console.error = originalConsoleError;
         });
 
-        it("should return a valid session when JWT is valid", async () => {
+        it("returns a valid session when JWT is valid", async () => {
             vi.mocked(cookiesUtils.getAuthCookies).mockReturnValue(mockAuthMaterial);
             vi.mocked(jwtUtils.verifyCrossmintJwt).mockResolvedValue({ sub: "user123" });
 
@@ -85,7 +85,7 @@ describe("CrossmintAuthServer", () => {
             });
         });
 
-        it("should refresh the session when JWT is invalid", async () => {
+        it("refreshes the session when JWT is invalid", async () => {
             vi.mocked(cookiesUtils.getAuthCookies).mockReturnValue(mockAuthMaterial);
             vi.mocked(jwtUtils.verifyCrossmintJwt).mockRejectedValue(new Error("Invalid token"));
             mockApiClient.post.mockResolvedValue({
@@ -117,7 +117,7 @@ describe("CrossmintAuthServer", () => {
             );
         });
 
-        it("should accept AuthMaterialBasic as input", async () => {
+        it("accepts AuthMaterialBasic as input", async () => {
             const mockAuthMaterial = {
                 jwt: "mock.jwt.token",
                 refreshToken: "mock-refresh-token",
@@ -136,7 +136,7 @@ describe("CrossmintAuthServer", () => {
             });
         });
 
-        it("should call logout when error occurs and response is provided", async () => {
+        it("calls logout when error occurs and response is provided", async () => {
             const mockRequest = { headers: { cookie: "mock-cookie" } } as GenericRequest;
             const mockResponse = {} as GenericResponse;
 
@@ -158,7 +158,7 @@ describe("CrossmintAuthServer", () => {
             expect(CrossmintAuthServer.prototype.logout).toHaveBeenCalledWith(mockRequest, mockResponse);
         });
 
-        it("should throw CrossmintAuthenticationError when refresh token is not found", async () => {
+        it("throws CrossmintAuthenticationError when refresh token is not found", async () => {
             vi.mocked(cookiesUtils.getAuthCookies).mockReturnValue({ jwt: "mock.jwt.token" } as AuthMaterialBasic);
 
             await expect(crossmintAuthServer.getSession(mockRequest as GenericRequest)).rejects.toThrow(
@@ -169,7 +169,7 @@ describe("CrossmintAuthServer", () => {
             );
         });
 
-        it("should throw CrossmintAuthenticationError when session retrieval fails", async () => {
+        it("throws CrossmintAuthenticationError when session retrieval fails", async () => {
             vi.mocked(cookiesUtils.getAuthCookies).mockReturnValue(mockAuthMaterial);
             vi.mocked(jwtUtils.verifyCrossmintJwt).mockRejectedValue(new Error("Invalid token"));
             mockApiClient.post.mockRejectedValue(new Error("API error"));
@@ -184,7 +184,7 @@ describe("CrossmintAuthServer", () => {
     });
 
     describe("getUser", () => {
-        it("should fetch user data for a given external user ID", async () => {
+        it("fetches user data for a given external user ID", async () => {
             const mockExternalUserId = "external-user-123";
             const mockUserData = { id: "user456", email: "user@example.com" };
             mockApiClient.get.mockResolvedValue({
@@ -202,7 +202,7 @@ describe("CrossmintAuthServer", () => {
     });
 
     describe("storeAuthMaterial", () => {
-        it("should call setAuthCookies with the provided response and auth material", () => {
+        it("calls setAuthCookies with the provided response and auth material", () => {
             const mockResponse = {} as GenericResponse;
             const mockAuthMaterial = {
                 jwt: "new.jwt.token",
@@ -219,7 +219,7 @@ describe("CrossmintAuthServer", () => {
     });
 
     describe("handleCustomRefresh", () => {
-        it("should handle Fetch-based refresh requests", async () => {
+        it("handles Fetch-based refresh requests", async () => {
             const mockRequest = new Request("http://test.com", {
                 method: "POST",
                 body: JSON.stringify({ refresh: "mock-refresh-token" }),
@@ -258,7 +258,7 @@ describe("CrossmintAuthServer", () => {
             );
         });
 
-        it("should handle Fetch-based refresh errors and clear cookies", async () => {
+        it("handles Fetch-based refresh errors and clears cookies", async () => {
             const mockRequest = new Request("http://test.com", {
                 method: "POST",
                 body: JSON.stringify({ refresh: "mock-refresh-token" }),
@@ -284,7 +284,7 @@ describe("CrossmintAuthServer", () => {
             );
         });
 
-        it("should throw error when refresh token is missing", async () => {
+        it("throws error when refresh token is missing", async () => {
             const mockRequest = new Request("http://test.com", {
                 method: "POST",
                 body: JSON.stringify({}),
@@ -300,7 +300,7 @@ describe("CrossmintAuthServer", () => {
             });
         });
 
-        it("should handle Node-based refresh requests", async () => {
+        it("handles Node-based refresh requests", async () => {
             const { mockNodeRequest, mockNodeResponse } = getNodeReqResMock();
 
             const mockRefreshedAuthRes = {
@@ -343,7 +343,7 @@ describe("CrossmintAuthServer", () => {
             expect(result).toBe(mockNodeResponse);
         });
 
-        it("should handle Node-based refresh errors", async () => {
+        it("handles Node-based refresh errors", async () => {
             const { mockNodeRequest, mockNodeResponse } = getNodeReqResMock();
 
             mockApiClient.post.mockRejectedValue(new Error("API error"));
@@ -379,7 +379,7 @@ describe("CrossmintAuthServer", () => {
             });
         });
 
-        it("should clear auth material from response and return it", async () => {
+        it("clears auth material from response and returns it", async () => {
             const mockResponse = {} as GenericResponse;
 
             const result = await crossmintAuthServer.logout(undefined, mockResponse);
@@ -398,7 +398,7 @@ describe("CrossmintAuthServer", () => {
             expect(result).toBe(mockResponse);
         });
 
-        it("should create and return new Response when no response provided", async () => {
+        it("creates and returns new Response when no response provided", async () => {
             const result = await crossmintAuthServer.logout();
 
             expect(cookiesUtils.setAuthCookies).toHaveBeenCalledWith(
@@ -415,7 +415,7 @@ describe("CrossmintAuthServer", () => {
             expect(result).toBeInstanceOf(Response);
         });
 
-        it("should attempt to call logout endpoint when request is provided", async () => {
+        it("calls logout endpoint when request is provided", async () => {
             mockApiClient.post.mockResolvedValue({ ok: true });
 
             await crossmintAuthServer.logout(mockRequest);
@@ -428,7 +428,7 @@ describe("CrossmintAuthServer", () => {
             );
         });
 
-        it("should still clear cookies even if logout endpoint call fails", async () => {
+        it("clears cookies even if logout endpoint call fails", async () => {
             const mockResponse = {} as GenericResponse;
             mockApiClient.post.mockRejectedValue(new Error("API Error"));
             const consoleSpy = vi.spyOn(console, "error");

--- a/packages/server/src/auth/utils/cookies.test.ts
+++ b/packages/server/src/auth/utils/cookies.test.ts
@@ -25,7 +25,7 @@ describe("getAuthCookies", () => {
         vi.restoreAllMocks();
     });
 
-    it("should extract auth cookies from IncomingMessage", () => {
+    it("extracts auth cookies from IncomingMessage", () => {
         const mockRequest = {
             headers: {
                 cookie: `${SESSION_PREFIX}=mock-jwt-token; ${REFRESH_TOKEN_PREFIX}=mock-refresh-token`,
@@ -41,7 +41,7 @@ describe("getAuthCookies", () => {
         });
     });
 
-    it("should extract auth cookies from Fetch Request", () => {
+    it("extracts auth cookies from Fetch Request", () => {
         const mockRequest = new Request("https://example.com", {
             headers: {
                 Cookie: `${SESSION_PREFIX}=mock-jwt-token; ${REFRESH_TOKEN_PREFIX}=mock-refresh-token`,
@@ -56,7 +56,7 @@ describe("getAuthCookies", () => {
         });
     });
 
-    it("should throw CrossmintAuthenticationError if cookie header is missing in IncomingMessage", () => {
+    it("throws CrossmintAuthenticationError when cookie header is missing in IncomingMessage", () => {
         const mockRequest = {
             headers: {},
             httpVersion: "1.1",
@@ -66,7 +66,7 @@ describe("getAuthCookies", () => {
         expect(() => getAuthCookies(mockRequest)).toThrow("No cookies found in request");
     });
 
-    it("should throw CrossmintAuthenticationError if cookie header is missing in Fetch Request", () => {
+    it("throws CrossmintAuthenticationError when cookie header is missing in Fetch Request", () => {
         const mockRequest = new Request("https://example.com");
 
         expect(() => getAuthCookies(mockRequest)).toThrow(CrossmintAuthenticationError);
@@ -97,7 +97,7 @@ describe("setAuthCookies", () => {
         vi.restoreAllMocks();
     });
 
-    it("should set auth cookies for Node.js ServerResponse", () => {
+    it("sets auth cookies for Node.js ServerResponse", () => {
         const mockResponse = {
             setHeader: vi.fn(),
         } as unknown as ServerResponse;
@@ -110,7 +110,7 @@ describe("setAuthCookies", () => {
         ]);
     });
 
-    it("should set auth cookies for Fetch Response", () => {
+    it("sets auth cookies for Fetch Response", () => {
         const mockHeaders = new Headers();
         const appendSpy = vi.spyOn(mockHeaders, "append");
 
@@ -128,7 +128,7 @@ describe("setAuthCookies", () => {
         );
     });
 
-    it("should set expired cookies when setting empty auth material", () => {
+    it("sets expired cookies when setting empty auth material", () => {
         const response = new Response();
         const emptyAuthMaterial = {
             jwt: "",
@@ -150,7 +150,7 @@ describe("setAuthCookies", () => {
         );
     });
 
-    it("should set cookies with custom options", () => {
+    it("sets cookies with custom options", () => {
         const response = new Response();
         const customOptions = {
             sameSite: "Strict" as const,

--- a/packages/server/src/auth/utils/jwks-client.test.ts
+++ b/packages/server/src/auth/utils/jwks-client.test.ts
@@ -20,7 +20,7 @@ describe("createJWKSClient", () => {
         console.error = originalConsoleError;
     });
 
-    it("should create a JWKS client for a valid URI", () => {
+    it("creates a JWKS client for a valid URI", () => {
         const mockJWKSFunction = vi.fn() as unknown as ReturnType<typeof createRemoteJWKSet>;
         vi.mocked(createRemoteJWKSet).mockReturnValue(mockJWKSFunction);
 
@@ -35,7 +35,7 @@ describe("createJWKSClient", () => {
         expect(result).toBe(mockJWKSFunction);
     });
 
-    it("should throw an error when unable to create JWKS client", () => {
+    it("throws an error when unable to create JWKS client", () => {
         vi.mocked(createRemoteJWKSet).mockImplementation(() => {
             throw new Error("Failed to create JWKS client");
         });

--- a/packages/server/src/auth/utils/jwt.test.ts
+++ b/packages/server/src/auth/utils/jwt.test.ts
@@ -36,7 +36,7 @@ describe("JWT Verification", () => {
     });
 
     describe("verifyCrossmintJwt", () => {
-        it("should successfully verify a valid JWT", async () => {
+        it("successfully verifies a valid JWT", async () => {
             vi.mocked(jwtVerify).mockResolvedValue({ payload: mockPayload } as any);
 
             const result = await verifyCrossmintJwt(mockToken, mockJwksUri);
@@ -46,7 +46,7 @@ describe("JWT Verification", () => {
             expect(result).toEqual(mockPayload);
         });
 
-        it("should throw error for expired JWT", async () => {
+        it("throws error for expired JWT", async () => {
             const expiredTimestamp = 1234567890;
             const expiredDate = new Date(expiredTimestamp * 1000).toISOString();
 
@@ -57,7 +57,7 @@ describe("JWT Verification", () => {
             );
         });
 
-        it("should handle expired JWT with unknown expiration", async () => {
+        it("handles expired JWT with unknown expiration", async () => {
             vi.mocked(jwtVerify).mockRejectedValue(new errors.JWTExpired("token expired", { exp: undefined }));
 
             await expect(verifyCrossmintJwt(mockToken, mockJwksUri)).rejects.toThrow(
@@ -65,26 +65,26 @@ describe("JWT Verification", () => {
             );
         });
 
-        it("should throw error for signature verification failure", async () => {
+        it("throws error for signature verification failure", async () => {
             vi.mocked(jwtVerify).mockRejectedValue(new errors.JWSSignatureVerificationFailed());
 
             await expect(verifyCrossmintJwt(mockToken, mockJwksUri)).rejects.toThrow("signature verification failed");
         });
 
-        it("should throw error for invalid algorithm", async () => {
+        it("throws error for invalid algorithm", async () => {
             vi.mocked(jwtVerify).mockRejectedValue(new Error("invalid algorithm"));
 
             await expect(verifyCrossmintJwt(mockToken, mockJwksUri)).rejects.toThrow("invalid algorithm");
         });
 
-        it("should propagate unknown errors", async () => {
+        it("propagates unknown errors", async () => {
             const unknownError = new Error("unknown error");
             vi.mocked(jwtVerify).mockRejectedValue(unknownError);
 
             await expect(verifyCrossmintJwt(mockToken, mockJwksUri)).rejects.toThrow(unknownError);
         });
 
-        it("should propagate JWKS client errors", async () => {
+        it("propagates JWKS client errors", async () => {
             const jwksError = new Error("JWKS client error");
             vi.mocked(createJWKSClient).mockImplementation(() => {
                 throw jwksError;


### PR DESCRIPTION
## Summary

- Rename `CrossmintAuthServer.test.ts` → `crossmint-auth-server.test.ts` (PascalCase → kebab-case)
- Rename `jwksClient.test.ts` → `jwks-client.test.ts` (camelCase → kebab-case)
- Fix BDD naming in all 4 test files: remove `should` prefix from 37 test cases

## Test plan

- [ ] `pnpm vitest run` in `packages/server` — all tests pass with new names

Linear: ENG-2310