### PR TITLE
fix(wallets): remove browser environment check from createServerSigner

### DIFF
--- a/.changeset/remove-server-signer-window-check.md
+++ b/.changeset/remove-server-signer-window-check.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+Remove browser environment check from `createServerSigner` to allow client-side usage

--- a/packages/wallets/src/utils/server-signers/createServerSigner.ts
+++ b/packages/wallets/src/utils/server-signers/createServerSigner.ts
@@ -39,10 +39,6 @@ export type ServerSigner = {
  * ```
  */
 export function createServerSigner(params: CreateServerSignerParams): ServerSigner {
-    if (typeof window !== "undefined") {
-        throw new Error("Server signers can only be used from server-side code.");
-    }
-
     const { secret, chain, projectId, environment } = params;
     const chainType = getChainType(chain);
     const keyBytes = deriveKeyBytes(secret, projectId, environment, chainType);


### PR DESCRIPTION
## Description

Removes the `typeof window !== "undefined"` guard from `createServerSigner`. The check prevented calling the function from browser context, but the console app needs to derive server signer addresses client-side (e.g. in the create wallet modal). The "server" in "server signer" refers to where the keys are stored, not where the derivation runs.

## Test plan

* Existing unit tests continue to pass — no behavioral change other than removing the runtime guard
* Verified ESM/CJS builds succeed without the window check

## Package updates

* `@crossmint/wallets-sdk`: patch (changeset added)

Link to Devin session: https://crossmint.devinenterprise.com/sessions/ad482efc604a499cbc47a8690419621c
Requested by: @guilleasz-crossmint
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/crossmint-sdk/pull/1900" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->