### PR TITLE
docs: add JSDoc to exported types and hooks for SDK reference generation test

### DIFF
--- a/.changeset/test-doc-generation.md
+++ b/.changeset/test-doc-generation.md
@@ -1,0 +1,7 @@
+---
+"@crossmint/wallets-sdk": patch
+"@crossmint/client-sdk-react-ui": patch
+"@crossmint/client-sdk-react-native-ui": patch
+---
+
+Add JSDoc documentation to exported types and hooks for improved SDK reference generation

--- a/packages/client/ui/react-native/src/hooks/useAuth.ts
+++ b/packages/client/ui/react-native/src/hooks/useAuth.ts
@@ -8,6 +8,15 @@ interface RNCrossmintAuthContext extends CrossmintAuthBaseContextType {
     createAuthSession: (urlOrOneTimeSecret: string) => Promise<AuthMaterialWithUser | null>;
 }
 
+/**
+ * Hook to access the Crossmint authentication context in React Native.
+ *
+ * Provides methods for login, logout, OAuth, and deep-link auth session creation.
+ * Must be used within a {@link CrossmintAuthProvider}.
+ *
+ * @returns The authentication context including user state and auth methods.
+ * @throws If used outside of a CrossmintAuthProvider.
+ */
 export function useCrossmintAuth(): RNCrossmintAuthContext {
     const context = useContext(AuthContext);
     if (context == null) {

--- a/packages/client/ui/react-ui/src/hooks/useAuth.ts
+++ b/packages/client/ui/react-ui/src/hooks/useAuth.ts
@@ -7,6 +7,15 @@ export interface CrossmintAuthContext extends CrossmintAuthBaseContextType {
     loginWithOAuth: (provider: OAuthProvider) => Promise<void>;
 }
 
+/**
+ * Hook to access the Crossmint authentication context.
+ *
+ * Provides methods for login, logout, and accessing the current user session.
+ * Must be used within a {@link CrossmintAuthProvider}.
+ *
+ * @returns The authentication context including user state and auth methods.
+ * @throws If used outside of a CrossmintAuthProvider.
+ */
 export function useCrossmintAuth(): CrossmintAuthContext {
     const context = useContext(AuthContext);
     if (context == null) {

--- a/packages/wallets/src/wallets/types.ts
+++ b/packages/wallets/src/wallets/types.ts
@@ -30,6 +30,12 @@ export type TransactionInputOptions = PrepareOnly & {
     signer?: string | ServerSignerConfig;
 };
 
+/**
+ * Options for sending token transactions.
+ *
+ * Extends {@link TransactionInputOptions} with an optional transaction type
+ * that determines routing behavior (onramp, regulated transfer, or direct).
+ */
 export type SendTokenTransactionOptions = TransactionInputOptions & {
     transactionType?: SendTokenTransactionType;
 };


### PR DESCRIPTION
## Description

Adds JSDoc documentation to key exported types and hooks across all 3 SDK packages to test that the `sdk-reference-docs-generate` workflow correctly picks up source changes and generates updated reference docs.

Changes:
- **wallets-sdk**: Added JSDoc to `SendTokenTransactionOptions` type
- **react-ui**: Added JSDoc to `useCrossmintAuth()` hook
- **react-native**: Added JSDoc to `useCrossmintAuth()` hook

These are legitimate documentation improvements that also serve as a pipeline validation: once merged into `sdk-doc-sync-action`, the path filters should trigger the generation workflow for all 3 packages, and the resulting PR in crossbit-main should show the new descriptions in the generated reference docs.

## Test plan

* Merge this PR into `sdk-doc-sync-action`
* Verify the `SDK Reference Docs Generate` workflow triggers automatically via push path filters
* Verify all 3 packages generate docs (node-wallets, react-ui, react-native)
* Verify the sync workflow in crossbit-main creates a PR with updated reference docs reflecting the new JSDoc content

## Package updates

- `@crossmint/wallets-sdk`: patch (JSDoc only)
- `@crossmint/client-sdk-react-ui`: patch (JSDoc only)
- `@crossmint/client-sdk-react-native-ui`: patch (JSDoc only)

Changeset added via `.changeset/test-doc-generation.md`.

Link to Devin session: https://crossmint.devinenterprise.com/sessions/45f96af09e3d4c8385f81676856f221f
Requested by: @jmderby