### PR TITLE
docs: rename sdk-docs-generate workflow to sdk-reference-docs-generate

### DIFF
--- a/.github/workflows/sdk-reference-docs-generate.yml
+++ b/.github/workflows/sdk-reference-docs-generate.yml
@@ -1,4 +1,4 @@
-name: SDK Docs Generate
+name: SDK Reference Docs Generate
 
 on:
     push:
@@ -32,7 +32,7 @@ permissions:
     contents: read
 
 concurrency:
-    group: sdk-docs-generate-${{ github.ref }}
+    group: sdk-reference-docs-generate-${{ github.ref }}
     cancel-in-progress: true
 
 jobs:
@@ -141,5 +141,5 @@ jobs:
               with:
                   token: ${{ steps.generate_app_token.outputs.token }}
                   repository: Paella-Labs/crossbit-main
-                  event-type: sdk-docs-update
+                  event-type: sdk-reference-docs-update
                   client-payload: '{"run_id": "${{ github.run_id }}", "packages": ${{ toJSON(inputs.packages || ''react-ui,react-native,node-wallets'') }}, "source_ref": ${{ toJSON(github.ref_name) }}}'


### PR DESCRIPTION
## Description

Renames the SDK docs generate workflow file and internal references to include "reference" — since this workflow generates **SDK reference docs**, not general SDK docs.

Changes:
- `sdk-docs-generate.yml` → `sdk-reference-docs-generate.yml`
- Workflow name: `SDK Docs Generate` → `SDK Reference Docs Generate`
- Concurrency group: `sdk-docs-generate` → `sdk-reference-docs-generate`
- Event type dispatched: `sdk-docs-update` → `sdk-reference-docs-update`

**Note:** The corresponding crossbit-main PR updates the receiver workflow to listen for the new `sdk-reference-docs-update` event type. Both PRs must be merged together.

## Test plan

- Verified all internal references (event type, concurrency group) are updated consistently
- No functional logic changes — rename only

## Package updates

None — workflow file rename only.


Link to Devin session: https://crossmint.devinenterprise.com/sessions/45f96af09e3d4c8385f81676856f221f
Requested by: @jmderby