### PR TITLE
feat(signers-cryptography): move and fix BDD naming in algorithm tests (ENG-2313)

### DIFF
--- a/packages/client/signers-cryptography/src/algorithms/symmetric/aes-gcm.test.ts
+++ b/packages/client/signers-cryptography/src/algorithms/symmetric/aes-gcm.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { AesGcm } from "../../algorithms/symmetric/aes-gcm";
+import { AesGcm } from "./aes-gcm";
 import type { SymmetricKeyProvider } from "../../types/providers";
 
 describe("AesGcm", () => {
@@ -18,7 +18,7 @@ describe("AesGcm", () => {
         vi.restoreAllMocks();
     });
 
-    it("should encrypt and decrypt data successfully", async () => {
+    it("encrypts and decrypts data successfully", async () => {
         const handler = new AesGcm();
         const originalData = new TextEncoder().encode("hello world");
 
@@ -29,7 +29,7 @@ describe("AesGcm", () => {
         expect(new TextDecoder().decode(decryptedData)).toBe("hello world");
     });
 
-    it("should use a different IV for each encryption", async () => {
+    it("uses a different IV for each encryption", async () => {
         const handler = new AesGcm();
         const originalData = new TextEncoder().encode("hello world");
 

--- a/packages/client/signers-cryptography/src/algorithms/symmetric/fpe.test.ts
+++ b/packages/client/signers-cryptography/src/algorithms/symmetric/fpe.test.ts
@@ -1,4 +1,4 @@
-import { FPE } from "../../algorithms/symmetric/fpe";
+import { FPE } from "./fpe";
 import type { ECDHKeyProvider } from "../../providers/key-providers/ecdh-provider";
 import { mock } from "vitest-mock-extended";
 import { describe, it, expect, beforeEach, vi } from "vitest";
@@ -31,7 +31,7 @@ describe("FPE", () => {
     });
 
     describe("encrypt-decrypt", () => {
-        it("should encrypt and decrypt a number array", async () => {
+        it("encrypts and decrypts a number array", async () => {
             const encrypted = await fpe.encrypt(input, mockCryptoKey);
             const decrypted = await fpe.decrypt(encrypted, mockCryptoKey);
             expect(decrypted).toEqual(input);


### PR DESCRIPTION
## Summary

- Move `aes-gcm.test.ts` and `fpe.test.ts` from `__tests__/algorithms/` to `algorithms/symmetric/` (co-located with source files per convention)
- Update source imports to reflect new co-located paths
- Fix 3 BDD naming violations: remove `should` prefix and convert to active present-tense verbs

## Test plan

- [ ] Verify existing Vitest runs pass in `packages/client/signers-cryptography`
- [ ] Confirm imports resolve correctly after file moves