### PR TITLE
fix(wallets): skip approval submission when pending list is empty

### DIFF
--- a/.changeset/wal-10032-empty-approvals-guard.md
+++ b/.changeset/wal-10032-empty-approvals-guard.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+Fix `wallet.approve()` posting an empty `approvals: []` payload when a transaction or signature has no pending approvals. The SDK now short-circuits and returns the existing transaction/signature instead of calling the API with an invalid empty array, which was being rejected with `approvals: Too small: expected array to have >=1 items`.

--- a/packages/wallets/src/wallets/wallet.test.ts
+++ b/packages/wallets/src/wallets/wallet.test.ts
@@ -563,6 +563,55 @@ describe("Wallet - approve()", () => {
             );
         });
     });
+
+    describe("empty pending approvals", () => {
+        let externalWallet: Wallet<"base-sepolia">;
+
+        beforeEach(async () => {
+            externalWallet = await createMockWallet("base-sepolia", mockApiClient, "external-wallet");
+        });
+
+        it("should not submit an approval when transaction.approvals.pending is empty", async () => {
+            const mockTransactionResponse = {
+                id: "txn-empty",
+                status: "success",
+                approvals: { pending: [], submitted: [{ signer: "external-wallet:0x123" }] },
+                onChain: {
+                    txId: "0xabcdef",
+                    explorerLink: "https://explorer.example.com/tx/0xabcdef",
+                },
+            };
+
+            mockApiClient.getTransaction.mockResolvedValue(mockTransactionResponse as any);
+
+            const approvePromise = externalWallet.approve({ transactionId: "txn-empty" });
+            await vi.runAllTimersAsync();
+            const result = await approvePromise;
+
+            expect(result.hash).toBe("0xabcdef");
+            expect(result.transactionId).toBe("txn-empty");
+            expect(mockApiClient.approveTransaction).not.toHaveBeenCalled();
+        });
+
+        it("should not submit an approval when signature.approvals.pending is empty", async () => {
+            const mockSignatureResponse = {
+                id: "sig-empty",
+                status: "success",
+                outputSignature: "0xsigned",
+                approvals: { pending: [], submitted: [{ signer: "external-wallet:0x123" }] },
+            };
+
+            mockApiClient.getSignature.mockResolvedValue(mockSignatureResponse as any);
+
+            const approvePromise = externalWallet.approve({ signatureId: "sig-empty" });
+            await vi.runAllTimersAsync();
+            const result = await approvePromise;
+
+            expect(result.signature).toBe("0xsigned");
+            expect(result.signatureId).toBe("sig-empty");
+            expect(mockApiClient.approveSignature).not.toHaveBeenCalled();
+        });
+    });
 });
 
 describe("Wallet - addSigner()", () => {

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -1752,7 +1752,7 @@ export class Wallet<C extends Chain> {
 
         const pendingApprovals = signature.approvals?.pending;
 
-        if (pendingApprovals == null) {
+        if (pendingApprovals == null || pendingApprovals.length === 0) {
             return signature;
         }
 
@@ -1803,7 +1803,7 @@ export class Wallet<C extends Chain> {
 
         const pendingApprovals = transaction.approvals?.pending;
 
-        if (pendingApprovals == null) {
+        if (pendingApprovals == null || pendingApprovals.length === 0) {
             return transaction;
         }
 


### PR DESCRIPTION
## Description

Fixes [WAL-10032](https://linear.app/crossmint/issue/WAL-10032/error-in-transfer-api-for-transaction-760a8447-2ca9-4723-a9d0). The `wallet.approve()` flow was POSTing `{ approvals: [] }` to the Wallets v2025 approvals endpoint whenever `transaction.approvals.pending` (or `signature.approvals.pending`) was an empty array — e.g. when all required signatures had already been submitted, or `signers.required = 0`. The backend correctly rejects this with:

```
approvals: Too small: expected array to have >=1 items
```

In `approveTransactionInternal` and `approveSignatureInternal`, the existing guard only checked `pendingApprovals == null`, so an empty array slipped through, `Promise.all([].map(...))` resolved to `[]`, and the empty payload was sent.

The fix adds a `length === 0` check so the SDK short-circuits and returns the current transaction/signature instead of issuing a no-op API call that 400s.

### Scope of impact (Datadog, last 30d)
- 100+ `approvals: Too small` rejections on `crossmint-nextjs`
- Multiple API keys affected: SpotPay staging (`d4d8eebc-…`, 43 hits), SpotPay prod (`d3c40060-…`, 16 hits), and `46d02ccd-…` (37 hits)
- Symptom for customers is a noisy 400 on retry/idempotent flows even when the underlying transaction succeeded (the original `760a8447-…` cited in the ticket actually settled successfully)

## Test plan

- New `Wallet - approve() > empty pending approvals` describe block with two unit tests covering the transaction and signature paths. Verified that without the fix both tests fail (the SDK reaches `executeApproveTransactionWithErrorHandling` / `executeApproveSignatureWithErrorHandling` and calls the API), and with the fix both pass.
- Full wallets-sdk vitest suite (319 tests) passes locally: `pnpm --filter @crossmint/wallets-sdk test:vitest`
- `pnpm lint` passes

## Package updates

- `@crossmint/wallets-sdk`: patch — changeset added in `.changeset/wal-10032-empty-approvals-guard.md`


Link to Devin session: https://crossmint.devinenterprise.com/sessions/785d9ded05614fdbabf13e3c6553ba6d
Requested by: @albertoelias-crossmint
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/crossmint-sdk/pull/1835" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->