### PR TITLE
feat(wallets): rename and fix BDD naming in API client tests (ENG-2307)

### DIFF
--- a/packages/wallets/src/api/client-integration.test.ts
+++ b/packages/wallets/src/api/client-integration.test.ts
@@ -18,9 +18,9 @@ vi.mock("@crossmint/common-sdk-base", async () => {
     };
 });
 
-import type { ApiClient } from "../client";
+import type { ApiClient } from "./client";
 import type { Crossmint } from "@crossmint/common-sdk-base";
-import type { CreateWalletParams, SendParams, WalletLocator } from "../types";
+import type { CreateWalletParams, SendParams, WalletLocator } from "./types";
 import {
     fundWallet,
     sendTokenAndApprove,
@@ -36,7 +36,7 @@ import {
     expectSuccessTransactionResponse,
     isErrorResponse,
     isSuccessWalletResponse,
-} from "./test-utils";
+} from "./__tests__/test-utils";
 import {
     TIMEOUT_SHORT,
     TIMEOUT_MEDIUM,
@@ -46,7 +46,7 @@ import {
     DELAY_RATE_LIMIT_WINDOW,
     TEST_ADDRESSES,
     TEST_VALUES,
-} from "./constants";
+} from "./__tests__/constants";
 
 const API_KEY = process.env.CROSSMINT_API_KEY;
 const BASE_URL = process.env.CROSSMINT_BASE_URL;
