### PR TITLE
feat(client-sdk-base): expose rules in PaymentMethodManagementAppearance

### DIFF
--- a/.changeset/pmm-appearance-expose-rules.md
+++ b/.changeset/pmm-appearance-expose-rules.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-base": minor
+---
+
+Expose `rules` in `PaymentMethodManagementAppearance` so consumers can override `PrimaryButton`, `Input`, and other element-level styles. The iframe runtime already accepts and merges `rules` correctly; this change removes the public type narrowing that was preventing TypeScript consumers from reaching the lever.

--- a/packages/client/base/src/types/payment-method-management/CrossmintPaymentMethodManagementProps.ts
+++ b/packages/client/base/src/types/payment-method-management/CrossmintPaymentMethodManagementProps.ts
@@ -32,4 +32,5 @@ export type CrossmintPaymentMethod = {
 export type PaymentMethodManagementAppearance = {
     fonts?: EmbeddedCheckoutV3Appearance["fonts"];
     variables?: EmbeddedCheckoutV3Appearance["variables"];
+    rules?: EmbeddedCheckoutV3Appearance["rules"];
 };


### PR DESCRIPTION
## Description

The public type `PaymentMethodManagementAppearance` currently exposes only `fonts` and `variables`, but the iframe runtime already accepts and merges `rules` correctly. This narrowing forces TypeScript consumers to bypass the type system (e.g. `appearance={{...} as any}`) to override element-level styles like the primary button background.

Most concretely: `getPrimaryButtonAppearance()` in the iframe resolves the button background as `rules?.PrimaryButton?.colors?.background || variables.colors.accent`, and the default light theme always populates the first slot. Without `rules` in the public type, PMM consumers can't reach the only override that actually changes the button color.

This PR adds `rules?: EmbeddedCheckoutV3Appearance["rules"]` to the type. No runtime change — the iframe service already handles it.

```ts
export type PaymentMethodManagementAppearance = {
    fonts?: EmbeddedCheckoutV3Appearance["fonts"];
    variables?: EmbeddedCheckoutV3Appearance["variables"];
    rules?: EmbeddedCheckoutV3Appearance["rules"];  // added
};
```

Consumers can now write:

```tsx
<CrossmintPaymentMethodManagement
  appearance={{
    variables: { colors: { accent: "#7B5CFA" } },
    rules: { PrimaryButton: { colors: { background: "#000" } } },
  }}
/>
```

## Test plan

* Built `@crossmint/client-sdk-base` locally — type compiles, `PaymentMethodManagementAppearance` in the emitted `.d.cts` includes `rules`.
* Verified at runtime: passing `rules.PrimaryButton.colors.background` to `<CrossmintPaymentMethodManagement>` changes the button background as expected. The iframe URL serialization and `EmbeddedCheckoutV3AppearanceService` merge already handle `rules` — this PR only removes the public type narrowing.

## Package updates

* `@crossmint/client-sdk-base`: `minor` — relaxes the public type, no breaking change. Changeset included.