### PR TITLE
feat(verifiable-credentials): fix BDD naming in all unit tests (ENG-2314)

### DIFF
--- a/.github/workflows/e2e-regression-tests.yml
+++ b/.github/workflows/e2e-regression-tests.yml
@@ -53,8 +53,8 @@ jobs:
 
               run: |
                   mkdir -p test-results
-                  # Run e2e.spec.ts (regression tests) only; exclude smoke project
-                  pnpm exec playwright test e2e/e2e.spec.ts --project=chromium --project=firefox --project=webkit || true
+                  # Run regression tests only; testMatch in playwright.config.ts already excludes smoke and sdk projects
+                  pnpm exec playwright test --project=chromium --project=firefox --project=webkit || true
 
             - name: Generate test report
               if: always()

--- a/.github/workflows/e2e-regression-tests.yml
+++ b/.github/workflows/e2e-regression-tests.yml
@@ -53,8 +53,8 @@ jobs:
 
               run: |
                   mkdir -p test-results
-                  # Run regression tests only; testMatch in playwright.config.ts already excludes smoke and sdk projects
-                  pnpm exec playwright test --project=chromium --project=firefox --project=webkit || true
+                  # Run e2e.spec.ts (regression tests) only; exclude smoke project
+                  pnpm exec playwright test e2e/e2e.spec.ts --project=chromium --project=firefox --project=webkit || true
 
             - name: Generate test report
               if: always()

--- a/packages/client/verifiable-credentials/src/decryption/lit.test.ts
+++ b/packages/client/verifiable-credentials/src/decryption/lit.test.ts
@@ -21,7 +21,7 @@ describe("Lit", () => {
         jest.spyOn(LitJsSdk, "checkAndSignAuthMessage").mockResolvedValue({} as any);
     });
 
