### PR TITLE
feat(wallets): add scopes support for all chain delegated signers

### DIFF
--- a/.changeset/evm-scopes-support.md
+++ b/.changeset/evm-scopes-support.md
@@ -2,4 +2,4 @@
 "@crossmint/wallets-sdk": minor
 ---
 
-Add scopes support for EVM delegated signers (transfer spending limits and recipient restrictions)
+Add scopes support for delegated signers (transfer spending limits and recipient restrictions)

--- a/.changeset/evm-scopes-support.md
+++ b/.changeset/evm-scopes-support.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": minor
+---
+
+Add scopes support for EVM delegated signers (transfer spending limits and recipient restrictions)

--- a/packages/wallets/src/api/types.ts
+++ b/packages/wallets/src/api/types.ts
@@ -85,6 +85,7 @@ export type TransferScope = {
     recipients?: string[];
     spendingLimit?: {
         amount: string;
+        /** Positive integer representing the reset interval in seconds. Must be >= 1. */
         interval?: number;
     };
 };

--- a/packages/wallets/src/api/types.ts
+++ b/packages/wallets/src/api/types.ts
@@ -78,9 +78,23 @@ export type FundWalletResponse = BalanceControllerFundWallet4Responses | Balance
 
 export type RegisterSignerChain = Extract<CreateSignerV2025InputDtoClass, { chain: string }>["chain"];
 export type RegisterSignerPasskeyParams = Extract<CreateSignerV2025InputDtoClass["signer"], { type: "passkey" }>;
+
+export type TransferScope = {
+    type: "transfer";
+    tokenLocator: string;
+    recipients?: string[];
+    spendingLimit?: {
+        amount: string;
+        interval?: number;
+    };
+};
+
+export type Scope = TransferScope;
+
 export type RegisterSignerParams = {
     signer: SignerLocator | RegisterSignerPasskeyParams | SignerConfigForChain<Chain>;
     chain?: RegisterSignerChain;
+    scopes?: Scope[];
 };
 export type RegisterSignerResponse = DelegatedSignerV2025DtoClass | WalletsV2025ControllerCreateDelegatedSigner2Error;
 export type RemoveSignerParams = {

--- a/packages/wallets/src/index.ts
+++ b/packages/wallets/src/index.ts
@@ -5,7 +5,7 @@ export { createCrossmint, CrossmintWallets } from "./sdk";
 export { WalletNotAvailableError, InvalidTransferAmountError } from "./utils/errors";
 
 // API
-export { ApiClient as WalletsApiClient, type RegisterSignerPasskeyParams } from "./api";
+export { ApiClient as WalletsApiClient, type RegisterSignerPasskeyParams, type Scope, type TransferScope } from "./api";
 
 // Wallets
 export { Wallet } from "./wallets/wallet";

--- a/packages/wallets/src/openapi.json
+++ b/packages/wallets/src/openapi.json
@@ -7766,6 +7766,61 @@
                                 "type": "string",
                                 "format": "date-time",
                                 "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"
+                            },
+                            "scopes": {
+                                "description": "Optional array of scopes to restrict the signer's capabilities",
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "type": {
+                                            "type": "string",
+                                            "enum": ["transfer"]
+                                        },
+                                        "tokenLocator": {
+                                            "type": "string"
+                                        },
+                                        "recipients": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "spendingLimit": {
+                                            "type": "object",
+                                            "properties": {
+                                                "amount": {
+                                                    "type": "string"
+                                                },
+                                                "interval": {
+                                                    "type": "integer",
+                                                    "minimum": 1,
+                                                    "maximum": 9007199254740991
+                                                }
+                                            },
+                                            "required": ["amount"]
+                                        }
+                                    },
+                                    "required": ["type", "tokenLocator"],
+                                    "title": "Transfer",
+                                    "description": "Scope to transfer tokens with optional spending limits and recipient restrictions",
+                                    "example": {
+                                        "type": "transfer",
+                                        "tokenLocator": "base-sepolia:usdc",
+                                        "recipients": ["0x1234567890123456789012345678901234567890"],
+                                        "spendingLimit": {
+                                            "amount": "100",
+                                            "interval": 86400
+                                        }
+                                    }
+                                },
+                                "example": {
+                                    "type": "transfer",
+                                    "tokenLocator": "base-sepolia:eth",
+                                    "spendingLimit": {
+                                        "amount": "0.01"
+                                    }
+                                }
                             }
                         },
                         "required": ["signer", "chain"],
