### PR TITLE
fix(react-native): prevent iOS WKWebView JS throttling from zero-area clipping

### DIFF
--- a/.changeset/fix-rn-webview-ios-visibility.md
+++ b/.changeset/fix-rn-webview-ios-visibility.md
@@ -2,4 +2,4 @@
 "@crossmint/client-sdk-react-native-ui": patch
 ---
 
-Fix iOS WKWebView JS throttling caused by zero-area clipping. Replace `overflow: hidden` + `width: 0, height: 0` wrapper with `opacity: 0` + `pointerEvents: none` so the WebView backing layer stays composited and iOS does not deprioritize the WebContent process. Add diagnostic instrumentation (mount timing, bridge first-message, heartbeat).
+Fix iOS WKWebView JS throttling caused by zero-area clipping. Replace `overflow: hidden` + `width: 0, height: 0` wrapper with `opacity: 0` + `pointerEvents: none` so the WebView backing layer stays composited and iOS does not deprioritize the WebContent process.

--- a/.changeset/fix-rn-webview-ios-visibility.md
+++ b/.changeset/fix-rn-webview-ios-visibility.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-native-ui": patch
+---
+
+Fix iOS WKWebView JS throttling caused by zero-area clipping. Replace `overflow: hidden` + `width: 0, height: 0` wrapper with `opacity: 0` + `pointerEvents: none` so the WebView backing layer stays composited and iOS does not deprioritize the WebContent process. Add diagnostic instrumentation (mount timing, bridge first-message, heartbeat).

