### PR TITLE
fix(ci): remove fragile file arg from nightly e2e regression run

### DIFF
--- a/.github/workflows/e2e-regression-tests.yml
+++ b/.github/workflows/e2e-regression-tests.yml
@@ -53,8 +53,8 @@ jobs:
 
               run: |
                   mkdir -p test-results
-                  # Run e2e.spec.ts (regression tests) only; exclude smoke project
-                  pnpm exec playwright test e2e/e2e.spec.ts --project=chromium --project=firefox --project=webkit || true
+                  # Run regression tests only; testMatch in playwright.config.ts already excludes smoke and sdk projects
+                  pnpm exec playwright test --project=chromium --project=firefox --project=webkit || true
 
             - name: Generate test report
               if: always()

--- a/.github/workflows/e2e-regression-tests.yml
+++ b/.github/workflows/e2e-regression-tests.yml
@@ -55,6 +55,11 @@ jobs:
                   mkdir -p test-results
                   # Run regression tests only; testMatch in playwright.config.ts already excludes smoke and sdk projects
                   pnpm exec playwright test --project=chromium --project=firefox --project=webkit || true
+                  # Fail explicitly when no tests were discovered (|| true above would otherwise silently pass)
+                  if [ ! -f test-results/playwright-results.json ]; then
+                      echo "::error::No test results file generated — no tests were discovered. Check testMatch patterns in playwright.config.ts."
+                      exit 1
+                  fi
 
             - name: Generate test report
               if: always()


### PR DESCRIPTION
## Summary

- Today's nightly run (2026-05-14) completed in **4m46s with zero tests**, vs the normal 28-37 minutes with 60 tests. All 5 prior daily runs succeeded.
- Root cause: the workflow passes `e2e/e2e.spec.ts` as a CLI argument to Playwright. Playwright treats this as a **regex** matched against paths relative to `testDir` (`./e2e`). The relative path of the file is `e2e.spec.ts` — no directory prefix — so the regex `e2e/e2e.spec.ts` does **not** match it, yielding "No tests found".
- The `|| true` swallows the error, the workflow exits "success", and the Slack report shows 0 tests.

## Fix

Remove the explicit file argument. The `testMatch` in `playwright.config.ts` for the `chromium`/`firefox`/`webkit` projects already correctly selects `e2e.spec.ts` while excluding `smoke-tests/` and `sdk/`:

```js
testMatch: /^(?!.*smoke)(?!.*\/sdk\/).*\.spec\.ts$/
```

This is the same approach used by `smoke-tests.yml` (`pnpm exec playwright test --project=smoke` — no file arg needed).

## Test plan

- [ ] Verify next nightly run (or trigger manually via `workflow_dispatch`) finds the expected 60 tests and runs them across chromium/firefox/webkit