@@ -70,7 +70,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
     });
 
     describe("createWallet() - Happy Path", () => {
-        it("should create EVM MPC wallet successfully", async () => {
+        it("creates EVM MPC wallet successfully", async () => {
             const params: CreateWalletParams = {
                 chainType: "evm",
                 type: "mpc",
@@ -85,7 +85,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             expect(isValidEthereumAddress(result.address)).toBe(true);
         });
 
-        it("should create EVM smart wallet with external wallet admin signer", async () => {
+        it("creates EVM smart wallet with external wallet admin signer", async () => {
             const params: CreateWalletParams = {
                 chainType: "evm",
                 type: "smart",
@@ -106,7 +106,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             expect(result.config?.adminSigner).toBeDefined();
         });
 
-        it("should create Solana smart wallet", async () => {
+        it("creates Solana smart wallet", async () => {
             const params: CreateWalletParams = {
                 chainType: "solana",
                 type: "smart",
@@ -126,7 +126,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
         });
 
         it(
-            "should create wallet with different chain types",
+            "creates wallet with different chain types",
             async () => {
                 const chainTypes = ["evm", "solana"] as const;
 
@@ -150,7 +150,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
     });
 
     describe("createWallet() - Error Cases", () => {
-        it("should handle invalid API key", async () => {
+        it("handles invalid API key", async () => {
             const invalidKey = `sk_staging_${base58.encode(
                 new TextEncoder().encode(
                     "invalid_data:invalid_signature_12345678901234567890123456789012345678901234567890"
@@ -164,7 +164,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             }).toThrow("Invalid API key");
         });
 
-        it("should handle invalid chain type", async () => {
+        it("handles invalid chain type", async () => {
             const params = {
                 chainType: "invalid_chain" as any,
                 type: "mpc" as const,
@@ -174,7 +174,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             expectErrorResponse(result);
         });
 
-        it("should handle invalid wallet type", async () => {
+        it("handles invalid wallet type", async () => {
             const params = {
                 chainType: "evm" as const,
                 type: "invalid_type" as any,
@@ -184,7 +184,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             expectErrorResponse(result);
         });
 
-        it("should handle invalid admin signer address", async () => {
+        it("handles invalid admin signer address", async () => {
             const params: CreateWalletParams = {
                 chainType: "evm",
                 type: "smart",
@@ -200,7 +200,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             expectErrorResponse(result, "message");
         });
 
-        it("should handle missing required fields", async () => {
+        it("handles missing required fields", async () => {
             const params = {} as CreateWalletParams;
             const result = await apiClient.createWallet(params);
             expectErrorResponse(result);
@@ -208,7 +208,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
     });
 
     describe("getWallet() - Happy Path", () => {
-        it("should get wallet by address", async () => {
+        it("gets wallet by address", async () => {
             const walletAddress = await ensureWalletExists(apiClient, testData, {
                 testName: "get-wallet",
             });
@@ -223,17 +223,17 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
     });
 
     describe("getWallet() - Error Cases", () => {
-        it("should handle 404 for non-existent wallet", async () => {
+        it("handles 404 for non-existent wallet", async () => {
             const result = await apiClient.getWallet(TEST_ADDRESSES.EVM_NON_EXISTENT as WalletLocator);
             expectErrorResponse(result);
         });
 
-        it("should handle invalid wallet locator format", async () => {
+        it("handles invalid wallet locator format", async () => {
             const result = await apiClient.getWallet("invalid:locator:format" as WalletLocator);
             expectErrorResponse(result);
         });
 
-        it("should handle empty locator", async () => {
+        it("handles empty locator", async () => {
             const result = await apiClient.getWallet("" as WalletLocator);
             expectErrorResponse(result);
         });
@@ -241,7 +241,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
 
     describe("fundWallet()", () => {
         it(
-            "should fund wallet successfully",
+            "funds wallet successfully",
             async () => {
                 const walletAddress = await ensureWalletExists(apiClient, testData, {
                     testName: "fund-wallet",
@@ -261,7 +261,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
         );
 
         it(
-            "should handle funding with different tokens",
+            "handles funding with different tokens",
             async () => {
                 const walletAddress = await ensureWalletExists(apiClient, testData, {
                     testName: "fund-tokens",
@@ -287,7 +287,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
 
     describe("send() - Happy Path", () => {
         it(
-            "should send tokens successfully with funding and approval",
+            "sends tokens successfully with funding and approval",
             async () => {
                 const walletAddress = await ensureWalletExists(apiClient, testData, {
                     testName: "send-tokens",
@@ -318,7 +318,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
     });
 
     describe("send() - Error Cases", () => {
-        it("should handle invalid recipient address", async () => {
+        it("handles invalid recipient address", async () => {
             const walletAddress = await ensureWalletExists(apiClient, testData);
 
             if (walletAddress) {
@@ -332,7 +332,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             }
         });
 
-        it("should handle invalid amount format", async () => {
+        it("handles invalid amount format", async () => {
             const walletAddress = await ensureWalletExists(apiClient, testData);
 
             if (walletAddress) {
@@ -346,7 +346,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             }
         });
 
-        it("should handle insufficient balance", async () => {
+        it("handles insufficient balance", async () => {
             const walletAddress = await ensureWalletExists(apiClient, testData);
 
             if (walletAddress) {
@@ -360,7 +360,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             }
         });
 
-        it("should handle invalid token locator", async () => {
+        it("handles invalid token locator", async () => {
             const walletAddress = await ensureWalletExists(apiClient, testData);
 
             if (walletAddress) {
@@ -376,7 +376,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
     });
 
     describe("API Security - Authentication & Authorization", () => {
-        it("should reject requests without API key", async () => {
+        it("rejects requests without API key", async () => {
             try {
                 const noKeyClient = createApiClient({ apiKey: "" });
                 const result = await noKeyClient.createWallet({
@@ -389,7 +389,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             }
         });
 
-        it("should validate API key format", async () => {
+        it("validates API key format", async () => {
             try {
                 const invalidFormatClient = createApiClient({
                     apiKey: "not-a-valid-api-key-format",
@@ -404,7 +404,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             }
         });
 
-        it("should reject requests with invalid API key signature", async () => {
+        it("rejects requests with invalid API key signature", async () => {
             try {
                 const invalidKey = API_KEY!.slice(0, -10) + "invalid123";
                 const invalidClient = createApiClient({ apiKey: invalidKey });
@@ -418,7 +418,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             }
         });
 
-        it("should validate API key environment matches base URL", async () => {
+        it("validates API key environment matches base URL", async () => {
             try {
                 const stagingKey = "test_api_key_staging_123456789012345678901234567890";
                 const stagingClient = createApiClient({ apiKey: stagingKey });
@@ -441,7 +441,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             }
         });
 
-        it("should include required authentication headers", async () => {
+        it("includes required authentication headers", async () => {
             const originalFetch = global.fetch;
             let capturedHeaders: HeadersInit | undefined;
 
@@ -464,7 +464,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             }
         });
 
-        it("should include Authorization header when JWT is provided", async () => {
+        it("includes Authorization header when JWT is provided", async () => {
             const jwtClient = createApiClient({ jwt: "test-jwt-token-12345" });
             const originalFetch = global.fetch;
             let capturedHeaders: HeadersInit | undefined;
@@ -484,7 +484,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             }
         });
 
-        it("should reject requests with expired or invalid JWT", async () => {
+        it("rejects requests with expired or invalid JWT", async () => {
             const expiredJwtClient = createApiClient({ jwt: "expired.jwt.token" });
 
             const result = await expiredJwtClient.createWallet({
@@ -497,7 +497,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             }
         });
 
-        it("should validate appId and extensionId headers when provided", async () => {
+        it("validates appId and extensionId headers when provided", async () => {
             const appClient = createApiClient({
                 appId: "test-app-id",
                 extensionId: "test-extension-id",
@@ -521,12 +521,12 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             }
         });
 
-        it("should prevent unauthorized access to other users wallets", async () => {
+        it("prevents unauthorized access to other users wallets", async () => {
             const result = await apiClient.getWallet(TEST_ADDRESSES.EVM_NON_EXISTENT as WalletLocator);
             expectErrorResponse(result);
         });
 
-        it("should validate API key signature cryptographically", async () => {
+        it("validates API key signature cryptographically", async () => {
             try {
                 const tamperedKey = API_KEY!.slice(0, -5) + "XXXXX";
                 const tamperedClient = createApiClient({ apiKey: tamperedKey });
@@ -540,7 +540,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             }
         });
 
-        it("should enforce environment-specific API key restrictions", async () => {
+        it("enforces environment-specific API key restrictions", async () => {
             try {
                 const stagingKey = "test_api_key_staging_123456789012345678901234567890";
                 const stagingClient = createApiClient({ apiKey: stagingKey });
@@ -556,13 +556,13 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
     });
 
     describe("API Security - Input Sanitization", () => {
-        it("should sanitize SQL injection attempts in wallet locator", async () => {
+        it("sanitizes SQL injection attempts in wallet locator", async () => {
             const sqlInjection = "'; DROP TABLE wallets; --";
             const result = await apiClient.getWallet(sqlInjection as WalletLocator);
             expectErrorResponse(result);
         });
 
-        it("should sanitize XSS attempts in parameters", async () => {
+        it("sanitizes XSS attempts in parameters", async () => {
             const xssPayload = "<script>alert('xss')</script>";
             const result = await apiClient.createWallet({
                 chainType: "evm",
@@ -577,7 +577,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             expectErrorResponse(result);
         });
 
-        it("should sanitize command injection attempts", async () => {
+        it("sanitizes command injection attempts", async () => {
             const commandInjection = "; rm -rf /; #";
             const result = await apiClient.createWallet({
                 chainType: "evm",
@@ -592,7 +592,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             expectErrorResponse(result);
         });
 
-        it("should sanitize path traversal attempts", async () => {
+        it("sanitizes path traversal attempts", async () => {
             const pathTraversal = "../../../etc/passwd";
             try {
                 const result = await apiClient.getWallet(pathTraversal as WalletLocator);
@@ -602,7 +602,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             }
         });
 
-        it("should sanitize null byte injection", async () => {
+        it("sanitizes null byte injection", async () => {
             const nullByte = "0x123\0DROP TABLE";
             try {
                 const result = await apiClient.getWallet(nullByte as WalletLocator);
@@ -612,7 +612,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             }
         });
 
-        it("should sanitize special characters in recipient address", async () => {
+        it("sanitizes special characters in recipient address", async () => {
             const walletAddress = await ensureWalletExists(apiClient, testData);
 
             if (walletAddress) {
@@ -625,7 +625,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             }
         });
 
-        it("should sanitize extremely long input strings", async () => {
+        it("sanitizes extremely long input strings", async () => {
             const longString = "A".repeat(TEST_VALUES.LONG_STRING_LENGTH);
             const result = await apiClient.createWallet({
                 chainType: "evm",
@@ -640,7 +640,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             expectErrorResponse(result);
         });
 
-        it("should sanitize unicode and special character sequences", async () => {
+        it("sanitizes unicode and special character sequences", async () => {
             const unicodePayload = "\u0000\u0001\u0002\u0003\u0004\u0005";
             const result = await apiClient.createWallet({
                 chainType: "evm",
@@ -655,7 +655,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             expectErrorResponse(result);
         });
 
-        it("should sanitize nested object injection", async () => {
+        it("sanitizes nested object injection", async () => {
             const nestedInjection = {
                 chainType: "evm",
                 type: "smart",
@@ -672,13 +672,13 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             expect(isErrorResponse(result) || isSuccessWalletResponse(result)).toBe(true);
         });
 
-        it("should sanitize LDAP injection attempts", async () => {
+        it("sanitizes LDAP injection attempts", async () => {
             const ldapInjection = ")(&(cn=*))";
             const result = await apiClient.getWallet(ldapInjection as WalletLocator);
             expectErrorResponse(result);
         });
 
-        it("should sanitize XML injection attempts", async () => {
+        it("sanitizes XML injection attempts", async () => {
             const xmlInjection = "<?xml version='1.0'?><malicious></malicious>";
             const result = await apiClient.createWallet({
                 chainType: "evm",
@@ -693,7 +693,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             expectErrorResponse(result);
         });
 
-        it("should sanitize NoSQL injection attempts", async () => {
+        it("sanitizes NoSQL injection attempts", async () => {
             const nosqlInjection = { $ne: null };
             const result = await apiClient.createWallet({
                 chainType: "evm",
@@ -710,7 +710,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
     });
 
     describe("API Security - Encryption & Transport", () => {
-        it("should use HTTPS for all API requests", async () => {
+        it("uses HTTPS for all API requests", async () => {
             const originalFetch = global.fetch;
             let capturedUrl: string | undefined;
 
@@ -730,7 +730,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             }
         });
 
-        it("should not expose sensitive data in URL parameters", async () => {
+        it("does not expose sensitive data in URL parameters", async () => {
             const originalFetch = global.fetch;
             let capturedUrl: string | undefined;
 
@@ -751,7 +751,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             }
         });
 
-        it("should send sensitive data only in request body or headers", async () => {
+        it("sends sensitive data only in request body or headers", async () => {
             const originalFetch = global.fetch;
             let capturedUrl: string | undefined;
             let capturedBody: string | undefined;
@@ -783,7 +783,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             }
         });
 
-        it("should not log sensitive data in error messages", async () => {
+        it("does not log sensitive data in error messages", async () => {
             const result = await apiClient.createWallet({
                 chainType: "evm",
                 type: "mpc",
@@ -795,7 +795,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             }
         });
 
-        it("should use secure HTTP methods", async () => {
+        it("uses secure HTTP methods", async () => {
             const originalFetch = global.fetch;
             let capturedMethod: string | undefined;
 
@@ -817,7 +817,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
     });
 
     describe("API Security - Rate Limiting", () => {
-        it("should handle rate limiting gracefully", async () => {
+        it("handles rate limiting gracefully", async () => {
             const requests = Array.from({ length: TEST_VALUES.RATE_LIMIT_RAPID_COUNT }, () =>
                 apiClient.createWallet({
                     chainType: "evm",
@@ -841,7 +841,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             }
         });
 
-        it("should return 429 status when rate limit exceeded", async () => {
+        it("returns 429 status when rate limit exceeded", async () => {
             const rapidRequests = Array.from({ length: TEST_VALUES.RATE_LIMIT_STRESS_COUNT }, (_, i) =>
                 apiClient
                     .createWallet({
@@ -867,7 +867,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             }
         });
 
-        it("should allow requests after rate limit window", async () => {
+        it("allows requests after rate limit window", async () => {
             await delay(DELAY_RATE_LIMIT_WINDOW);
 
             const result = await apiClient.createWallet({
@@ -878,7 +878,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             expect(result).toBeDefined();
         });
 
-        it("should handle concurrent requests without overwhelming server", async () => {
+        it("handles concurrent requests without overwhelming server", async () => {
             for (let batch = 0; batch < TEST_VALUES.RATE_LIMIT_BATCHES; batch++) {
                 const requests = Array.from({ length: TEST_VALUES.RATE_LIMIT_BATCH_SIZE }, () =>
                     apiClient.createWallet({
@@ -894,13 +894,13 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
     });
 
     describe("API Security - Request Validation", () => {
-        it("should validate request body structure", async () => {
+        it("validates request body structure", async () => {
             const invalidBody = { invalidField: "value" };
             const result = await apiClient.createWallet(invalidBody as any);
             expectErrorResponse(result);
         });
 
-        it("should reject malformed JSON in request body", async () => {
+        it("rejects malformed JSON in request body", async () => {
             const originalFetch = global.fetch;
 
             global.fetch = (async (url, init) => {
@@ -917,12 +917,12 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             }
         });
 
-        it("should validate required fields are present", async () => {
+        it("validates required fields are present", async () => {
             const result = await apiClient.createWallet({} as CreateWalletParams);
             expectErrorResponse(result);
         });
 
-        it("should validate field types", async () => {
+        it("validates field types", async () => {
             const result = await apiClient.createWallet({
                 chainType: 123 as any,
                 type: "mpc",
@@ -930,7 +930,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             expectErrorResponse(result);
         });
 
-        it("should validate enum values", async () => {
+        it("validates enum values", async () => {
             const result = await apiClient.createWallet({
                 chainType: "invalid_chain" as any,
                 type: "mpc",
@@ -938,7 +938,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             expectErrorResponse(result);
         });
 
-        it("should validate address formats", async () => {
+        it("validates address formats", async () => {
             const result = await apiClient.createWallet({
                 chainType: "evm",
                 type: "smart",
@@ -952,7 +952,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             expectErrorResponse(result);
         });
 
-        it("should validate amount is numeric string", async () => {
+        it("validates amount is numeric string", async () => {
             const walletAddress = await ensureWalletExists(apiClient, testData);
 
             if (walletAddress) {
@@ -966,7 +966,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
     });
 
     describe("Edge Cases", () => {
-        it("should handle very large amounts", async () => {
+        it("handles very large amounts", async () => {
             const walletAddress = await ensureWalletExists(apiClient, testData);
 
             if (walletAddress) {
@@ -981,7 +981,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
         });
 
         // TODO: Fix zero amount handling - see WAL-7928
-        it.skip("should handle zero amount", async () => {
+        it.skip("handles zero amount", async () => {
             const walletAddress = await ensureWalletExists(apiClient, testData);
 
             if (walletAddress) {
@@ -996,7 +996,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
         });
 
         it(
-            "should handle very small amounts",
+            "handles very small amounts",
             async () => {
                 const walletAddress = await ensureWalletExists(apiClient, testData, {
                     testName: "small-amounts",
@@ -1025,7 +1025,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             TIMEOUT_MEDIUM
         );
 
-        it("should handle concurrent wallet creation", async () => {
+        it("handles concurrent wallet creation", async () => {
             const promises = Array.from({ length: TEST_VALUES.CONCURRENT_REQUESTS }, (_, i) =>
                 apiClient.createWallet({
                     chainType: "evm",
@@ -1045,7 +1045,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
         });
 
         it(
-            "should handle rapid sequential requests",
+            "handles rapid sequential requests",
             async () => {
                 for (let i = 0; i < TEST_VALUES.RAPID_SEQUENTIAL_COUNT; i++) {
                     const result = await apiClient.createWallet({
@@ -1067,7 +1067,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
     });
 
     describe("Response Validation", () => {
-        it("should return properly structured wallet response", async () => {
+        it("returns properly structured wallet response", async () => {
             const result = await apiClient.createWallet({
                 chainType: "evm",
                 type: "mpc",
@@ -1081,7 +1081,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
         });
 
         it(
-            "should return properly structured send response",
+            "returns properly structured send response",
             async () => {
                 const walletAddress = await ensureWalletExists(apiClient, testData, {
                     testName: "structured-send",
@@ -1112,7 +1112,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
             TIMEOUT_MEDIUM
         );
 
-        it("should handle error response structure", async () => {
+        it("handles error response structure", async () => {
             const result = await apiClient.createWallet({
                 chainType: "evm",
                 type: "smart",
@@ -1131,7 +1131,7 @@ describe.skipIf(!shouldRunTests)("ApiClient - Integration Tests (Real HTTP)", ()
     });
 
     describe("Server-Side vs Client-Side", () => {
-        it("should use correct endpoint for createWallet", async () => {
+        it("uses correct endpoint for createWallet", async () => {
             const testClient = createApiClient();
             const originalFetch = global.fetch;
             let capturedUrl: string | undefined;

--- a/packages/wallets/src/api/client.test.ts
+++ b/packages/wallets/src/api/client.test.ts
@@ -44,7 +44,7 @@ describe("ApiClient - createWallet()", () => {
     });
 
     describe("success cases", () => {
-        it("should create EVM smart wallet successfully (client-side)", async () => {
+        it("creates EVM smart wallet successfully (client-side)", async () => {
             const mockResponse = createMockWalletResponse();
             mockPost.mockResolvedValue(createMockSuccessResponse(mockResponse));
 
@@ -66,7 +66,7 @@ describe("ApiClient - createWallet()", () => {
             validateRequest(extractFetchCall(mockPost), "api/2025-06-09/wallets/me", params);
         });
 
-        it("should create wallet successfully (server-side)", async () => {
+        it("creates wallet successfully (server-side)", async () => {
             const serverClient = createServerSideApiClient();
             const serverMockPost = vi.spyOn(serverClient, "post") as MockedFunction<ApiClient["post"]>;
 
@@ -90,7 +90,7 @@ describe("ApiClient - createWallet()", () => {
             validateRequest(extractFetchCall(serverMockPost), "api/2025-06-09/wallets", params);
         });
 
-        it("should create Solana wallet successfully", async () => {
+        it("creates Solana wallet successfully", async () => {
             const mockResponse = createMockWalletResponse({
                 address: "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
                 chainType: "solana",
@@ -123,7 +123,7 @@ describe("ApiClient - createWallet()", () => {
             validateRequest(extractFetchCall(mockPost), "api/2025-06-09/wallets/me", params);
         });
 
-        it("should create MPC wallet successfully", async () => {
+        it("creates MPC wallet successfully", async () => {
             const mockResponse = createMockWalletResponse({ type: "mpc" });
             mockPost.mockResolvedValue(createMockSuccessResponse(mockResponse));
 
@@ -139,7 +139,7 @@ describe("ApiClient - createWallet()", () => {
             validateRequest(extractFetchCall(mockPost), "api/2025-06-09/wallets/me", params);
         });
 
-        it("should create Stellar wallet successfully", async () => {
+        it("creates Stellar wallet successfully", async () => {
             const mockResponse = createMockWalletResponse({
                 address: "GCKFBEIYTKP6RCZX6LRQW2JVAVLMGGVSNESWKN7L2YGQNI2DCOHVHJVY",
                 chainType: "stellar",
@@ -173,7 +173,7 @@ describe("ApiClient - createWallet()", () => {
     });
 
     describe("error cases", () => {
-        it("should handle API error response with error field", async () => {
+        it("handles API error response with error field", async () => {
             const errorResponse = {
                 error: true,
                 message: "Wallet creation failed: invalid configuration",
@@ -187,7 +187,7 @@ describe("ApiClient - createWallet()", () => {
             );
         });
 
-        it("should handle 400 Bad Request error", async () => {
+        it("handles 400 Bad Request error", async () => {
             const errorResponse = {
                 error: true,
                 message: "Invalid request parameters",
@@ -206,7 +206,7 @@ describe("ApiClient - createWallet()", () => {
             );
         });
 
-        it("should handle common HTTP error status codes", async () => {
+        it("handles common HTTP error status codes", async () => {
             await testCommonHttpErrors(
                 () => apiClient.createWallet({ chainType: "evm", type: "smart" }),
                 mockPost,
@@ -214,19 +214,19 @@ describe("ApiClient - createWallet()", () => {
             );
         });
 
-        it("should handle network errors", async () => {
+        it("handles network errors", async () => {
             await testNetworkError(() => apiClient.createWallet({ chainType: "evm", type: "smart" }), mockPost);
         });
 
-        it("should handle invalid JSON response", async () => {
+        it("handles invalid JSON response", async () => {
             await testInvalidJsonResponse(() => apiClient.createWallet({ chainType: "evm", type: "smart" }), mockPost);
         });
 
-        it("should handle timeout errors", async () => {
+        it("handles timeout errors", async () => {
             await testTimeoutError(() => apiClient.createWallet({ chainType: "evm", type: "smart" }), mockPost);
         });
 
-        it("should handle error response without message field", async () => {
+        it("handles error response without message field", async () => {
             const errorResponse = { error: true };
             await testHttpErrorResponse(
                 () => apiClient.createWallet({ chainType: "evm", type: "smart" }),
@@ -236,7 +236,7 @@ describe("ApiClient - createWallet()", () => {
             );
         });
 
-        it("should handle error response with additional fields", async () => {
+        it("handles error response with additional fields", async () => {
             const errorResponse = {
                 error: true,
                 message: "Custom error",
@@ -252,7 +252,7 @@ describe("ApiClient - createWallet()", () => {
     });
 
     describe("request validation", () => {
-        it("should serialize request body correctly", async () => {
+        it("serializes request body correctly", async () => {
             const mockResponse = createMockWalletResponse();
             mockPost.mockResolvedValue(createMockSuccessResponse(mockResponse));
 
@@ -275,7 +275,7 @@ describe("ApiClient - createWallet()", () => {
             }
         });
 
-        it("should include correct headers", async () => {
+        it("includes correct headers", async () => {
             const mockResponse = createMockWalletResponse();
             mockPost.mockResolvedValue(createMockSuccessResponse(mockResponse));
 
@@ -287,7 +287,7 @@ describe("ApiClient - createWallet()", () => {
             }
         });
 
-        it("should handle MPC wallet without config", async () => {
+        it("handles MPC wallet without config", async () => {
             const mockResponse = createMockWalletResponse({ config: undefined, type: "mpc" });
             mockPost.mockResolvedValue(createMockSuccessResponse(mockResponse));
 
@@ -307,7 +307,7 @@ describe("ApiClient - createWallet()", () => {
     });
 
     describe("response validation", () => {
-        it("should parse response correctly with all required fields", async () => {
+        it("parses response correctly with all required fields", async () => {
             const mockResponse = createMockWalletResponse({
                 address: "0x9876543210987654321098765432109876543210",
                 chainType: "evm",
@@ -323,7 +323,7 @@ describe("ApiClient - createWallet()", () => {
             expect((result as any).address).toBe((mockResponse as any).address);
         });
 
-        it("should preserve additional response fields", async () => {
+        it("preserves additional response fields", async () => {
             const mockResponse = {
                 ...createMockWalletResponse(),
                 unexpectedField: "should be preserved",
@@ -336,7 +336,7 @@ describe("ApiClient - createWallet()", () => {
             expect((result as any).unexpectedField).toBe("should be preserved");
         });
 
-        it("should handle response with partial fields", async () => {
+        it("handles response with partial fields", async () => {
             const partialResponse = {
                 address: "0x1234567890123456789012345678901234567890",
             };
@@ -345,7 +345,7 @@ describe("ApiClient - createWallet()", () => {
             expect(result).toHaveProperty("address");
         });
 
-        it("should handle response with null address", async () => {
+        it("handles response with null address", async () => {
             const mockResponse = {
                 ...createMockWalletResponse(),
                 address: null,
@@ -357,7 +357,7 @@ describe("ApiClient - createWallet()", () => {
     });
 
     describe("edge cases", () => {
-        it("should handle createWallet with minimal params", async () => {
+        it("handles createWallet with minimal params", async () => {
             const mockResponse = createMockWalletResponse();
             mockPost.mockResolvedValue(createMockSuccessResponse(mockResponse));
 
@@ -366,7 +366,7 @@ describe("ApiClient - createWallet()", () => {
             expect(result).toEqual(mockResponse);
         });
 
-        it("should handle createWallet with complex nested config", async () => {
+        it("handles createWallet with complex nested config", async () => {
             const mockResponse = createMockWalletResponse();
             mockPost.mockResolvedValue(createMockSuccessResponse(mockResponse));
 
@@ -389,7 +389,7 @@ describe("ApiClient - createWallet()", () => {
             }
         });
 
-        it("should handle createWallet with all chain types", async () => {
+        it("handles createWallet with all chain types", async () => {
             const testCases = [
                 { chainType: "evm" as const, type: "smart" as const },
                 {
@@ -440,7 +440,7 @@ describe("ApiClient - getWallet()", () => {
     });
 
     describe("success cases", () => {
-        it("should get wallet successfully with me: locator", async () => {
+        it("gets wallet successfully with me: locator", async () => {
             const mockResponse = createMockWalletResponse();
             mockGet.mockResolvedValue(createMockSuccessResponse(mockResponse));
 
@@ -452,7 +452,7 @@ describe("ApiClient - getWallet()", () => {
             validateRequest(extractFetchCall(mockGet), `api/2025-06-09/wallets/${locator}`);
         });
 
-        it("should get wallet successfully with EVM address locator", async () => {
+        it("gets wallet successfully with EVM address locator", async () => {
             const mockResponse = createMockWalletResponse();
             mockGet.mockResolvedValue(createMockSuccessResponse(mockResponse));
 
@@ -464,7 +464,7 @@ describe("ApiClient - getWallet()", () => {
             expectRequestPath(call, `api/2025-06-09/wallets/${locator}`);
         });
 
-        it("should get Solana wallet successfully", async () => {
+        it("gets Solana wallet successfully", async () => {
             const mockResponse = createMockWalletResponse({
                 address: "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
                 chainType: "solana",
@@ -480,7 +480,7 @@ describe("ApiClient - getWallet()", () => {
             expectRequestPath(call, `api/2025-06-09/wallets/${locator}`);
         });
 
-        it("should get MPC wallet successfully", async () => {
+        it("gets MPC wallet successfully", async () => {
             const mockResponse = createMockWalletResponse({ type: "mpc" });
             mockGet.mockResolvedValue(createMockSuccessResponse(mockResponse));
 
@@ -491,7 +491,7 @@ describe("ApiClient - getWallet()", () => {
             expectRequestPath(extractFetchCall(mockGet), `api/2025-06-09/wallets/${locator}`);
         });
 
-        it("should get wallet with Solana address locator", async () => {
+        it("gets wallet with Solana address locator", async () => {
             const solanaAddress = WALLET_LOCATORS.solanaAddress;
             const mockResponse = createMockWalletResponse({
                 address: solanaAddress,
@@ -508,7 +508,7 @@ describe("ApiClient - getWallet()", () => {
     });
 
     describe("error cases", () => {
-        it("should handle 404 error (wallet not found)", async () => {
+        it("handles 404 error (wallet not found)", async () => {
             const errorResponse = {
                 error: true,
                 message: "Wallet not found",
@@ -522,23 +522,23 @@ describe("ApiClient - getWallet()", () => {
             );
         });
 
-        it("should handle common HTTP error status codes", async () => {
+        it("handles common HTTP error status codes", async () => {
             await testCommonHttpErrors(() => apiClient.getWallet(WALLET_LOCATORS.evmSmart), mockGet);
         });
 
-        it("should handle network errors", async () => {
+        it("handles network errors", async () => {
             await testNetworkError(() => apiClient.getWallet(WALLET_LOCATORS.evmSmart), mockGet);
         });
 
-        it("should handle invalid JSON response", async () => {
+        it("handles invalid JSON response", async () => {
             await testInvalidJsonResponse(() => apiClient.getWallet(WALLET_LOCATORS.evmSmart), mockGet);
         });
 
-        it("should handle timeout errors", async () => {
+        it("handles timeout errors", async () => {
             await testTimeoutError(() => apiClient.getWallet(WALLET_LOCATORS.evmSmart), mockGet);
         });
 
-        it("should handle error response without message field", async () => {
+        it("handles error response without message field", async () => {
             const errorResponse = { error: true };
             await testHttpErrorResponse(
                 () => apiClient.getWallet(WALLET_LOCATORS.evmSmart),
@@ -548,7 +548,7 @@ describe("ApiClient - getWallet()", () => {
             );
         });
 
-        it("should handle 404 with detailed error message", async () => {
+        it("handles 404 with detailed error message", async () => {
             const errorResponse = {
                 error: true,
                 message: "Wallet not found",
@@ -562,7 +562,7 @@ describe("ApiClient - getWallet()", () => {
     });
 
     describe("request validation", () => {
-        it("should encode wallet locator in URL path correctly", async () => {
+        it("encodes wallet locator in URL path correctly", async () => {
             const mockResponse = createMockWalletResponse();
             mockGet.mockResolvedValue(createMockSuccessResponse(mockResponse));
 
@@ -573,7 +573,7 @@ describe("ApiClient - getWallet()", () => {
             expectRequestPath(call, `api/2025-06-09/wallets/${locator}`);
         });
 
-        it("should include correct headers", async () => {
+        it("includes correct headers", async () => {
             const mockResponse = createMockWalletResponse();
             mockGet.mockResolvedValue(createMockSuccessResponse(mockResponse));
 
@@ -587,7 +587,7 @@ describe("ApiClient - getWallet()", () => {
     });
 
     describe("response validation", () => {
-        it("should parse response correctly with all required fields", async () => {
+        it("parses response correctly with all required fields", async () => {
             const mockResponse = createMockWalletResponse();
             mockGet.mockResolvedValue(createMockSuccessResponse(mockResponse));
 
@@ -598,7 +598,7 @@ describe("ApiClient - getWallet()", () => {
             expect(result).toHaveProperty("type");
         });
 
-        it("should preserve additional response fields", async () => {
+        it("preserves additional response fields", async () => {
             const mockResponse = {
                 ...createMockWalletResponse(),
                 unexpectedField: "should be preserved",
@@ -612,7 +612,7 @@ describe("ApiClient - getWallet()", () => {
             expect((result as any).unexpectedField).toBe("should be preserved");
         });
 
-        it("should handle response with partial fields", async () => {
+        it("handles response with partial fields", async () => {
             const partialResponse = {
                 address: "0x1234567890123456789012345678901234567890",
             };
@@ -623,7 +623,7 @@ describe("ApiClient - getWallet()", () => {
     });
 
     describe("edge cases", () => {
-        it("should handle getWallet with various locator formats", async () => {
+        it("handles getWallet with various locator formats", async () => {
             const locators = [
                 WALLET_LOCATORS.evmSmart,
                 WALLET_LOCATORS.evmMpc,
@@ -645,7 +645,7 @@ describe("ApiClient - getWallet()", () => {
             expect(mockGet).toHaveBeenCalledTimes(locators.length);
         });
 
-        it("should handle getWallet with special characters in address", async () => {
+        it("handles getWallet with special characters in address", async () => {
             const mockResponse = createMockWalletResponse();
             mockGet.mockResolvedValue(createMockSuccessResponse(mockResponse));
 
@@ -672,7 +672,7 @@ describe("ApiClient - send()", () => {
     });
 
     describe("success cases", () => {
-        it("should send tokens successfully", async () => {
+        it("sends tokens successfully", async () => {
             const mockResponse = createMockSendResponse();
             mockPost.mockResolvedValue(createMockSuccessResponse(mockResponse));
 
@@ -694,7 +694,7 @@ describe("ApiClient - send()", () => {
             );
         });
 
-        it("should send tokens with custom token locator (contract address)", async () => {
+        it("sends tokens with custom token locator (contract address)", async () => {
             const mockResponse = createMockSendResponse({ id: "txn-456" });
             mockPost.mockResolvedValue(createMockSuccessResponse(mockResponse));
 
@@ -712,7 +712,7 @@ describe("ApiClient - send()", () => {
             expectRequestPath(call, `api/2025-06-09/wallets/${walletLocator}/tokens/${tokenLocator}/transfers`);
         });
 
-        it("should send tokens for Solana wallet", async () => {
+        it("sends tokens for Solana wallet", async () => {
             const mockResponse = createMockSendResponse({
                 id: "txn-sol-789",
                 chainType: "solana",
@@ -748,7 +748,7 @@ describe("ApiClient - send()", () => {
             expectRequestPath(call, `api/2025-06-09/wallets/${walletLocator}/tokens/${tokenLocator}/transfers`);
         });
 
-        it("should send with very large amount", async () => {
+        it("sends with very large amount", async () => {
             const mockResponse = createMockSendResponse();
             mockPost.mockResolvedValue(createMockSuccessResponse(mockResponse));
 
@@ -766,7 +766,7 @@ describe("ApiClient - send()", () => {
             }
         });
 
-        it("should send with small amount", async () => {
+        it("sends with small amount", async () => {
             const mockResponse = createMockSendResponse();
             mockPost.mockResolvedValue(createMockSuccessResponse(mockResponse));
 
@@ -780,7 +780,7 @@ describe("ApiClient - send()", () => {
             expect(result).toEqual(mockResponse);
         });
 
-        it("should send with zero amount", async () => {
+        it("sends with zero amount", async () => {
             const mockResponse = createMockSendResponse();
             mockPost.mockResolvedValue(createMockSuccessResponse(mockResponse));
 
@@ -796,7 +796,7 @@ describe("ApiClient - send()", () => {
     });
 
     describe("error cases", () => {
-        it("should handle API error response with error field", async () => {
+        it("handles API error response with error field", async () => {
             const errorResponse = {
                 error: true,
                 message: "Insufficient balance",
@@ -814,7 +814,7 @@ describe("ApiClient - send()", () => {
             );
         });
 
-        it("should handle 400 Bad Request (invalid recipient)", async () => {
+        it("handles 400 Bad Request (invalid recipient)", async () => {
             const errorResponse = {
                 error: true,
                 message: "Invalid recipient address",
@@ -832,7 +832,7 @@ describe("ApiClient - send()", () => {
             );
         });
 
-        it("should handle common HTTP error status codes", async () => {
+        it("handles common HTTP error status codes", async () => {
             await testCommonHttpErrors(
                 () =>
                     apiClient.send(WALLET_LOCATORS.evmSmart, TOKEN_LOCATORS.eth, {
@@ -843,7 +843,7 @@ describe("ApiClient - send()", () => {
             );
         });
 
-        it("should handle network errors", async () => {
+        it("handles network errors", async () => {
             await testNetworkError(
                 () =>
                     apiClient.send(WALLET_LOCATORS.evmSmart, TOKEN_LOCATORS.eth, {
@@ -854,7 +854,7 @@ describe("ApiClient - send()", () => {
             );
         });
 
-        it("should handle invalid JSON response", async () => {
+        it("handles invalid JSON response", async () => {
             await testInvalidJsonResponse(
                 () =>
                     apiClient.send(WALLET_LOCATORS.evmSmart, TOKEN_LOCATORS.eth, {
@@ -865,7 +865,7 @@ describe("ApiClient - send()", () => {
             );
         });
 
-        it("should handle timeout errors", async () => {
+        it("handles timeout errors", async () => {
             await testTimeoutError(
                 () =>
                     apiClient.send(WALLET_LOCATORS.evmSmart, TOKEN_LOCATORS.eth, {
@@ -876,7 +876,7 @@ describe("ApiClient - send()", () => {
             );
         });
 
-        it("should handle error response without message field", async () => {
+        it("handles error response without message field", async () => {
             const errorResponse = { error: true };
             await testHttpErrorResponse(
                 () =>
@@ -890,7 +890,7 @@ describe("ApiClient - send()", () => {
             );
         });
 
-        it("should handle 400 error with insufficient balance details", async () => {
+        it("handles 400 error with insufficient balance details", async () => {
             const errorResponse = {
                 error: true,
                 message: "Insufficient balance",
@@ -910,7 +910,7 @@ describe("ApiClient - send()", () => {
     });
 
     describe("request validation", () => {
-        it("should serialize request body correctly", async () => {
+        it("serializes request body correctly", async () => {
             const mockResponse = createMockSendResponse();
             mockPost.mockResolvedValue(createMockSuccessResponse(mockResponse));
 
@@ -927,7 +927,7 @@ describe("ApiClient - send()", () => {
             }
         });
 
-        it("should construct URL path correctly with wallet and token locators", async () => {
+        it("constructs URL path correctly with wallet and token locators", async () => {
             const mockResponse = createMockSendResponse();
             mockPost.mockResolvedValue(createMockSuccessResponse(mockResponse));
 
@@ -943,7 +943,7 @@ describe("ApiClient - send()", () => {
             expectRequestPath(call, `api/2025-06-09/wallets/${walletLocator}/tokens/${tokenLocator}/transfers`);
         });
 
-        it("should include correct headers", async () => {
+        it("includes correct headers", async () => {
             const mockResponse = createMockSendResponse();
             mockPost.mockResolvedValue(createMockSuccessResponse(mockResponse));
 
@@ -960,7 +960,7 @@ describe("ApiClient - send()", () => {
     });
 
     describe("response validation", () => {
-        it("should parse response correctly with all required fields", async () => {
+        it("parses response correctly with all required fields", async () => {
             const mockResponse = createMockSendResponse();
             mockPost.mockResolvedValue(createMockSuccessResponse(mockResponse));
 
@@ -975,7 +975,7 @@ describe("ApiClient - send()", () => {
             expect(result).toHaveProperty("walletType");
         });
 
-        it("should preserve additional response fields", async () => {
+        it("preserves additional response fields", async () => {
             const mockResponse = {
                 ...createMockSendResponse(),
                 unexpectedField: "should be preserved",
@@ -991,7 +991,7 @@ describe("ApiClient - send()", () => {
             expect((result as any).unexpectedField).toBe("should be preserved");
         });
 
-        it("should handle response with partial fields", async () => {
+        it("handles response with partial fields", async () => {
             const partialResponse = {
                 id: "txn-123",
                 status: "pending",
@@ -1007,7 +1007,7 @@ describe("ApiClient - send()", () => {
     });
 
     describe("edge cases", () => {
-        it("should handle send with different token locator formats", async () => {
+        it("handles send with different token locator formats", async () => {
             const tokenLocators = [
                 TOKEN_LOCATORS.eth,
                 TOKEN_LOCATORS.usdc,
@@ -1035,7 +1035,7 @@ describe("ApiClient - send()", () => {
             expect(mockPost).toHaveBeenCalledTimes(tokenLocators.length);
         });
 
-        it("should handle send with very long recipient address", async () => {
+        it("handles send with very long recipient address", async () => {
             const mockResponse = createMockSendResponse();
             mockPost.mockResolvedValue(createMockSuccessResponse(mockResponse));
 
@@ -1053,7 +1053,7 @@ describe("ApiClient - send()", () => {
             }
         });
 
-        it("should handle send with scientific notation amount", async () => {
+        it("handles send with scientific notation amount", async () => {
             const mockResponse = createMockSendResponse();
             mockPost.mockResolvedValue(createMockSuccessResponse(mockResponse));
 
@@ -1084,7 +1084,7 @@ describe("ApiClient - edge cases and integration scenarios", () => {
     });
 
     describe("concurrent requests", () => {
-        it("should handle concurrent createWallet calls", async () => {
+        it("handles concurrent createWallet calls", async () => {
             const mockPost = vi.spyOn(apiClient, "post") as MockedFunction<ApiClient["post"]>;
 
             const mockResponse1 = createMockWalletResponse({
@@ -1108,7 +1108,7 @@ describe("ApiClient - edge cases and integration scenarios", () => {
             expect(mockPost).toHaveBeenCalledTimes(2);
         });
 
-        it("should handle concurrent getWallet calls", async () => {
+        it("handles concurrent getWallet calls", async () => {
             const mockGet = vi.spyOn(apiClient, "get") as MockedFunction<ApiClient["get"]>;
 
             const mockResponse1 = createMockWalletResponse({
@@ -1132,7 +1132,7 @@ describe("ApiClient - edge cases and integration scenarios", () => {
             expect(mockGet).toHaveBeenCalledTimes(2);
         });
 
-        it("should handle concurrent send calls", async () => {
+        it("handles concurrent send calls", async () => {
             const mockPost = vi.spyOn(apiClient, "post") as MockedFunction<ApiClient["post"]>;
 
             const mockResponse1 = createMockSendResponse({ id: "txn-111" });
@@ -1160,7 +1160,7 @@ describe("ApiClient - edge cases and integration scenarios", () => {
     });
 
     describe("response parsing edge cases", () => {
-        it("should handle empty response body gracefully", async () => {
+        it("handles empty response body gracefully", async () => {
             const mockPost = vi.spyOn(apiClient, "post") as MockedFunction<ApiClient["post"]>;
             const emptyResponse = {
                 json: vi.fn().mockResolvedValue({}),
@@ -1174,7 +1174,7 @@ describe("ApiClient - edge cases and integration scenarios", () => {
             expect(result).toEqual({});
         });
 
-        it("should handle response with null values in nested objects", async () => {
+        it("handles response with null values in nested objects", async () => {
             const mockGet = vi.spyOn(apiClient, "get") as MockedFunction<ApiClient["get"]>;
             const mockResponse = {
                 ...createMockWalletResponse(),
@@ -1187,7 +1187,7 @@ describe("ApiClient - edge cases and integration scenarios", () => {
             expect((result as any).config).toBeNull();
         });
 
-        it("should handle response with undefined fields", async () => {
+        it("handles response with undefined fields", async () => {
             const mockPost = vi.spyOn(apiClient, "post") as MockedFunction<ApiClient["post"]>;
             const mockResponse = {
                 address: "0x1234567890123456789012345678901234567890",
@@ -1202,7 +1202,7 @@ describe("ApiClient - edge cases and integration scenarios", () => {
             expect((result as any).config).toBeUndefined();
         });
 
-        it("should handle response with array fields", async () => {
+        it("handles response with array fields", async () => {
             const mockGet = vi.spyOn(apiClient, "get") as MockedFunction<ApiClient["get"]>;
             const mockResponse = {
                 ...createMockWalletResponse(),
@@ -1215,7 +1215,7 @@ describe("ApiClient - edge cases and integration scenarios", () => {
             expect((result as any).tags).toEqual(["tag1", "tag2"]);
         });
 
-        it("should handle malformed response data", async () => {
+        it("handles malformed response data", async () => {
             const mockPost = vi.spyOn(apiClient, "post") as MockedFunction<ApiClient["post"]>;
             const malformedData = {};
             mockPost.mockResolvedValue(createMockSuccessResponse(malformedData));
@@ -1226,7 +1226,7 @@ describe("ApiClient - edge cases and integration scenarios", () => {
     });
 
     describe("server-side vs client-side behavior", () => {
-        it("should use correct endpoint for createWallet on server-side", async () => {
+        it("uses correct endpoint for createWallet on server-side", async () => {
             const serverClient = createServerSideApiClient();
             const mockPost = vi.spyOn(serverClient, "post") as MockedFunction<ApiClient["post"]>;
             const mockResponse = createMockWalletResponse();
@@ -1238,7 +1238,7 @@ describe("ApiClient - edge cases and integration scenarios", () => {
             expectRequestPath(call, "api/2025-06-09/wallets");
         });
 
-        it("should use correct endpoint for createWallet on client-side", async () => {
+        it("uses correct endpoint for createWallet on client-side", async () => {
             const client = createTestApiClient();
             const mockPost = vi.spyOn(client, "post") as MockedFunction<ApiClient["post"]>;
             const mockResponse = createMockWalletResponse();
@@ -1252,7 +1252,7 @@ describe("ApiClient - edge cases and integration scenarios", () => {
     });
 
     describe("error response structure variations", () => {
-        it("should handle error with only error field", async () => {
+        it("handles error with only error field", async () => {
             const mockPost = vi.spyOn(apiClient, "post") as MockedFunction<ApiClient["post"]>;
             const errorResponse = { error: true };
             mockPost.mockResolvedValue(createMockErrorResponse(errorResponse, 400));
@@ -1262,7 +1262,7 @@ describe("ApiClient - edge cases and integration scenarios", () => {
             expect((result as any).error).toBe(true);
         });
 
-        it("should handle error with error and message fields", async () => {
+        it("handles error with error and message fields", async () => {
             const mockPost = vi.spyOn(apiClient, "post") as MockedFunction<ApiClient["post"]>;
             const errorResponse = { error: true, message: "Error occurred" };
             mockPost.mockResolvedValue(createMockErrorResponse(errorResponse, 400));
@@ -1273,7 +1273,7 @@ describe("ApiClient - edge cases and integration scenarios", () => {
             expect((result as any).message).toBe("Error occurred");
         });
 
-        it("should handle error with nested error details", async () => {
+        it("handles error with nested error details", async () => {
             const mockPost = vi.spyOn(apiClient, "post") as MockedFunction<ApiClient["post"]>;
             const errorResponse = {
                 error: true,
@@ -1293,7 +1293,7 @@ describe("ApiClient - edge cases and integration scenarios", () => {
     });
 
     describe("request serialization edge cases", () => {
-        it("should handle request with special characters in JSON", async () => {
+        it("handles request with special characters in JSON", async () => {
             const mockPost = vi.spyOn(apiClient, "post") as MockedFunction<ApiClient["post"]>;
             const mockResponse = createMockWalletResponse();
             mockPost.mockResolvedValue(createMockSuccessResponse(mockResponse));
@@ -1318,7 +1318,7 @@ describe("ApiClient - edge cases and integration scenarios", () => {
             }
         });
 
-        it("should handle request with unicode characters", async () => {
+        it("handles request with unicode characters", async () => {
             const mockPost = vi.spyOn(apiClient, "post") as MockedFunction<ApiClient["post"]>;
             const mockResponse = createMockSendResponse();
             mockPost.mockResolvedValue(createMockSuccessResponse(mockResponse));


### PR DESCRIPTION
## Summary

- Rename `client.unit.test.ts` → `client.test.ts` (drops `.unit.` infix per naming convention)
- Move `__tests__/client.integration.test.ts` → `client-integration.test.ts` (out of `__tests__/` dir, drops `.integration.` infix)
- Update all relative imports in the moved integration test file (`../client` → `./client`, `../types` → `./types`, `./test-utils` → `./__tests__/test-utils`, `./constants` → `./__tests__/constants`)
- Fix ~140 BDD naming violations: remove `should` prefix from all `it()` descriptions, converting to active present-tense verbs (e.g., `"should create wallet"` → `"creates wallet"`)

## Test plan

- [ ] Verify existing Vitest runs pass (`pnpm test:vitest` in `packages/wallets`)
- [ ] Confirm no remaining `it("should` patterns in both files
- [ ] Confirm import paths resolve correctly after file moves
