### PR TITLE
fix(react-ui): fix OAuth prefetch race when dialog opens before auth init

### DIFF
--- a/.changeset/fix-oauth-prefetch-race.md
+++ b/.changeset/fix-oauth-prefetch-race.md
@@ -1,0 +1,10 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+---
+
+Fix OAuth URL prefetch race condition when auth dialog opens before initialization completes.
+
+- Gate prefetch on `jwt == null` instead of `getAuthStatus() === "logged-out"` so the prefetch still runs when the dialog is open during initialization.
+- Skip prefetch when `crossmintAuth` is not yet available to avoid fetching with a null client.
+- Initialize `isLoadingOauthUrlMap` to `false` so consumers are not stuck in a loading state when the prefetch has not started.
+- Strengthen URL validation to reject empty strings in addition to null/undefined.

--- a/packages/client/ui/react-ui/src/hooks/useOAuthWindowListener.ts
+++ b/packages/client/ui/react-ui/src/hooks/useOAuthWindowListener.ts
@@ -48,7 +48,7 @@ export const useOAuthWindowListener = (oauthUrlMap: OAuthUrlMap, setError: (erro
 
                 const prefetchedUrl = oauthUrlMap[provider];
                 const resolvedUrl = prefetchedUrl || (await crossmintAuth?.getOAuthUrl(provider));
-                if (resolvedUrl == null) {
+                if (!resolvedUrl) {
                     throw new Error("Failed to resolve OAuth URL");
                 }
                 baseUrl = new URL(resolvedUrl);

--- a/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.tsx
@@ -128,7 +128,7 @@ function CrossmintAuthProviderContent({
                     defaultEmail,
                 }}
             >
-                <OAuthFlowProvider prefetchOAuthUrls={getAuthStatus() === "logged-out" && prefetchOAuthUrls}>
+                <OAuthFlowProvider prefetchOAuthUrls={baseAuth.jwt == null && prefetchOAuthUrls}>
                     <AuthWrapper loginWithOAuthRef={loginWithOAuthRef}>
                         {children}
                         <AuthFormDialog open={dialogOpen} />

--- a/packages/client/ui/react-ui/src/providers/auth/OAuthFlowProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/auth/OAuthFlowProvider.tsx
@@ -38,7 +38,7 @@ export function OAuthFlowProvider({
     const { setError } = useAuthForm();
 
     const [oauthUrlMap, setOauthUrlMap] = useState<OAuthUrlMap>(initialOAuthUrlMap);
-    const [isLoadingOauthUrlMap, setIsLoadingOauthUrlMap] = useState(true);
+    const [isLoadingOauthUrlMap, setIsLoadingOauthUrlMap] = useState(false);
 
     const {
         createPopupAndSetupListeners,
@@ -47,6 +47,9 @@ export function OAuthFlowProvider({
     } = useOAuthWindowListener(oauthUrlMap, setError);
 
     const preFetchAndSetOauthUrl = useCallback(async () => {
+        if (crossmintAuth == null) {
+            return;
+        }
         setIsLoadingOauthUrlMap(true);
         try {
             const oauthProviders = (loginMethods || []).filter(


### PR DESCRIPTION
## Description

Fixes a race condition where OAuth URL prefetch never runs if the user opens the auth dialog before auth initialization completes.

**Root cause:** The prefetch was gated by `getAuthStatus() === "logged-out"`, but when the dialog opens during initialization, the status transitions from `"initializing"` → `"in-progress"` (skipping `"logged-out"` entirely). This left `oauthUrlMap` empty (`{google: '', twitter: ''}`), and the on-demand fallback to `crossmintAuth?.getOAuthUrl()` could fail if `crossmintAuth` was not yet available in the closure.

**Changes:**
- **`CrossmintAuthProvider.tsx`**: Gate prefetch on `baseAuth.jwt == null` instead of `getAuthStatus() === "logged-out"` — this ensures the prefetch runs whenever the user is not logged in, regardless of dialog or init state.
- **`OAuthFlowProvider.tsx`**: Guard prefetch with `crossmintAuth == null` early return to avoid running it before the auth client is initialized. Initialize `isLoadingOauthUrlMap` to `false` since no prefetch has started yet.
- **`useOAuthWindowListener.ts`**: Strengthen URL validation from `resolvedUrl == null` to `!resolvedUrl` to also catch empty strings, preventing `new URL("")` from throwing.

## Test plan

- Verified lint passes (`pnpm lint`)
- The fix addresses the specific scenario where a user opens the login dialog quickly after page load (before auth init completes), then clicks an OAuth button — the prefetch now runs correctly once `crossmintAuth` becomes available
- The fallback `getOAuthUrl` call in `useOAuthWindowListener` is still present as a safety net if the prefetch hasn't completed by the time the user clicks

## Package updates

- `@crossmint/client-sdk-react-ui`: patch (changeset added via `.changeset/fix-oauth-prefetch-race.md`)

Link to Devin session: https://crossmint.devinenterprise.com/sessions/c4d91faa048d4a0b8a834127afcff9b4
Requested by: @jmderby