### PR TITLE
test(common): migrate auth+base unit tests to conventions-compliant style (ENG-2311)

### DIFF
--- a/packages/common/auth/src/crossmint-auth.test.ts
+++ b/packages/common/auth/src/crossmint-auth.test.ts
@@ -24,14 +24,14 @@ describe("CrossmintAuth", () => {
     });
 
     describe("from", () => {
-        it("should create a new CrossmintAuth instance", () => {
+        it("creates a new CrossmintAuth instance", () => {
             expect(crossmintAuth).toBeInstanceOf(CrossmintAuth);
             expect(CrossmintApiClient).toHaveBeenCalledWith(mockCrossmint, expect.any(Object));
         });
     });
 
     describe("getJwksUri", () => {
-        it("should return the correct JWKS URI", () => {
+        it("returns the correct JWKS URI", () => {
             expect(crossmintAuth.getJwksUri()).toBe("https://api.crossmint.com/.well-known/jwks.json");
         });
     });

--- a/packages/common/base/src/apiKey/validate-api-key-prefix.test.ts
+++ b/packages/common/base/src/apiKey/validate-api-key-prefix.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from "vitest";
 import { validateAPIKeyPrefix } from "./validateAPIKeyPrefix";
 
 describe("validateAPIKeyPrefix", () => {
-    test("Should disallow API keys with old format", () => {
+    test("disallows API keys with old format", () => {
         const prefixes = ["sk_live", "sk_test"];
 
         for (const prefix of prefixes) {
@@ -19,7 +19,7 @@ describe("validateAPIKeyPrefix", () => {
         }
     });
 
-    test("Should disallow when usage prefix is invalid", () => {
+    test("disallows when usage prefix is invalid", () => {
         const result = validateAPIKeyPrefix("bk_");
         if (result.isValid) {
             throw new Error("Expected API key to be invalid");
@@ -29,7 +29,7 @@ describe("validateAPIKeyPrefix", () => {
         expect(result.message).toBe("Malformed API key. Must start with 'ck' or 'sk'.");
     });
 
-    test("Should disallow when API key does not have expected usage origin", () => {
+    test("disallows when API key does not have expected usage origin", () => {
         const clientDevKey = "ck_development";
         const result1 = validateAPIKeyPrefix(clientDevKey, { usageOrigin: "server" });
         if (result1.isValid) {
@@ -51,7 +51,7 @@ describe("validateAPIKeyPrefix", () => {
         );
     });
 
-    test("Should disallow when environment prefix is invalid", () => {
+    test("disallows when environment prefix is invalid", () => {
         const prefixes = ["ck_badenv", "sk_random"];
 
         for (const prefix of prefixes) {
@@ -67,7 +67,7 @@ describe("validateAPIKeyPrefix", () => {
         }
     });
 
-    test("Should disallow when API key does not have expected environment", () => {
+    test("disallows when API key does not have expected environment", () => {
         const key = "ck_development_2EwmxKnPjzbvK";
 
         const result = validateAPIKeyPrefix(key, { environment: "production" });
@@ -81,7 +81,7 @@ describe("validateAPIKeyPrefix", () => {
         );
     });
 
-    test("Should allow correctly formatted API key", () => {
+    test("allows correctly formatted API key", () => {
         const usageOriginPrefixes = ["ck", "sk"];
         const environmentPrefixes = ["development", "staging", "production"];
 
@@ -102,7 +102,7 @@ describe("validateAPIKeyPrefix", () => {
         }
     });
 
-    test("Should allow when API key has expected usage origin and environment", () => {
+    test("allows when API key has expected usage origin and environment", () => {
         const key = "ck_development_2EwmxKnPjzbvK";
 
         const result = validateAPIKeyPrefix(key, { usageOrigin: "client", environment: "development" });

--- a/packages/common/base/src/apiKey/validate-api-key.test.ts
+++ b/packages/common/base/src/apiKey/validate-api-key.test.ts
@@ -9,7 +9,7 @@ const VALID_API_KEY =
 describe("validateAPIKey", () => {
     // All prefix validation tests are in validateAPIKeyPrefix.test.ts
     // This test is just to make sure that validateAPIKey calls validateAPIKeyPrefix
-    test("Should disallow when prefix is invalid", () => {
+    test("disallows when prefix is invalid", () => {
         const result = validateAPIKey("bk_");
         if (result.isValid) {
             throw new Error("Expected API key to be invalid");
@@ -18,7 +18,7 @@ describe("validateAPIKey", () => {
         expect(result.isValid).toBe(false);
     });
 
-    test("Should disallow when signature is invalid", () => {
+    test("disallows when signature is invalid", () => {
         const key = `ck_development_${base58.encode(
             new TextEncoder().encode(
                 "incorrect_data:5gt3DJTWBAw1AjL5pHo6z6NunHZNJqj15iEAveVN5CBUSqBB94Hetn9paFpx9zLFreQGAgy1TkDQaWSUXFMXjgvU"
@@ -34,7 +34,7 @@ describe("validateAPIKey", () => {
         expect(result.message).toBe("Invalid API key. Failed to validate signature");
     });
 
-    test("Should allow when API key is valid", () => {
+    test("allows when API key is valid", () => {
         const result = validateAPIKey(VALID_API_KEY);
         if (!result.isValid) {
             throw new Error("Expected API key to be valid");


### PR DESCRIPTION
## Summary

- Rename `CrossmintAuth.test.ts` → `crossmint-auth.test.ts` (PascalCase → kebab-case)
- Rename `validateAPIKey.test.ts` → `validate-api-key.test.ts` (camelCase → kebab-case)
- Rename `validateAPIKeyPrefix.test.ts` → `validate-api-key-prefix.test.ts`
- Fix BDD naming in all 3 files: remove capitalized/lowercase `Should` prefix from 12 test cases

## Test plan

- [ ] `pnpm vitest run` in `packages/common/auth` — all tests pass with new names
- [ ] `pnpm vitest run` in `packages/common/base` — all tests pass with new names

Linear: ENG-2311
