### PR TITLE
refactor(wallets): rename HKDF_SALT to HKDF_DOMAIN_SEPARATOR

### DIFF
--- a/packages/wallets/src/utils/server-key-derivation.ts
+++ b/packages/wallets/src/utils/server-key-derivation.ts
@@ -2,7 +2,7 @@ import { hkdf } from "@noble/hashes/hkdf";
 import { sha256 } from "@noble/hashes/sha2";
 import { bytesToHex } from "@noble/hashes/utils";
 
-const HKDF_SALT = "crossmint";
+const HKDF_DOMAIN_SEPARATOR = "crossmint";
 const SECRET_PREFIX = "xmsk1_";
 
 /**
@@ -24,7 +24,7 @@ export function deriveKeyBytes(secret: string, projectId: string, environment: s
     const algorithm = getAlgorithmForChain(chain);
     const info = `${projectId}:${environment}:${chain}-${algorithm}`;
 
-    return hkdf(sha256, ikm, HKDF_SALT, info, 32);
+    return hkdf(sha256, ikm, HKDF_DOMAIN_SEPARATOR, info, 32);
 }
 
 /**
@@ -37,7 +37,7 @@ export function deriveAlias(secret: string, projectId: string, environment: stri
     const info = `${projectId}:${environment}:${chain}-alias`;
 
     // Alias max length is 36 chars. "s-" prefix (2) + 34 hex chars = 36.
-    const derived = hkdf(sha256, ikm, HKDF_SALT, info, 17);
+    const derived = hkdf(sha256, ikm, HKDF_DOMAIN_SEPARATOR, info, 17);
     return `s-${bytesToHex(derived).slice(0, 34)}`;
 }
 


### PR DESCRIPTION
## Description

Renames the `HKDF_SALT` constant to `HKDF_DOMAIN_SEPARATOR` in `packages/wallets/src/utils/server-key-derivation.ts`.

The constant `"crossmint"` is a fixed domain separator, not a per-secret random salt. The old name was misleading since "salt" implies a random anti-brute-force value. This is a pure rename with no behavioral change.

Resolves [WAL-10251](https://linear.app/crossmint/issue/WAL-10251/rename-hkdf-salt-constant-to-domain-separator).

## Test plan

* Existing `server-key-derivation.test.ts` (12 tests) all pass — confirms no functional change
* `pnpm lint` passes
* Full `@crossmint/wallets-sdk` test suite passes (337 tests)

## Package updates

No package updates.

Link to Devin session: https://crossmint.devinenterprise.com/sessions/a09bf9c9f397424c9ac8551eaeb8bf00
Requested by: @albertoelias-crossmint
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/crossmint-sdk/pull/1906" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->