### PR TITLE
fix: use page-specific version banners and preserve reference.mdx title

### DIFF
--- a/packages/wallets/typedoc-custom-plugin.mjs
+++ b/packages/wallets/typedoc-custom-plugin.mjs
@@ -7,16 +7,29 @@ const pkg = JSON.parse(readFileSync(join(dirname(fileURLToPath(import.meta.url))
 const CURRENT_MAJOR_VERSION = Number.parseInt(pkg.version.split(".")[0], 10);
 const PREVIOUS_MAJOR_VERSION = CURRENT_MAJOR_VERSION - 1;
 
-const VERSION_BANNER = `<Note>
+// globals.mdx → reference.mdx rename happens in the workflow
+const URL_RENAMES = { "globals.mdx": "reference" };
+
+function versionBanner(pageUrl) {
+    if (pageUrl === "README.mdx") {
+        return `<Note>
 **This page has been updated for Wallets SDK V${CURRENT_MAJOR_VERSION}.** If you are using the previous version,
-see the [previous version docs](/sdk-reference/wallets/v${PREVIOUS_MAJOR_VERSION}/typescript/overview) or the [V${CURRENT_MAJOR_VERSION} migration guide](/wallets/guides/migrate-to-v${CURRENT_MAJOR_VERSION}).
+see the [previous version docs](/wallets/v${PREVIOUS_MAJOR_VERSION}/overview) or the [V${CURRENT_MAJOR_VERSION} migration guide](/wallets/guides/migrate-to-v${CURRENT_MAJOR_VERSION}).
 </Note>`;
+    }
+    const pagePath = URL_RENAMES[pageUrl] ?? pageUrl.replace(/\.mdx$/, "");
+    return `<Note>
+**This page has been updated for Wallets SDK V${CURRENT_MAJOR_VERSION}.** If you are using the previous version,
+see the [previous version of this page](/sdk-reference/wallets/v${PREVIOUS_MAJOR_VERSION}/typescript/${pagePath}) or the [V${CURRENT_MAJOR_VERSION} migration guide](/wallets/guides/migrate-to-v${CURRENT_MAJOR_VERSION}).
+</Note>`;
+}
 
 // README.mdx is renamed to overview.mdx in the workflow; its typedoc-derived
 // title is the package name, which collides with reference.mdx in nav. Give
 // the overview page a distinct, human-friendly title here.
 const TITLE_OVERRIDES = {
     "README.mdx": "Getting Started",
+    "globals.mdx": "Reference",
 };
 
 const NPM_BADGE = `### Latest Node.js SDK version - <a href="https://www.npmjs.com/package/${pkg.name}" target="_blank" rel="noopener" style={{display: "inline-block", verticalAlign: "middle", textDecoration: "none", borderBottom: "none"}}><img src="https://img.shields.io/npm/v/${pkg.name}" alt="npm" style={{display: "inline-block", verticalAlign: "middle", margin: 0}} noZoom /></a>`;
@@ -91,13 +104,14 @@ export function load(app) {
             }
         }
 
+        const banner = versionBanner(page.url);
         const frontmatterMatch = page.contents.match(/^---\n[\s\S]*?\n---\n/);
         if (frontmatterMatch) {
             const idx = frontmatterMatch[0].length;
             const body = page.contents.slice(idx).replace(/^\n+/, "");
-            page.contents = `${frontmatterMatch[0]}\n${VERSION_BANNER}\n\n${body}`;
+            page.contents = `${frontmatterMatch[0]}\n${banner}\n\n${body}`;
         } else {
-            page.contents = `${VERSION_BANNER}\n\n${page.contents.replace(/^\n+/, "")}`;
+            page.contents = `${banner}\n\n${page.contents.replace(/^\n+/, "")}`;
         }
     });
 }


### PR DESCRIPTION
## Description

Follow-up to #1866. Fixes two remaining issues in `typedoc-custom-plugin.mjs`:

1. **Page-specific version banners**: The plugin now generates two types of `<Note>` banners:
   - **Overview page (README.mdx)**: "previous version docs" → `/wallets/v0/overview` (general link to the v0 wallets section)
   - **All API reference pages**: "previous version of this page" → `/sdk-reference/wallets/v0/typescript/{pagePath}` (direct link to the v0 equivalent of each page)

2. **reference.mdx title preserved**: Added `"globals.mdx": "Reference"` to `TITLE_OVERRIDES` so the reference page keeps its title as `"Reference"` instead of being overwritten to `"@crossmint/wallets-sdk"`.

Also handles the `globals.mdx` → `reference` URL rename in the banner link path via `URL_RENAMES`.

## Test plan

Ran `pnpm generate:docs` locally and verified:
- **README.mdx**: title = `"Getting Started"`, banner links to `/wallets/v0/overview`
- **globals.mdx**: title = `"Reference"`, banner links to `/sdk-reference/wallets/v0/typescript/reference`
- **classes/SolanaWallet.mdx**: banner links to `/sdk-reference/wallets/v0/typescript/classes/SolanaWallet`
- **type-aliases/AddSignerOptions.mdx**: banner links to `/sdk-reference/wallets/v0/typescript/type-aliases/AddSignerOptions`
- `pnpm lint` passes

## Package updates

No package updates — only modifies the typedoc plugin script (not published as part of the SDK package).

Link to Devin session: https://crossmint.devinenterprise.com/sessions/45f96af09e3d4c8385f81676856f221f
Requested by: @jmderby