@@ -11728,6 +11783,63 @@
                                                     "description": "Delegated signer that is awaiting approval for this chain"
                                                 }
                                             ]
+                                        }
+                                    },
+                                    "scopes": {
+                                        "description": "Optional array of scopes restricting the signer's capabilities",
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "type": "string",
+                                                    "enum": ["transfer"]
+                                                },
+                                                "tokenLocator": {
+                                                    "type": "string"
+                                                },
+                                                "recipients": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "spendingLimit": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "amount": {
+                                                            "type": "string"
+                                                        },
+                                                        "interval": {
+                                                            "type": "integer",
+                                                            "minimum": 1,
+                                                            "maximum": 9007199254740991
+                                                        }
+                                                    },
+                                                    "required": ["amount"]
+                                                }
+                                            },
+                                            "required": ["type", "tokenLocator"],
+                                            "title": "Transfer",
+                                            "description": "Scope to transfer tokens with optional spending limits and recipient restrictions",
+                                            "example": {
+                                                "type": "transfer",
+                                                "tokenLocator": "stellar:usdc",
+                                                "recipients": [
+                                                    "GDUCX62IF76FFIYRNI25LJDS2V43QEZDY4YNF2DJWVIASN5LKX76Q4TW"
+                                                ],
+                                                "spendingLimit": {
+                                                    "amount": "100",
+                                                    "interval": 86400
+                                                }
+                                            }
+                                        },
+                                        "example": {
+                                            "type": "transfer",
+                                            "tokenLocator": "solana:sol",
+                                            "spendingLimit": {
+                                                "amount": "1"
+                                            }
                                         }
                                     }
                                 }

--- a/packages/wallets/src/openapi.json
+++ b/packages/wallets/src/openapi.json
@@ -11824,10 +11824,8 @@
                                             "description": "Scope to transfer tokens with optional spending limits and recipient restrictions",
                                             "example": {
                                                 "type": "transfer",
-                                                "tokenLocator": "stellar:usdc",
-                                                "recipients": [
-                                                    "GDUCX62IF76FFIYRNI25LJDS2V43QEZDY4YNF2DJWVIASN5LKX76Q4TW"
-                                                ],
+                                                "tokenLocator": "base-sepolia:usdc",
+                                                "recipients": ["0x1234567890123456789012345678901234567890"],
                                                 "spendingLimit": {
                                                     "amount": "100",
                                                     "interval": 86400
@@ -11836,9 +11834,9 @@
                                         },
                                         "example": {
                                             "type": "transfer",
-                                            "tokenLocator": "solana:sol",
+                                            "tokenLocator": "base-sepolia:eth",
                                             "spendingLimit": {
-                                                "amount": "1"
+                                                "amount": "0.01"
                                             }
                                         }
                                     }

--- a/packages/wallets/src/utils/signer-mapping.ts
+++ b/packages/wallets/src/utils/signer-mapping.ts
@@ -1,4 +1,4 @@
-import type { Signer as APISigner } from "../api";
+import type { Signer as APISigner, Scope } from "../api";
 import type { Signer, SignerStatus } from "../wallets/types";
 import type { Chain } from "../chains/chains";
 