--- a/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
@@ -315,16 +315,8 @@ function CrossmintWalletProviderInternal({
 
             const rawData = event.nativeEvent.data;
 
-            if (bridgeFirstMessageTimeRef.current === 0) {
-                bridgeFirstMessageTimeRef.current = Date.now();
-                const msSinceMount = webViewMountTimeRef.current > 0 ? Date.now() - webViewMountTimeRef.current : null;
-                logger.info("react-native.wallet.webview.bridge.firstMessage", {
-                    msSinceMount,
-                    messageType: typeof rawData === "string" ? rawData.slice(0, 50) : "non-string",
-                });
-            }
-
-            // Handle heartbeat pong from WebView
+            // Handle heartbeat pong from WebView (check before first-message tracking so pongs
+            // don't skew the mount-to-first-protocol-message latency metric)
             if (typeof rawData === "string" && rawData.startsWith("__heartbeat_pong__:")) {
                 try {
                     const pong = JSON.parse(rawData.slice("__heartbeat_pong__:".length));
@@ -334,6 +326,15 @@ function CrossmintWalletProviderInternal({
                     });
                 } catch {}
                 return;
+            }
+
+            if (bridgeFirstMessageTimeRef.current === 0) {
+                bridgeFirstMessageTimeRef.current = Date.now();
+                const msSinceMount = webViewMountTimeRef.current > 0 ? Date.now() - webViewMountTimeRef.current : null;
+                logger.info("react-native.wallet.webview.bridge.firstMessage", {
+                    msSinceMount,
+                    messageType: typeof rawData === "string" ? rawData.slice(0, 50) : "non-string",
+                });
             }
 
             // Handle "frame-ready" signal from child — child is ready to handshake.

--- a/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
@@ -286,7 +286,8 @@ function CrossmintWalletProviderInternal({
             msSinceMount,
         });
         await performHandshake("onLoadEnd");
-    }, [logger, performHandshake]);
+        startHeartbeat();
+    }, [logger, performHandshake, startHeartbeat]);
 
     const handleMessage = useCallback(
         (event: WebViewMessageEvent) => {
@@ -307,9 +308,9 @@ function CrossmintWalletProviderInternal({
             }
 
             // Handle heartbeat pong from WebView
-            if (typeof rawData === "string" && rawData.startsWith('{"type":"heartbeat-pong"')) {
+            if (typeof rawData === "string" && rawData.startsWith("__heartbeat_pong__:")) {
                 try {
-                    const pong = JSON.parse(rawData);
+                    const pong = JSON.parse(rawData.slice("__heartbeat_pong__:".length));
                     logger.debug("react-native.wallet.webview.heartbeat.pong", {
                         seq: pong.seq,
                         roundTripMs: Date.now() - (pong.sentAt ?? 0),
@@ -431,8 +432,8 @@ function CrossmintWalletProviderInternal({
 
     // Periodic heartbeat: inject JS into the WebView that echoes back via postMessage.
     // Detects silent JS throttling where the WebContent process is alive but timers are slowed.
-    useEffect(() => {
-        if (!needsWebView || webviewRef.current == null) {
+    const startHeartbeat = useCallback(() => {
+        if (heartbeatIntervalRef.current != null) {
             return;
         }
 
@@ -441,9 +442,17 @@ function CrossmintWalletProviderInternal({
             const seq = heartbeatSeqRef.current++;
             const sentAt = Date.now();
             webviewRef.current?.injectJavaScript(
-                `window.ReactNativeWebView && window.ReactNativeWebView.postMessage(JSON.stringify({type:"heartbeat-pong",seq:${seq},sentAt:${sentAt}}));true;`
+                `window.ReactNativeWebView && window.ReactNativeWebView.postMessage("__heartbeat_pong__:" + JSON.stringify({seq:${seq},sentAt:${sentAt}}));true;`
             );
         }, HEARTBEAT_INTERVAL_MS);
+    }, []);
+
+    useEffect(() => {
+        if (!needsWebView) {
+            return;
+        }
+
+        startHeartbeat();
 
         return () => {
             if (heartbeatIntervalRef.current != null) {
@@ -451,7 +460,7 @@ function CrossmintWalletProviderInternal({
                 heartbeatIntervalRef.current = null;
             }
         };
-    }, [needsWebView]);
+    }, [needsWebView, startHeartbeat]);
 
     useEffect(() => {
         if (hasPasskeySigner(createOnLogin)) {

--- a/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
@@ -275,6 +275,23 @@ function CrossmintWalletProviderInternal({
         }
     }, [needsWebView, logger, performHandshake]);
 
+    // Periodic heartbeat: inject JS into the WebView that echoes back via postMessage.
+    // Detects silent JS throttling where the WebContent process is alive but timers are slowed.
+    const startHeartbeat = useCallback(() => {
+        if (heartbeatIntervalRef.current != null) {
+            return;
+        }
+
+        const HEARTBEAT_INTERVAL_MS = 30_000;
+        heartbeatIntervalRef.current = setInterval(() => {
+            const seq = heartbeatSeqRef.current++;
+            const sentAt = Date.now();
+            webviewRef.current?.injectJavaScript(
+                `window.ReactNativeWebView && window.ReactNativeWebView.postMessage("__heartbeat_pong__:" + JSON.stringify({seq:${seq},sentAt:${sentAt}}));true;`
+            );
+        }, HEARTBEAT_INTERVAL_MS);
+    }, []);
+
     const onWebViewLoad = useCallback(async () => {
         // onLoadEnd is a fallback — eager handshake should have started already.
         // This still triggers in case the eager start couldn't run (e.g. ref timing).
@@ -429,23 +446,6 @@ function CrossmintWalletProviderInternal({
 
         logger.info("react-native.wallet.webview.init.success", { attempts });
     };
-
-    // Periodic heartbeat: inject JS into the WebView that echoes back via postMessage.
-    // Detects silent JS throttling where the WebContent process is alive but timers are slowed.
-    const startHeartbeat = useCallback(() => {
-        if (heartbeatIntervalRef.current != null) {
-            return;
-        }
-
-        const HEARTBEAT_INTERVAL_MS = 30_000;
-        heartbeatIntervalRef.current = setInterval(() => {
-            const seq = heartbeatSeqRef.current++;
-            const sentAt = Date.now();
-            webviewRef.current?.injectJavaScript(
-                `window.ReactNativeWebView && window.ReactNativeWebView.postMessage("__heartbeat_pong__:" + JSON.stringify({seq:${seq},sentAt:${sentAt}}));true;`
-            );
-        }, HEARTBEAT_INTERVAL_MS);
-    }, []);
 
     useEffect(() => {
         if (!needsWebView) {

--- a/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
@@ -140,10 +140,6 @@ function CrossmintWalletProviderInternal({
     const handshakeGenerationRef = useRef<number>(0);
     const handshakeStartTimeRef = useRef<number>(0);
     const handshakeRetryCountRef = useRef<number>(0);
-    const webViewMountTimeRef = useRef<number>(0);
-    const bridgeFirstMessageTimeRef = useRef<number>(0);
-    const heartbeatIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-    const heartbeatSeqRef = useRef<number>(0);
 
     const secureGlobals = useMemo(() => {
         if (appId != null) {
@@ -275,36 +271,16 @@ function CrossmintWalletProviderInternal({
         }
     }, [needsWebView, logger, performHandshake]);
 
-    // Periodic heartbeat: inject JS into the WebView that echoes back via postMessage.
-    // Detects silent JS throttling where the WebContent process is alive but timers are slowed.
-    const startHeartbeat = useCallback(() => {
-        if (heartbeatIntervalRef.current != null) {
-            return;
-        }
-
-        const HEARTBEAT_INTERVAL_MS = 30_000;
-        heartbeatIntervalRef.current = setInterval(() => {
-            const seq = heartbeatSeqRef.current++;
-            const sentAt = Date.now();
-            webviewRef.current?.injectJavaScript(
-                `window.ReactNativeWebView && window.ReactNativeWebView.postMessage("__heartbeat_pong__:" + JSON.stringify({seq:${seq},sentAt:${sentAt}}));true;`
-            );
-        }, HEARTBEAT_INTERVAL_MS);
-    }, []);
-
     const onWebViewLoad = useCallback(async () => {
         // onLoadEnd is a fallback — eager handshake should have started already.
         // This still triggers in case the eager start couldn't run (e.g. ref timing).
-        const msSinceMount = webViewMountTimeRef.current > 0 ? Date.now() - webViewMountTimeRef.current : null;
         logger.info("react-native.wallet.webview.onLoadEnd", {
             handshakeInProgress: handshakeInProgressRef.current,
             isConnected: webViewParentRef.current?.isConnected ?? false,
             generation: handshakeGenerationRef.current,
-            msSinceMount,
         });
         await performHandshake("onLoadEnd");
-        startHeartbeat();
-    }, [logger, performHandshake, startHeartbeat]);
+    }, [logger, performHandshake]);
 
     const handleMessage = useCallback(
         (event: WebViewMessageEvent) => {
@@ -314,28 +290,6 @@ function CrossmintWalletProviderInternal({
             }
 
             const rawData = event.nativeEvent.data;
-
-            // Handle heartbeat pong from WebView (check before first-message tracking so pongs
-            // don't skew the mount-to-first-protocol-message latency metric)
-            if (typeof rawData === "string" && rawData.startsWith("__heartbeat_pong__:")) {
-                try {
-                    const pong = JSON.parse(rawData.slice("__heartbeat_pong__:".length));
-                    logger.debug("react-native.wallet.webview.heartbeat.pong", {
-                        seq: pong.seq,
-                        roundTripMs: Date.now() - (pong.sentAt ?? 0),
-                    });
-                } catch {}
-                return;
-            }
-
-            if (bridgeFirstMessageTimeRef.current === 0) {
-                bridgeFirstMessageTimeRef.current = Date.now();
-                const msSinceMount = webViewMountTimeRef.current > 0 ? Date.now() - webViewMountTimeRef.current : null;
-                logger.info("react-native.wallet.webview.bridge.firstMessage", {
-                    msSinceMount,
-                    messageType: typeof rawData === "string" ? rawData.slice(0, 50) : "non-string",
-                });
-            }
 
             // Handle "frame-ready" signal from child — child is ready to handshake.
             // With eager handshake, the parent is already polling, so the handshake
@@ -426,8 +380,6 @@ function CrossmintWalletProviderInternal({
 
     const initializeWebView = async () => {
         logger.info("react-native.wallet.webview.init.start");
-        webViewMountTimeRef.current = Date.now();
-        bridgeFirstMessageTimeRef.current = 0;
         setNeedsWebView(true);
 
         let attempts = 0;
@@ -447,21 +399,6 @@ function CrossmintWalletProviderInternal({
 
         logger.info("react-native.wallet.webview.init.success", { attempts });
     };
-
-    useEffect(() => {
-        if (!needsWebView) {
-            return;
-        }
-
-        startHeartbeat();
-
-        return () => {
-            if (heartbeatIntervalRef.current != null) {
-                clearInterval(heartbeatIntervalRef.current);
-                heartbeatIntervalRef.current = null;
-            }
-        };
-    }, [needsWebView, startHeartbeat]);
 
     useEffect(() => {
         if (hasPasskeySigner(createOnLogin)) {
@@ -507,19 +444,15 @@ function CrossmintWalletProviderInternal({
                         onContentProcessDidTerminate={() => {
                             const prevGeneration = handshakeGenerationRef.current;
                             handshakeGenerationRef.current++;
-                            const msSinceMount =
-                                webViewMountTimeRef.current > 0 ? Date.now() - webViewMountTimeRef.current : null;
                             logger.warn("react-native.wallet.webview.process.terminated", {
                                 prevGeneration,
                                 newGeneration: handshakeGenerationRef.current,
                                 wasConnected: webViewParentRef.current?.isConnected ?? false,
                                 hadHandshakeInProgress: handshakeInProgressRef.current,
-                                msSinceMount,
                             });
                             handshakeTriggeredRef.current = false;
                             handshakeInProgressRef.current = false;
                             handshakeRetryCountRef.current = 0;
-                            bridgeFirstMessageTimeRef.current = 0;
                             if (webViewParentRef.current != null) {
                                 webViewParentRef.current.isConnected = false;
                             }
@@ -530,19 +463,15 @@ function CrossmintWalletProviderInternal({
                         onRenderProcessGone={() => {
                             const prevGeneration = handshakeGenerationRef.current;
                             handshakeGenerationRef.current++;
-                            const msSinceMount =
-                                webViewMountTimeRef.current > 0 ? Date.now() - webViewMountTimeRef.current : null;
                             logger.warn("react-native.wallet.webview.process.renderGone", {
                                 prevGeneration,
                                 newGeneration: handshakeGenerationRef.current,
                                 wasConnected: webViewParentRef.current?.isConnected ?? false,
                                 hadHandshakeInProgress: handshakeInProgressRef.current,
-                                msSinceMount,
                             });
                             handshakeTriggeredRef.current = false;
                             handshakeInProgressRef.current = false;
                             handshakeRetryCountRef.current = 0;
-                            bridgeFirstMessageTimeRef.current = 0;
                             if (webViewParentRef.current != null) {
                                 webViewParentRef.current.isConnected = false;
                             }

--- a/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
@@ -140,6 +140,10 @@ function CrossmintWalletProviderInternal({
     const handshakeGenerationRef = useRef<number>(0);
     const handshakeStartTimeRef = useRef<number>(0);
     const handshakeRetryCountRef = useRef<number>(0);
+    const webViewMountTimeRef = useRef<number>(0);
+    const bridgeFirstMessageTimeRef = useRef<number>(0);
+    const heartbeatIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const heartbeatSeqRef = useRef<number>(0);
 
     const secureGlobals = useMemo(() => {
         if (appId != null) {
@@ -274,10 +278,12 @@ function CrossmintWalletProviderInternal({
     const onWebViewLoad = useCallback(async () => {
         // onLoadEnd is a fallback — eager handshake should have started already.
         // This still triggers in case the eager start couldn't run (e.g. ref timing).
+        const msSinceMount = webViewMountTimeRef.current > 0 ? Date.now() - webViewMountTimeRef.current : null;
         logger.info("react-native.wallet.webview.onLoadEnd", {
             handshakeInProgress: handshakeInProgressRef.current,
             isConnected: webViewParentRef.current?.isConnected ?? false,
             generation: handshakeGenerationRef.current,
+            msSinceMount,
         });
         await performHandshake("onLoadEnd");
     }, [logger, performHandshake]);
@@ -290,6 +296,27 @@ function CrossmintWalletProviderInternal({
             }
 
             const rawData = event.nativeEvent.data;
+
+            if (bridgeFirstMessageTimeRef.current === 0) {
+                bridgeFirstMessageTimeRef.current = Date.now();
+                const msSinceMount = webViewMountTimeRef.current > 0 ? Date.now() - webViewMountTimeRef.current : null;
+                logger.info("react-native.wallet.webview.bridge.firstMessage", {
+                    msSinceMount,
+                    messageType: typeof rawData === "string" ? rawData.slice(0, 50) : "non-string",
+                });
+            }
+
+            // Handle heartbeat pong from WebView
+            if (typeof rawData === "string" && rawData.startsWith('{"type":"heartbeat-pong"')) {
+                try {
+                    const pong = JSON.parse(rawData);
+                    logger.debug("react-native.wallet.webview.heartbeat.pong", {
+                        seq: pong.seq,
+                        roundTripMs: Date.now() - (pong.sentAt ?? 0),
+                    });
+                } catch {}
+                return;
+            }
 
             // Handle "frame-ready" signal from child — child is ready to handshake.
             // With eager handshake, the parent is already polling, so the handshake
@@ -380,6 +407,8 @@ function CrossmintWalletProviderInternal({
 
     const initializeWebView = async () => {
         logger.info("react-native.wallet.webview.init.start");
+        webViewMountTimeRef.current = Date.now();
+        bridgeFirstMessageTimeRef.current = 0;
         setNeedsWebView(true);
 
         let attempts = 0;
@@ -399,6 +428,30 @@ function CrossmintWalletProviderInternal({
 
         logger.info("react-native.wallet.webview.init.success", { attempts });
     };
+
+    // Periodic heartbeat: inject JS into the WebView that echoes back via postMessage.
+    // Detects silent JS throttling where the WebContent process is alive but timers are slowed.
+    useEffect(() => {
+        if (!needsWebView || webviewRef.current == null) {
+            return;
+        }
+
+        const HEARTBEAT_INTERVAL_MS = 30_000;
+        heartbeatIntervalRef.current = setInterval(() => {
+            const seq = heartbeatSeqRef.current++;
+            const sentAt = Date.now();
+            webviewRef.current?.injectJavaScript(
+                `window.ReactNativeWebView && window.ReactNativeWebView.postMessage(JSON.stringify({type:"heartbeat-pong",seq:${seq},sentAt:${sentAt}}));true;`
+            );
+        }, HEARTBEAT_INTERVAL_MS);
+
+        return () => {
+            if (heartbeatIntervalRef.current != null) {
+                clearInterval(heartbeatIntervalRef.current);
+                heartbeatIntervalRef.current = null;
+            }
+        };
+    }, [needsWebView]);
 
     useEffect(() => {
         if (hasPasskeySigner(createOnLogin)) {
@@ -423,9 +476,10 @@ function CrossmintWalletProviderInternal({
                 <View
                     style={{
                         position: "absolute",
-                        width: 0,
-                        height: 0,
-                        overflow: "hidden",
+                        width: 1,
+                        height: 1,
+                        opacity: 0,
+                        pointerEvents: "none",
                     }}
                 >
                     <RNWebView
@@ -443,15 +497,19 @@ function CrossmintWalletProviderInternal({
                         onContentProcessDidTerminate={() => {
                             const prevGeneration = handshakeGenerationRef.current;
                             handshakeGenerationRef.current++;
+                            const msSinceMount =
+                                webViewMountTimeRef.current > 0 ? Date.now() - webViewMountTimeRef.current : null;
                             logger.warn("react-native.wallet.webview.process.terminated", {
                                 prevGeneration,
                                 newGeneration: handshakeGenerationRef.current,
                                 wasConnected: webViewParentRef.current?.isConnected ?? false,
                                 hadHandshakeInProgress: handshakeInProgressRef.current,
+                                msSinceMount,
                             });
                             handshakeTriggeredRef.current = false;
                             handshakeInProgressRef.current = false;
                             handshakeRetryCountRef.current = 0;
+                            bridgeFirstMessageTimeRef.current = 0;
                             if (webViewParentRef.current != null) {
                                 webViewParentRef.current.isConnected = false;
                             }
@@ -462,15 +520,19 @@ function CrossmintWalletProviderInternal({
                         onRenderProcessGone={() => {
                             const prevGeneration = handshakeGenerationRef.current;
                             handshakeGenerationRef.current++;
+                            const msSinceMount =
+                                webViewMountTimeRef.current > 0 ? Date.now() - webViewMountTimeRef.current : null;
                             logger.warn("react-native.wallet.webview.process.renderGone", {
                                 prevGeneration,
                                 newGeneration: handshakeGenerationRef.current,
                                 wasConnected: webViewParentRef.current?.isConnected ?? false,
                                 hadHandshakeInProgress: handshakeInProgressRef.current,
+                                msSinceMount,
                             });
                             handshakeTriggeredRef.current = false;
                             handshakeInProgressRef.current = false;
                             handshakeRetryCountRef.current = 0;
+                            bridgeFirstMessageTimeRef.current = 0;
                             if (webViewParentRef.current != null) {
                                 webViewParentRef.current.isConnected = false;
                             }


### PR DESCRIPTION
## Description

On iOS, a WKWebView hidden via `width: 0, height: 0, overflow: "hidden"` gets its `ActivityState::IsVisible` flag cleared by WebKit. This causes `updateThrottleState()` to drop the foreground assertion on the WebContent process, making it eligible for suspension, timer throttling, and priority termination under memory pressure — which explains intermittent JS execution failures in the signer relay WebView.

**Fix:** Replace the zero-area clipped wrapper with `width: 1, height: 1, opacity: 0, pointerEvents: "none"`. This keeps the compositing layer present so iOS treats the WebView as visible, maintaining full JS execution priority. Matches the Flutter SDK's `Offstage` pattern.

**WebKit source references** (from [WebKit/WebKit](https://github.com/WebKit/WebKit)):
- `WebPageProxy::isViewVisible()` → checks `ActivityState::IsVisible` flag (`WebPageProxy.cpp:3257`)
- `updateThrottleState()` → `isViewVisible() ? takeVisibleActivity() : dropVisibleActivity()` (`WebPageProxy.cpp:3546`)
- `PageClientImpl::isActiveViewVisible()` → `isViewInWindow() && !_isBackground` (`PageClientImplIOS.mm:163`)

See [detailed source code walkthrough](https://github.com/Crossmint/crossmint-sdk/pull/1878#issuecomment-4596988817) in PR comments.

## Test plan

* Verify on physical iOS devices that wallet creation/signing flows work consistently
* Monitor for reduced `react-native.wallet.webview.process.terminated` events
* Test under memory pressure scenarios (open many apps, then return)
* Confirm WebView remains invisible and non-interactive to users

## Package updates

* `@crossmint/client-sdk-react-native-ui`: patch (changeset added)

Link to Devin session: https://crossmint.devinenterprise.com/sessions/aa42293821a24fee86c25e350715efd5
Requested by: @panosinthezone