-    it("should connect to the Lit network", async () => {
+    it("connects to the Lit network", async () => {
         const mockConnect = jest.fn();
         litSpy.mockImplementation(() => {
             return { connect: mockConnect } as any;

--- a/packages/client/verifiable-credentials/src/decryption/secret.test.ts
+++ b/packages/client/verifiable-credentials/src/decryption/secret.test.ts
@@ -8,7 +8,7 @@ describe("VCSymmetricEncryptionService", () => {
     });
 
     describe("decrypt", () => {
-        it("should throw error if the data is malformed", async () => {
+        it("throws error if the data is malformed", async () => {
             const encrypted = {
                 id: "testId",
                 payload:
@@ -20,7 +20,7 @@ describe("VCSymmetricEncryptionService", () => {
             );
         });
 
-        it("should return decrypted data", async () => {
+        it("returns decrypted data", async () => {
             const encrypted = {
                 id: "urn:uuid:c00ffbfa-4dc3-4e22-8b24-ce2f720c7a58",
                 payload:

--- a/packages/client/verifiable-credentials/src/decryption/wallet.test.ts
+++ b/packages/client/verifiable-credentials/src/decryption/wallet.test.ts
@@ -19,14 +19,14 @@ describe("WalletDecrypt", () => {
         walletDecrypt = new CrossmintDecrypt("userAddress", signCallbackMock, authServiceMock);
     });
 
-    it("should decrypt a credential", async () => {
+    it("decrypts a credential", async () => {
         const result = await walletDecrypt.decrypt(encryptedCredentialMock);
         expect(result).toEqual(mockCredential);
         expect(authServiceMock.getChallenge).toHaveBeenCalledWith("userAddress");
         expect(signCallbackMock).toHaveBeenCalledWith("userAddress", "payloadchallenge");
     });
 
-    it("should throw error if malformed", async () => {
+    it("throws error if malformed", async () => {
         authServiceMock.decrypt.mockResolvedValue("malformed");
         await expect(walletDecrypt.decrypt(encryptedCredentialMock)).rejects.toThrow(
             new Error("Decrypted data is not a valid Verifiable Credential")

--- a/packages/client/verifiable-credentials/src/presentation/getCredential.test.ts
+++ b/packages/client/verifiable-credentials/src/presentation/getCredential.test.ts
@@ -23,7 +23,7 @@ describe("getCredentialFromId", () => {
         jest.clearAllMocks();
     });
 
-    it("should fetch credential by id", async () => {
+    it("fetches credential by id", async () => {
         jest.spyOn(crossmintAPI, "getBaseUrl").mockReturnValue("test.com");
         const credential = await credentialService.getById("test-id");
         expect(credential).toEqual({ id: "test", type: "VerifiableCredential" });
@@ -33,7 +33,7 @@ describe("getCredentialFromId", () => {
         });
     });
 
-    it("should throw if fetch throws an error", async () => {
+    it("throws if fetch throws an error", async () => {
         jest.spyOn(crossmintAPI, "getBaseUrl").mockReturnValue("test-env");
         (fetch as jest.Mock).mockRejectedValue(new Error("Fetch error"));
         const credential = credentialService.getById("test-id");

--- a/packages/client/verifiable-credentials/src/presentation/getNfts.test.ts
+++ b/packages/client/verifiable-credentials/src/presentation/getNfts.test.ts
@@ -13,7 +13,7 @@ describe("getNfts", () => {
         crossmintAPI.init("test", { environment: "test" });
         jest.spyOn(crossmintAPI, "getHeaders").mockReturnValue({} as any);
     });
-    it("should fetch wallet NFTs", async () => {
+    it("fetches wallet NFTs", async () => {
         const mockResponse = Array(50).fill({ a: "a" });
         const mockResponse2 = [{ a: "a" }, { b: "b" }];
 
@@ -33,7 +33,7 @@ describe("getNfts", () => {
         expect(fetch).toHaveBeenCalled();
     });
 
-    it("should filter Polygon ERC-721 NFTs", () => {
+    it("filters Polygon ERC-721 NFTs", () => {
         const nfts: CrossmintWalletNft[] = [
             { chain: "polygon", tokenStandard: "erc-721" } as any,
             { chain: "ethereum", tokenStandard: "erc-721" } as any,

--- a/packages/client/verifiable-credentials/src/verifiableCredentialsSDK/encryption/lit.test.ts
+++ b/packages/client/verifiable-credentials/src/verifiableCredentialsSDK/encryption/lit.test.ts
@@ -23,7 +23,7 @@ describe("Lit", () => {
         jest.spyOn(LitJsSdk, "checkAndSignAuthMessage").mockResolvedValue({} as any);
     });
 
-    it("should connect to the Lit network", async () => {
+    it("connects to the Lit network", async () => {
         const mockConnect = jest.fn();
         litSpy.mockImplementation(() => {
             return { connect: mockConnect } as any;
@@ -33,7 +33,7 @@ describe("Lit", () => {
         expect(mockConnect).toHaveBeenCalled();
     });
 
-    it("should throw an error when decryption fails", async () => {
+    it("throws an error when decryption fails", async () => {
         const mockDecryptZipFileWithMetadata = jest.fn().mockResolvedValue({});
         jest.spyOn(LitJsSdk, "decryptZipFileWithMetadata").mockImplementation(mockDecryptZipFileWithMetadata);
 
@@ -42,7 +42,7 @@ describe("Lit", () => {
         );
     });
 
-    it("should decrypt a base64 ciphertext", async () => {
+    it("decrypts a base64 ciphertext", async () => {
         const mockDecryptZipFileWithMetadata = jest.fn().mockResolvedValue({
             decryptedFile: [1, 2, 3],
         });

--- a/packages/client/verifiable-credentials/src/verifiableCredentialsSDK/onchainServices/nft.test.ts
+++ b/packages/client/verifiable-credentials/src/verifiableCredentialsSDK/onchainServices/nft.test.ts
@@ -22,7 +22,7 @@ describe("NFTStatusService", () => {
         });
     });
 
-    it("should return false if NFT is not burnt", async () => {
+    it("returns false if NFT is not burnt", async () => {
         const mockNFT: Nft = {
             chain: "polygon",
             contractAddress: "mockContractAddress",
@@ -34,7 +34,7 @@ describe("NFTStatusService", () => {
         expect(result).toBe(false);
     });
 
-    it("should return true if NFT is burnt", async () => {
+    it("returns true if NFT is burnt", async () => {
         const mockNFT: Nft = {
             chain: "polygon",
             contractAddress: "mockContractAddress",
@@ -46,7 +46,7 @@ describe("NFTStatusService", () => {
         expect(result).toBe(true);
     });
 
-    it("should return true if NFT is burnt", async () => {
+    it("returns true if NFT is burnt", async () => {
         const mockNFT: Nft = {
             chain: "polygon",
             contractAddress: "mockContractAddress",
@@ -58,7 +58,7 @@ describe("NFTStatusService", () => {
         expect(result).toBe(true);
     });
 
-    it("should throw error if chain is not polygon", async () => {
+    it("throws error if chain is not polygon", async () => {
         const mockNFT: Nft = {
             chain: "someChain" as any,
             contractAddress: "mockContractAddress",
@@ -70,7 +70,7 @@ describe("NFTStatusService", () => {
         );
     });
 
-    it("should throw error if failed to check if NFT is burned", async () => {
+    it("throws error if failed to check if NFT is burned", async () => {
         const mockNFT: Nft = {
             chain: "polygon",
             contractAddress: "mockContractAddress",

--- a/packages/client/verifiable-credentials/src/verifiableCredentialsSDK/presentation/contractMetadata.test.ts
+++ b/packages/client/verifiable-credentials/src/verifiableCredentialsSDK/presentation/contractMetadata.test.ts
@@ -27,7 +27,7 @@ describe("getMetadata", () => {
             configManager.init({ ipfsGateways: ["gateway1", "gateway2"] });
         });
 
-        it("should fetch metadata", async () => {
+        it("fetches metadata", async () => {
             const mockResponse = { a: "a" };
             (IPFSService.prototype.getFile as jest.Mock).mockResolvedValue(mockResponse);
 
@@ -38,7 +38,7 @@ describe("getMetadata", () => {
     });
 
     describe("getContractWithVCMetadata", () => {
-        it("should fetch contract with VC metadata", async () => {
+        it("fetches contract with VC metadata", async () => {
             const mockResponse = {
                 a: "a",
                 credentialMetadata: {

--- a/packages/client/verifiable-credentials/src/verifiableCredentialsSDK/presentation/getCollections.test.ts
+++ b/packages/client/verifiable-credentials/src/verifiableCredentialsSDK/presentation/getCollections.test.ts
@@ -5,7 +5,7 @@ import { bundleNfts, getCredentialNfts } from "./getCollections";
 jest.mock("./contractMetadata");
 
 describe("bundleNfts", () => {
-    it("should group NFTs by contract address", () => {
+    it("groups NFTs by contract address", () => {
         const nfts: Nft[] = [
             { contractAddress: "address1" } as any,
             { contractAddress: "address1" } as any,
@@ -25,13 +25,13 @@ describe("getCredentialCollections", () => {
     const getNftsFunction = jest.fn().mockResolvedValue([] as any);
     beforeEach(() => {});
 
-    it("should throw error if chain is not polygon", async () => {
+    it("throws error if chain is not polygon", async () => {
         await expect(getCredentialNfts("someChain" as any, "wallet", getNftsFunction, {})).rejects.toThrow(
             "Verifiable credentials are not supported on someChain chain"
         );
     });
 
-    it("should filter collections by types if filter is provided", async () => {
+    it("filters collections by types if filter is provided", async () => {
         const collections: CredentialsCollection[] = [
             { metadata: { credentialMetadata: { type: ["type1"] } } } as any,
             { metadata: { credentialMetadata: { type: ["type2"] } } } as any,

--- a/packages/client/verifiable-credentials/src/verifiableCredentialsSDK/presentation/nftByLocator.test.ts
+++ b/packages/client/verifiable-credentials/src/verifiableCredentialsSDK/presentation/nftByLocator.test.ts
@@ -18,7 +18,7 @@ describe("getCredentialNFTFromLocator", () => {
         );
     });
 
-    it("fetches and return the NFT and its collection", async () => {
+    it("fetches and returns the NFT and its collection", async () => {
         const mockNftUri = "ipfs://uri";
         const mockNftMetadata = { name: "NFT Name" };
         const collectionMetadata = {

--- a/packages/client/verifiable-credentials/src/verifiableCredentialsSDK/presentation/nftByLocator.test.ts
+++ b/packages/client/verifiable-credentials/src/verifiableCredentialsSDK/presentation/nftByLocator.test.ts
@@ -12,13 +12,13 @@ describe("getCredentialNFTFromLocator", () => {
         jest.resetAllMocks();
     });
 
-    it("should throw error if chain is not supported", async () => {
+    it("throws error if chain is not supported", async () => {
         await expect(getCredentialNFTFromLocator("ethereum:0x1234:1")).rejects.toThrow(
             "Verifiable Credentials are not available on the provided chain: ethereum"
         );
     });
 
-    it("should fetch and return the NFT and its collection", async () => {
+    it("fetches and return the NFT and its collection", async () => {
         const mockNftUri = "ipfs://uri";
         const mockNftMetadata = { name: "NFT Name" };
         const collectionMetadata = {

--- a/packages/client/verifiable-credentials/src/verifiableCredentialsSDK/services/ipfs.test.ts
+++ b/packages/client/verifiable-credentials/src/verifiableCredentialsSDK/services/ipfs.test.ts
@@ -17,7 +17,7 @@ describe("IPFSService", () => {
     });
 
     describe("formatUrl", () => {
-        it("should correctly format URL", () => {
+        it("correctly formats URL", () => {
             const baseUrl = "http://example.com/";
             const result = ipfsService.formatUrl(baseUrl, "123");
             expect(result).toEqual("http://example.com/123");
@@ -27,14 +27,14 @@ describe("IPFSService", () => {
     describe("getFile", () => {
         beforeEach(() => {});
 
-        it("should fetch file from gateway", async () => {
+        it("fetches file from gateway", async () => {
             const uri = "ipfs://123";
             const result = await ipfsService.getFile(uri);
             expect(result).toEqual({});
             expect(global.fetch).toHaveBeenCalled();
         });
 
-        it("should throw error when fetch fails", async () => {
+        it("throws error when fetch fails", async () => {
             (global.fetch as jest.MockedFunction<typeof fetch>).mockRejectedValue(new Error("Fetch error"));
 
             const uri = "ipfs://123";

--- a/packages/client/verifiable-credentials/src/verifiableCredentialsSDK/types/utils.test.ts
+++ b/packages/client/verifiable-credentials/src/verifiableCredentialsSDK/types/utils.test.ts
@@ -3,21 +3,21 @@ import { isEncryptedVerifiableCredential, isVcChain, parseLocator } from "./util
 
 describe("utils", () => {
     describe("isPolygon", () => {
-        it("should return true if the chain includes 'poly'", () => {
+        it("returns true if the chain includes 'poly'", () => {
             expect(isVcChain("polygon")).toBe(true);
         });
 
-        it("should return true if the chain is poly-amoy", () => {
+        it("returns true if the chain is poly-amoy", () => {
             expect(isVcChain("poly-amoy")).toBe(true);
         });
 
-        it("should return false if the chain does not include 'poly'", () => {
+        it("returns false if the chain does not include 'poly'", () => {
             expect(isVcChain("ethereum")).toBe(false);
         });
     });
 
     describe("parseLocator", () => {
-        it("should parse a valid locator string", () => {
+        it("parses a valid locator string", () => {
             const locator = "ethereum:0x1234:5678";
             const result = parseLocator(locator);
 
@@ -28,7 +28,7 @@ describe("utils", () => {
             });
         });
 
-        it("should throw an error for an invalid locator string", () => {
+        it("throws an error for an invalid locator string", () => {
             const locator = "ethereum";
 
             expect(() => parseLocator(locator)).toThrowError(
@@ -38,7 +38,7 @@ describe("utils", () => {
     });
 
     describe("isEncryptedVerifiableCredential", () => {
-        it("should return true if the credential is an EncryptedVerifiableCredential", () => {
+        it("returns true if the credential is an EncryptedVerifiableCredential", () => {
             const encryptedCredential: EncryptedVerifiableCredential = {
                 id: "id",
                 payload: "payload",
@@ -47,7 +47,7 @@ describe("utils", () => {
             expect(isEncryptedVerifiableCredential(encryptedCredential)).toBe(true);
         });
 
-        it("should return false if the credential is not an EncryptedVerifiableCredential", () => {
+        it("returns false if the credential is not an EncryptedVerifiableCredential", () => {
             const verifiableCredential: VerifiableCredential = {
                 id: "id",
                 type: ["type"],

--- a/packages/client/verifiable-credentials/src/verifiableCredentialsSDK/verification/signature.test.ts
+++ b/packages/client/verifiable-credentials/src/verifiableCredentialsSDK/verification/signature.test.ts
@@ -10,13 +10,13 @@ describe("VerifiableCredentialSignatureService", () => {
         jest.resetAllMocks();
     });
 
-    it("should verify a valid credential", async () => {
+    it("verifies a valid credential", async () => {
         const result = await service.verify(mockCredential);
 
         expect(result).toBe(true);
     });
 
-    it("should fail a invalid credential", async () => {
+    it("fails a invalid credential", async () => {
         const invalidCredential: VerifiableCredential = {
             ...mockCredential,
             proof: {
@@ -31,7 +31,7 @@ describe("VerifiableCredentialSignatureService", () => {
         expect(result).toBe(false);
     });
 
-    it("should throw error for invalid issuer DID", async () => {
+    it("throws error for invalid issuer DID", async () => {
         const mockCredential: VerifiableCredential = {
             issuer: { id: "invalidDID" },
             proof: {},
@@ -42,7 +42,7 @@ describe("VerifiableCredentialSignatureService", () => {
         )) as any;
     });
 
-    it("should throw error for missing proof", async () => {
+    it("throws error for missing proof", async () => {
         const mockCredential: VerifiableCredential = {
             issuer: { id: "did:chain:address" },
         } as any;
@@ -50,7 +50,7 @@ describe("VerifiableCredentialSignatureService", () => {
         await expect(service.verify(mockCredential)).rejects.toThrow("No proof associated with credential");
     });
 
-    it("should throw error for tampered issuer address", async () => {
+    it("throws error for tampered issuer address", async () => {
         const mockCredential: VerifiableCredential = {
             issuer: { id: "did:chain:address" },
             proof: {},

--- a/packages/client/verifiable-credentials/src/verifiableCredentialsSDK/verification/signature.test.ts
+++ b/packages/client/verifiable-credentials/src/verifiableCredentialsSDK/verification/signature.test.ts
@@ -16,7 +16,7 @@ describe("VerifiableCredentialSignatureService", () => {
         expect(result).toBe(true);
     });
 
-    it("fails a invalid credential", async () => {
+    it("fails an invalid credential", async () => {
         const invalidCredential: VerifiableCredential = {
             ...mockCredential,
             proof: {

--- a/packages/client/verifiable-credentials/src/verifiableCredentialsSDK/verification/verify.test.ts
+++ b/packages/client/verifiable-credentials/src/verifiableCredentialsSDK/verification/verify.test.ts
@@ -11,7 +11,7 @@ describe("verifyCredential", () => {
         jest.resetAllMocks();
     });
 
-    it("should verify a valid credential", async () => {
+    it("verifies a valid credential", async () => {
         const mockCredential: VerifiableCredential = {
             validUntil: new Date(Date.now() + 86400000).toISOString(),
             nft: {} as any,
@@ -22,7 +22,7 @@ describe("verifyCredential", () => {
         expect(result).toEqual({ validVC: true, error: undefined });
     });
 
-    it("should verify a valid credential without expiration date", async () => {
+    it("verifies a valid credential without expiration date", async () => {
         const mockCredential: VerifiableCredential = {
             nft: {} as any,
         } as any;
@@ -32,7 +32,7 @@ describe("verifyCredential", () => {
         expect(result).toEqual({ validVC: true, error: undefined });
     });
 
-    it("should fail if revoked credential", async () => {
+    it("fails if revoked credential", async () => {
         const mockCredential: VerifiableCredential = {
             validUntil: new Date(Date.now() + 86400000).toISOString(),
             nft: {} as any,
@@ -43,7 +43,7 @@ describe("verifyCredential", () => {
         expect(result).toEqual({ validVC: false, error: "Credential has been revoked" });
     });
 
-    it("should fail if invalid proof credential", async () => {
+    it("fails if invalid proof credential", async () => {
         const mockCredential: VerifiableCredential = {
             validUntil: new Date(Date.now() + 86400000).toISOString(),
             nft: {} as any,
@@ -54,7 +54,7 @@ describe("verifyCredential", () => {
         expect(result).toEqual({ validVC: false, error: "Invalid proof" });
     });
 
-    it("should fail if expirationDate is not a valid ISO string", async () => {
+    it("fails if expirationDate is not a valid ISO string", async () => {
         const mockCredential: VerifiableCredential = {
             validUntil: "not a valid ISO string",
             nft: {} as any,
@@ -63,7 +63,7 @@ describe("verifyCredential", () => {
             "Invalid expiration date: not a valid ISO string"
         );
     });
-    it("should fail if expirationDate is not a string", async () => {
+    it("fails if expirationDate is not a string", async () => {
         const mockCredential: VerifiableCredential = {
             validUntil: 1,
             nft: {} as any,
@@ -71,7 +71,7 @@ describe("verifyCredential", () => {
         await expect(verifyCredential(mockCredential)).rejects.toThrow("expirationDate must be a ISO string");
     });
 
-    it("should fail if expirationDate is in the past", async () => {
+    it("fails if expirationDate is in the past", async () => {
         const mockCredential: VerifiableCredential = {
             validUntil: new Date(Date.now() - 86400000).toISOString(), // 1 day in the past
             nft: {} as any,


### PR DESCRIPTION
## Summary

- Fix 46 BDD naming violations across 14 test files by removing `should` prefix from all `it()` descriptions and converting to active present-tense verbs
- Verbs converted: `throws`, `returns`, `fetches`, `fails`, `verifies`, `filters`, `decrypts`, `connects`, `parses`, `groups`, `correctly formats`
- `provider.test.ts` was already fully compliant — no changes needed
- No structural changes — only test description strings updated

## Test plan

- [ ] Verify existing Vitest runs pass in `packages/client/verifiable-credentials`
- [ ] Confirm no remaining `it("should` patterns across all 14 files