### PR TITLE
docs: add JSDoc to useWallet hook for SDK reference generation

### DIFF
--- a/.changeset/wallet-hook-jsdoc.md
+++ b/.changeset/wallet-hook-jsdoc.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-base": patch
+---
+
+Add JSDoc documentation to useWallet hook for SDK reference generation

--- a/packages/client/react-base/src/hooks/useWallet.ts
+++ b/packages/client/react-base/src/hooks/useWallet.ts
@@ -1,6 +1,16 @@
 import { useContext } from "react";
 import { CrossmintWalletBaseContext } from "@/providers/CrossmintWalletBaseProvider";
 
+/**
+ * Hook to access the current wallet instance and wallet state.
+ *
+ * Returns the wallet context including the active wallet, loading state,
+ * and methods for wallet creation and retrieval.
+ * Must be used within a {@link CrossmintWalletProvider}.
+ *
+ * @returns The wallet context with the active wallet and wallet management methods.
+ * @throws If used outside of a CrossmintWalletProvider.
+ */
 export function useWallet(): CrossmintWalletBaseContext {
     const walletContext = useContext(CrossmintWalletBaseContext);
     if (!walletContext) {


### PR DESCRIPTION
## Description

Adds JSDoc documentation to the `useWallet` hook in `react-base` (re-exported by both React and React Native SDKs). This hook is already in both generators' `exports` lists, so the added JSDoc will produce visible changes in the generated React and React Native reference docs.

This validates that the doc generation pipeline correctly picks up JSDoc changes for wallet-related hooks and reflects them in the generated output.

## Test plan

* Merge into `sdk-doc-sync-action`
* Verify `SDK Reference Docs Generate` workflow triggers via path filters (`packages/client/react-base/src/**`)
* Verify the resulting sync PR in crossbit-main includes updated React and React Native `useWallet` page descriptions

## Package updates

- `@crossmint/client-sdk-react-base`: patch (JSDoc only)

Changeset added via `.changeset/wallet-hook-jsdoc.md`.

Link to Devin session: https://crossmint.devinenterprise.com/sessions/45f96af09e3d4c8385f81676856f221f
Requested by: @jmderby