### PR TITLE
fix(react-native): retry handshake on timeout with WebView reload

### DIFF
--- a/.changeset/handshake-retry-on-timeout.md
+++ b/.changeset/handshake-retry-on-timeout.md
@@ -1,0 +1,5 @@
+---
+'@crossmint/client-sdk-react-native-ui': patch
+---
+
+fix: retry handshake on timeout with WebView reload instead of silently failing

--- a/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
@@ -48,6 +48,8 @@ export interface CrossmintWalletProviderProps {
     children: ReactNode;
 }
 
+const MAX_HANDSHAKE_RETRIES = 2;
+
 const PASSKEY_RN_ERROR =
     "Passkey signers are not supported in React Native. Use a different signer type such as 'device', or 'external-wallet'.";
 
@@ -137,6 +139,7 @@ function CrossmintWalletProviderInternal({
     const handshakeInProgressRef = useRef<boolean>(false);
     const handshakeGenerationRef = useRef<number>(0);
     const handshakeStartTimeRef = useRef<number>(0);
+    const handshakeRetryCountRef = useRef<number>(0);
 
     const secureGlobals = useMemo(() => {
         if (appId != null) {
@@ -180,6 +183,7 @@ function CrossmintWalletProviderInternal({
                     parent.isConnected = false;
                     await parent.handshakeWithChild();
                     const durationMs = Date.now() - handshakeStartTime;
+                    handshakeRetryCountRef.current = 0;
                     logger.info("react-native.wallet.webview.handshake.success", {
                         trigger,
                         generation,
@@ -187,6 +191,38 @@ function CrossmintWalletProviderInternal({
                     });
                 } catch (e) {
                     const durationMs = Date.now() - handshakeStartTime;
+                    const errorMessage = e instanceof Error ? e.message : String(e);
+                    const isTimeout =
+                        typeof e === "string"
+                            ? e.startsWith("Timed out") || e.startsWith("Max retries")
+                            : errorMessage.startsWith("Timed out") || errorMessage.startsWith("Max retries");
+
+                    if (isTimeout && handshakeRetryCountRef.current < MAX_HANDSHAKE_RETRIES) {
+                        handshakeRetryCountRef.current++;
+                        const retryAttempt = handshakeRetryCountRef.current;
+
+                        logger.info("react-native.wallet.webview.handshake.retry", {
+                            trigger,
+                            generation,
+                            durationMs,
+                            retryAttempt,
+                            maxRetries: MAX_HANDSHAKE_RETRIES,
+                            error: errorMessage,
+                        });
+
+                        // Increment generation so stale attempts don't interfere
+                        handshakeGenerationRef.current++;
+                        handshakeTriggeredRef.current = false;
+                        handshakeInProgressRef.current = false;
+                        if (webViewParentRef.current != null) {
+                            webViewParentRef.current.isConnected = false;
+                        }
+                        webviewRef.current?.reload();
+                        performHandshake("eager");
+                        return;
+                    }
+
+                    handshakeRetryCountRef.current = 0;
                     if (generation === handshakeGenerationRef.current) {
                         handshakeTriggeredRef.current = false;
                     }
@@ -194,7 +230,8 @@ function CrossmintWalletProviderInternal({
                         trigger,
                         generation,
                         durationMs,
-                        error: e instanceof Error ? e.message : String(e),
+                        error: errorMessage,
+                        retriesExhausted: isTimeout,
                     });
                     console.error("[CrossmintWalletProvider] Handshake error:", e);
                 } finally {

--- a/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
@@ -192,10 +192,7 @@ function CrossmintWalletProviderInternal({
                 } catch (e) {
                     const durationMs = Date.now() - handshakeStartTime;
                     const errorMessage = e instanceof Error ? e.message : String(e);
-                    const isTimeout =
-                        typeof e === "string"
-                            ? e.startsWith("Timed out") || e.startsWith("Max retries")
-                            : errorMessage.startsWith("Timed out") || errorMessage.startsWith("Max retries");
+                    const isTimeout = errorMessage.startsWith("Timed out") || errorMessage.startsWith("Max retries");
 
                     if (isTimeout && handshakeRetryCountRef.current < MAX_HANDSHAKE_RETRIES) {
                         handshakeRetryCountRef.current++;
@@ -454,6 +451,7 @@ function CrossmintWalletProviderInternal({
                             });
                             handshakeTriggeredRef.current = false;
                             handshakeInProgressRef.current = false;
+                            handshakeRetryCountRef.current = 0;
                             if (webViewParentRef.current != null) {
                                 webViewParentRef.current.isConnected = false;
                             }
@@ -472,6 +470,7 @@ function CrossmintWalletProviderInternal({
                             });
                             handshakeTriggeredRef.current = false;
                             handshakeInProgressRef.current = false;
+                            handshakeRetryCountRef.current = 0;
                             if (webViewParentRef.current != null) {
                                 webViewParentRef.current.isConnected = false;
                             }


### PR DESCRIPTION
## Description

When the initial eager handshake times out (30s), the error was previously caught and logged but nothing else happened — the WebView would remain in a broken state until the app was restarted.

This change adds automatic retry logic to `performHandshake` in `CrossmintWalletProvider.tsx`. When a timeout is detected in the catch block:

1. The WebView is reloaded via `webviewRef.current?.reload()`
2. A new handshake attempt is triggered via `performHandshake("eager")`
3. Retries are capped at 2 (3 total attempts) to avoid infinite loops / battery drain
4. Provider state (`handshakeGenerationRef`, `handshakeTriggeredRef`, `handshakeInProgressRef`, `isConnected`) is properly reset before each retry so stale attempts do not interfere
5. Each retry is logged with telemetry (`react-native.wallet.webview.handshake.retry`) including attempt number and error details
6. If all retries are exhausted, the final error log includes `retriesExhausted: true` for tracking

The retry pattern mirrors the existing recovery logic in `onContentProcessDidTerminate` and `onRenderProcessGone` (reload + fire-and-forget `performHandshake("eager")`), and is consistent with `WebViewParent.sendAction`'s timeout recovery in `Parent.ts`.

## Test plan

- Verified lint passes (`pnpm lint`)
- The retry logic mirrors the battle-tested `onContentProcessDidTerminate` pattern already in this component — reload WebView, reset state, re-trigger eager handshake
- Timeout detection matches the error format used by `WebViewParent.isTimeoutError` (strings starting with "Timed out" or "Max retries")
- Generation increment before retry ensures the `finally` block of the timed-out attempt does not reset `handshakeInProgressRef`, preventing state corruption
- Non-timeout errors and retries-exhausted cases fall through to original error handling unchanged

## Package updates

- `@crossmint/client-sdk-react-native-ui` — changeset to be added

Link to Devin session: https://crossmint.devinenterprise.com/sessions/6ea761d6771243d6a753594f0af551c0
Requested by: @guilleasz-crossmint
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/crossmint-sdk/pull/1862" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->