### PR TITLE
feat(ci): add mobile E2E dispatch trigger for React Native (ENG-2344)

### DIFF
--- a/.github/workflows/e2e-mobile-trigger.yml
+++ b/.github/workflows/e2e-mobile-trigger.yml
@@ -10,6 +10,7 @@ on:
             - "apps/wallets/expo/**"
             - "apps/wallets/shared/**"
             - "packages/wallets/**"
+            - "packages/client/react-base/**"
             - "packages/client/ui/react-native/**"
             - "packages/client/rn-window/**"
 

--- a/.github/workflows/e2e-mobile-trigger.yml
+++ b/.github/workflows/e2e-mobile-trigger.yml
@@ -5,11 +5,15 @@ name: Trigger Mobile E2E Tests
 
 on:
     pull_request:
-        types: [opened, synchronize, reopened]
+        types: [opened, synchronize, reopened, ready_for_review]
         paths:
             - "apps/wallets/expo/**"
             - "packages/wallets/**"
             - "packages/client/**"
+
+concurrency:
+    group: mobile-e2e-${{ github.event.pull_request.number }}
+    cancel-in-progress: true
 
 permissions:
     contents: read
@@ -18,6 +22,7 @@ jobs:
     dispatch:
         name: Dispatch to mobile E2E test repo
         runs-on: ubuntu-latest
+        if: github.event.pull_request.draft == false
         steps:
             - name: Dispatch e2e tests
               uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4

--- a/.github/workflows/e2e-mobile-trigger.yml
+++ b/.github/workflows/e2e-mobile-trigger.yml
@@ -8,8 +8,10 @@ on:
         types: [opened, synchronize, reopened, ready_for_review]
         paths:
             - "apps/wallets/expo/**"
+            - "apps/wallets/shared/**"
             - "packages/wallets/**"
-            - "packages/client/**"
+            - "packages/client/ui/react-native/**"
+            - "packages/client/rn-window/**"
 
 concurrency:
     group: mobile-e2e-${{ github.event.pull_request.number }}

--- a/.github/workflows/e2e-mobile-trigger.yml
+++ b/.github/workflows/e2e-mobile-trigger.yml
@@ -1,0 +1,35 @@
+name: Trigger Mobile E2E Tests
+# On every PR push that touches the Expo app or its package dependencies,
+# dispatches to crossmint-mobile-e2e-tests which builds the app, runs Maestro flows,
+# and posts a commit status check back to this PR.
+
+on:
+    pull_request:
+        types: [opened, synchronize, reopened]
+        paths:
+            - "apps/wallets/expo/**"
+            - "packages/wallets/**"
+            - "packages/client/**"
+
+permissions:
+    contents: read
+
+jobs:
+    dispatch:
+        name: Dispatch to mobile E2E test repo
+        runs-on: ubuntu-latest
+        steps:
+            - name: Dispatch e2e tests
+              uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
+              with:
+                  token: ${{ secrets.CROSSMINT_E2E_BOT_TOKEN }}
+                  repository: Crossmint/crossmint-mobile-e2e-tests
+                  event-type: e2e-mobile-tests
+                  client-payload: |
+                      {
+                        "sdk": "react-native",
+                        "sdk_repo": "Crossmint/crossmint-sdk",
+                        "sdk_ref": "${{ github.event.pull_request.head.sha }}",
+                        "commit_sha": "${{ github.event.pull_request.head.sha }}",
+                        "pr_number": "${{ github.event.pull_request.number }}"
+                      }


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/e2e-mobile-trigger.yml` which fires on every PR push touching `apps/wallets/expo/**`, `packages/wallets/**`, or `packages/client/**`
- Dispatches to `crossmint-mobile-e2e-tests` via `repository_dispatch` — the test repo builds the app, runs Maestro flows, and posts a `mobile-e2e / react-native` commit status check back to this PR

**Depends on**: `Crossmint/crossmint-mobile-e2e-tests` PR #1 being merged first (the test repo workflows must exist before this dispatch has something to call).

## Test plan

- [ ] Merge `crossmint-mobile-e2e-tests` PR #1 first
- [ ] Merge this PR and open a test PR that touches `apps/wallets/expo/` — confirm the `mobile-e2e / react-native` status check appears on the PR

<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/crossmint-sdk/pull/1865" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->