### PR TITLE
docs: add useWallet JSDoc and include useCrossmintAuth in React/RN doc generators

### DIFF
--- a/.changeset/fix-react-doc-generation.md
+++ b/.changeset/fix-react-doc-generation.md
@@ -1,0 +1,7 @@
+---
+"@crossmint/client-sdk-react-base": patch
+"@crossmint/client-sdk-react-ui": patch
+"@crossmint/client-sdk-react-native-ui": patch
+---
+
+Add JSDoc to useWallet hook and include useCrossmintAuth in React/RN doc generators

--- a/packages/client/react-base/src/hooks/useWallet.ts
+++ b/packages/client/react-base/src/hooks/useWallet.ts
@@ -1,6 +1,16 @@
 import { useContext } from "react";
 import { CrossmintWalletBaseContext } from "@/providers/CrossmintWalletBaseProvider";
 
+/**
+ * Hook to access the current wallet instance and wallet state.
+ *
+ * Returns the wallet context including the active wallet, loading state,
+ * and methods for wallet creation and retrieval.
+ * Must be used within a {@link CrossmintWalletProvider}.
+ *
+ * @returns The wallet context with the active wallet and wallet management methods.
+ * @throws If used outside of a CrossmintWalletProvider.
+ */
 export function useWallet(): CrossmintWalletBaseContext {
     const walletContext = useContext(CrossmintWalletBaseContext);
     if (!walletContext) {

--- a/packages/client/ui/react-native/scripts/generate-reference.mjs
+++ b/packages/client/ui/react-native/scripts/generate-reference.mjs
@@ -26,6 +26,7 @@ see the [previous version of this page](/sdk-reference/wallets/v0/react-native/{
             "CrossmintProvider",
             "CrossmintWalletProvider",
             "useWallet",
+            "useCrossmintAuth",
             "useWalletOtpSigner",
             "ExportPrivateKeyButton",
         ],

--- a/packages/client/ui/react-ui/scripts/generate-reference.mjs
+++ b/packages/client/ui/react-ui/scripts/generate-reference.mjs
@@ -22,7 +22,13 @@ const PRODUCTS = {
 **This page has been updated for Wallets SDK V1.** If you are using the previous version,
 see the [previous version of this page](/sdk-reference/wallets/v0/react/{page}) or the [V1 migration guide](/wallets/guides/migrate-to-v1).
 </Note>`,
-        exports: ["CrossmintProvider", "CrossmintWalletProvider", "useWallet", "ExportPrivateKeyButton"],
+        exports: [
+            "CrossmintProvider",
+            "CrossmintWalletProvider",
+            "useWallet",
+            "useCrossmintAuth",
+            "ExportPrivateKeyButton",
+        ],
         descriptions: {
             CrossmintProvider: "SDK initialization (required for all Crossmint features)",
             CrossmintWalletProvider: "Wallet creation and management",


### PR DESCRIPTION
## Description

The previous test PR (#1879) successfully triggered the generation workflow for all 3 packages, but only the TypeScript/wallets docs showed changes. React and React Native docs were unchanged because:

1. `useCrossmintAuth` (where we added JSDoc) wasn't in the generators' `exports` lists
2. `useWallet` (which IS in the exports list) had no JSDoc to generate from

This PR fixes both:
- Adds JSDoc to `useWallet` in `react-base` (re-exported by both React and React Native) so the existing `useWallet` page shows updated content
- Adds `useCrossmintAuth` to both React and React Native generators' `exports` lists so it gets its own dedicated reference page

After merging, the generation workflow should produce visible changes in the React and React Native doc output (updated `useWallet` description + new `useCrossmintAuth` page for each).

## Test plan

* Merge into `sdk-doc-sync-action`
* Verify `SDK Reference Docs Generate` workflow triggers via path filters
* Verify the resulting sync PR in crossbit-main includes React and React Native doc changes
* Confirm `useCrossmintAuth` pages are generated for both platforms
* Confirm `useWallet` page descriptions are updated for both platforms

## Package updates

No package version changes needed — these are doc generation script changes only (no runtime impact).

Link to Devin session: https://crossmint.devinenterprise.com/sessions/45f96af09e3d4c8385f81676856f221f
Requested by: @jmderby