### PR TITLE
wallets-sdk: fix issue when device signer is pending on wallet init

### DIFF
--- a/packages/wallets/src/wallets/wallet.test.ts
+++ b/packages/wallets/src/wallets/wallet.test.ts
@@ -2996,8 +2996,7 @@ describe("Wallet - waitForInit()", () => {
         // and resumes the pending operation via checkAndResumeDeviceSigner rather
         // than generating a brand-new device key.
         expect(wallet.signer?.type).toBe("device");
-        expect(wallet.signer?.status).not.toBe("success");
-        expect(wallet.signer?.status).not.toBe("active");
+        expect(wallet.signer?.status).toBe("awaiting-approval");
     });
 });
 describe("Wallet - isSignerApproved()", () => {

--- a/packages/wallets/src/wallets/wallet.test.ts
+++ b/packages/wallets/src/wallets/wallet.test.ts
@@ -2953,6 +2953,52 @@ describe("Wallet - waitForInit()", () => {
         await wallet.waitForInit();
         expect(wallet.needsRecovery()).toBe(false);
     });
+
+    it("flags needsRecovery=true after waitForInit when local device key exists but backend signer is still pending (interrupted recover)", async () => {
+        // Scenario: previous recover() ran createDeviceSigner (wrote local key) and
+        // started addSigner, but the app was killed mid-approval. On restart the
+        // local key resolves a locator pointing at a still-pending backend signer.
+        // Without the fix, resolveDeviceSignerAvailability would leave
+        // needsRecovery=false even though the signer is unusable.
+        const mockStorage = {
+            generateKey: vi.fn().mockResolvedValue("mockPublicKeyBase64"),
+            getKey: vi.fn().mockResolvedValue("pendingKeyBase64"),
+            hasKey: vi.fn().mockResolvedValue(true),
+            mapAddressToKey: vi.fn().mockResolvedValue(undefined),
+            deleteKey: vi.fn().mockResolvedValue(undefined),
+            signMessage: vi.fn().mockResolvedValue({ r: "0x1", s: "0x2" }),
+            getDeviceName: vi.fn().mockReturnValue("Test Device"),
+        };
+
+        // Backend reports the device signer as still awaiting approval
+        mockApiClient.getSigner.mockResolvedValue({
+            type: "device",
+            locator: "device:pendingKeyBase64",
+            publicKey: { x: "1", y: "2" },
+            chains: { "base-sepolia": { status: "awaiting-approval", id: "sig-pending-1" } },
+        } as any);
+
+        const wallet = new Wallet(
+            {
+                chain: "base-sepolia",
+                address: "0x1234567890123456789012345678901234567890",
+                recovery: { type: "api-key" } as any,
+                options: { deviceSignerKeyStorage: mockStorage as any },
+            },
+            mockApiClient as unknown as ApiClient
+        );
+
+        await wallet.waitForInit();
+
+        // needsRecovery must reflect that approval is still pending
+        expect(wallet.needsRecovery()).toBe(true);
+        // The signer is still assembled so recover() takes the device fast-path
+        // and resumes the pending operation via checkAndResumeDeviceSigner rather
+        // than generating a brand-new device key.
+        expect(wallet.signer?.type).toBe("device");
+        expect(wallet.signer?.status).not.toBe("success");
+        expect(wallet.signer?.status).not.toBe("active");
+    });
 });
 describe("Wallet - isSignerApproved()", () => {
     it("returns true only when signer status is success", async () => {

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -158,6 +158,20 @@ export class Wallet<C extends Chain> {
         // Assemble the device signer with the resolved config
         const internalConfig = this.buildInternalSignerConfig(deviceConfig as SignerConfigForChain<C>);
         this.#signer = await this.assembleFullSigner(internalConfig, deviceSignerKeyStorage);
+
+        // If the backend signer isn't approved yet (e.g. a previous recover() was
+        // interrupted mid-approval), flag for recovery so the next recover() call
+        // resumes the pending operation via checkAndResumeDeviceSigner. The signer
+        // is kept assigned so recover() takes the device fast-path and resumes
+        // rather than creating a new device signer.
+        if (!this.isApprovedSignerStatus(this.#signer.status)) {
+            walletsLogger.info("wallet.initDeviceSigner.pendingApproval", {
+                signerLocator: this.#signer.locator(),
+                status: this.#signer.status,
+            });
+            this.#needsRecovery = true;
+            this.#deviceSignerApproved = false;
+        }
     }
 
     /**


### PR DESCRIPTION
## Description

## Problem

If `recover()` registers a new device signer via `addSigner()` and the app is killed while waiting for the user to approve it (OTP / signature), the wallet is left mid-flight: the local device key is saved, and the backend signer exists but is still pending ("awaiting-approval").

On the next app start, `resolveDeviceSignerAvailability()` finds the local key and resolves a locator for that pending signer, but never checks its backend status. So `#needsRecovery` stays false, `needsRecovery()` lies, and any signing attempt fails because the signer isn't actually approved. Callers that gate `recover()` on `needsRecovery()` skip it and the pending approval is never resumed.

## Fix

In `initDeviceSigner()`, after `assembleFullSigner()` resolves, inspect the signer's status (already fetched as part of assembly, so no extra network call). If it isn't approved, set `#needsRecovery` to true. The signer stays assigned so the next `recover()` call takes the existing device fast-path and resumes the pending operation via `checkAndResumeDeviceSigner()` instead of generating a new key and orphaning the pending one.


## Test plan
- Added unit test for specific scenario

## Package updates

<!-- 
  List any package updates and ensure you've added the necessary changesets, running `pnpm change:add` to do so.
-->
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/crossmint-sdk/pull/1849" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->