### PR TITLE
fix: simplify version banner to single page-specific format

### DIFF
--- a/packages/wallets/typedoc-custom-plugin.mjs
+++ b/packages/wallets/typedoc-custom-plugin.mjs
@@ -7,17 +7,10 @@ const pkg = JSON.parse(readFileSync(join(dirname(fileURLToPath(import.meta.url))
 const CURRENT_MAJOR_VERSION = Number.parseInt(pkg.version.split(".")[0], 10);
 const PREVIOUS_MAJOR_VERSION = CURRENT_MAJOR_VERSION - 1;
 
-// globals.mdx → reference.mdx rename happens in the workflow
-const URL_RENAMES = { "globals.mdx": "reference" };
+const PAGE_RENAMES = { "globals.mdx": "reference", "README.mdx": "overview" };
 
 function versionBanner(pageUrl) {
-    if (pageUrl === "README.mdx") {
-        return `<Note>
-**This page has been updated for Wallets SDK V${CURRENT_MAJOR_VERSION}.** If you are using the previous version,
-see the [previous version docs](/wallets/v${PREVIOUS_MAJOR_VERSION}/overview) or the [V${CURRENT_MAJOR_VERSION} migration guide](/wallets/guides/migrate-to-v${CURRENT_MAJOR_VERSION}).
-</Note>`;
-    }
-    const pagePath = URL_RENAMES[pageUrl] ?? pageUrl.replace(/\.mdx$/, "");
+    const pagePath = PAGE_RENAMES[pageUrl] ?? pageUrl.replace(/\.mdx$/, "");
     return `<Note>
 **This page has been updated for Wallets SDK V${CURRENT_MAJOR_VERSION}.** If you are using the previous version,
 see the [previous version of this page](/sdk-reference/wallets/v${PREVIOUS_MAJOR_VERSION}/typescript/${pagePath}) or the [V${CURRENT_MAJOR_VERSION} migration guide](/wallets/guides/migrate-to-v${CURRENT_MAJOR_VERSION}).


### PR DESCRIPTION
## Description

Simplifies the `versionBanner()` function in `typedoc-custom-plugin.mjs` to use a single banner format for all pages instead of having two variants (general vs page-specific).

Previously the plugin had conditional logic: README got a "previous version docs" banner linking to `/wallets/v0/overview`, while all other pages got a "previous version of this page" banner with a page-specific path. This is no longer needed because the sync workflow in crossbit-main ([PR #26069](https://github.com/Paella-Labs/crossbit-main/pull/26069)) now handles the fallback — it checks if a V0 equivalent exists and swaps page-specific banners to general ones when needed.

Changes:
- Removed the `README.mdx` special case from `versionBanner()`
- Merged `URL_RENAMES` into a single `PAGE_RENAMES` map (`globals.mdx` → `reference`, `README.mdx` → `overview`)
- All pages now get the same "previous version of this page" banner format
- Net reduction of 7 lines

## Test plan

- Verified all pages generate with page-specific banners pointing to correct paths
- `README.mdx` → banner links to `/sdk-reference/wallets/v0/typescript/overview`
- `globals.mdx` → banner links to `/sdk-reference/wallets/v0/typescript/reference`
- `classes/SolanaWallet.mdx` → banner links to `/sdk-reference/wallets/v0/typescript/classes/SolanaWallet`
- `pnpm lint` passes

## Package updates

No package updates — only modifies the typedoc plugin script (not published as part of the SDK package).

Link to Devin session: https://crossmint.devinenterprise.com/sessions/45f96af09e3d4c8385f81676856f221f
Requested by: @jmderby