@@ -67,13 +67,15 @@ export function extractSignerBase(apiSigner: APISigner): SignerBase {
 export function mapApiSignerToSigner(apiSigner: APISigner, chain: Chain): Signer | null {
     const base = extractSignerBase(apiSigner);
 
+    const scopes = "scopes" in apiSigner ? (apiSigner.scopes as Scope[] | undefined) : undefined;
+
     if (chain === "solana" || chain === "stellar") {
         // For Solana/Stellar, status comes from the transaction field
         let status: SignerStatus = "success";
         if ("transaction" in apiSigner && apiSigner.transaction != null) {
             status = apiSigner.transaction.status;
         }
-        return { ...base, status } as Signer;
+        return { ...base, status, ...(scopes != null && { scopes }) } as Signer;
     }
 
     // For EVM, status comes from the chains field
@@ -82,11 +84,11 @@ export function mapApiSignerToSigner(apiSigner: APISigner, chain: Chain): Signer
         if (chainEntry == null) {
             return null; // No approval for this chain
         }
-        return { ...base, status: chainEntry.status } as Signer;
+        return { ...base, status: chainEntry.status, ...(scopes != null && { scopes }) } as Signer;
     }
 
     // If chains field is empty, the signer was created during wallet creation.
-    return { ...base, status: "success" } as Signer;
+    return { ...base, status: "success", ...(scopes != null && { scopes }) } as Signer;
 }
 
 export function getPendingSignerOperation(

--- a/packages/wallets/src/wallets/types.ts
+++ b/packages/wallets/src/wallets/types.ts
@@ -3,7 +3,7 @@ import type { HandshakeParent } from "@crossmint/client-sdk-window";
 import type { signerInboundEvents, signerOutboundEvents } from "@crossmint/client-signers";
 import type { TypedData, TypedDataDefinition } from "viem";
 import type { Abi } from "abitype";
-import type { CreateTransactionSuccessResponse } from "../api";
+import type { CreateTransactionSuccessResponse, Scope } from "../api";
 import type { Chain, EVMSmartWalletChain, StellarChain } from "../chains/chains";
 import type {
     SignerConfigForChain,
@@ -18,7 +18,7 @@ import type {
 } from "../signers/types";
 import type { DeviceSignerKeyStorage } from "@/utils/device-signers/DeviceSignerKeyStorage";
 
-export type { Transfers } from "../api/types";
+export type { Transfers, Scope, TransferScope } from "../api/types";
 
 export type PrepareOnly<T extends boolean = boolean> = {
     prepareOnly: T;
@@ -36,7 +36,9 @@ export type SendTokenTransactionOptions = TransactionInputOptions & {
 
 export type SignatureInputOptions = PrepareOnly;
 
-export type AddSignerOptions = PrepareOnly;
+export type AddSignerOptions = PrepareOnly & {
+    scopes?: Scope[];
+};
 
 export type RemoveSignerOptions = PrepareOnly;
 
@@ -139,18 +141,21 @@ export type Signer =
           validatorContractVersion: string;
           locator: string;
           status: SignerStatus;
+          scopes?: Scope[];
       }
     | {
           type: "api-key";
           address: string;
           locator: string;
           status: SignerStatus;
+          scopes?: Scope[];
       }
     | {
           type: "external-wallet";
           address: string;
           locator: string;
           status: SignerStatus;
+          scopes?: Scope[];
       }
     | {
           type: "email";
@@ -158,6 +163,7 @@ export type Signer =
           address: string;
           locator: string;
           status: SignerStatus;
+          scopes?: Scope[];
       }
     | {
           type: "phone";
@@ -165,18 +171,21 @@ export type Signer =
           address: string;
           locator: string;
           status: SignerStatus;
+          scopes?: Scope[];
       }
     | {
           type: "device";
           publicKey: { x: string; y: string };
           locator: string;
           status: SignerStatus;
+          scopes?: Scope[];
       }
     | {
           type: "server";
           address: string;
           locator: string;
           status: SignerStatus;
+          scopes?: Scope[];
       };
 
 // Approvals

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -846,6 +846,7 @@ export class Wallet<C extends Chain> {
             const response = await this.#apiClient.registerSigner(this.walletLocator, {
                 signer: signerInput as RegisterSignerParams["signer"],
                 chain: this.getSignerRegistrationChain(),
+                ...(options?.scopes != null && { scopes: options.scopes }),
             });
 
             if ("error" in response) {


### PR DESCRIPTION
## Description

Adds `scopes` support for all chain delegated signers. EVM now has parity with Solana and Stellar for transfer spending limits and recipient restrictions when registering delegated signers.

Corresponds to backend PR: https://github.com/Paella-Labs/crossbit-main/pull/25647

Changes:
- Updated `openapi.json` to add `scopes` field to EVM `CreateSignerV2025InputDtoClass` and `DelegatedSignerV2025DtoClass`
- Added `Scope` / `TransferScope` types to `api/types.ts`
- Extended `AddSignerOptions` to accept `scopes`
- Updated `wallet.addSigner()` to pass scopes through to the API
- Updated `mapApiSignerToSigner` to propagate scopes from API responses
- Exported `Scope` and `TransferScope` from the package

## Test plan

* All 336 existing unit tests pass (`pnpm --filter @crossmint/wallets-sdk test:vitest`)
* Build succeeds with no type errors (`pnpm --filter @crossmint/wallets-sdk build`)
* Lint passes (`pnpm lint`)

## Package updates

- `@crossmint/wallets-sdk`: minor (changeset added via `.changeset/evm-scopes-support.md`)

Link to Devin session: https://crossmint.devinenterprise.com/sessions/f8a89d63a05d4758be895037ce8c9ea4
Requested by: @maxsch-xmint