### PR TITLE
fix(logger): redact server signer sensitive keys in logs

### DIFF
--- a/.changeset/redact-server-signer-keys.md
+++ b/.changeset/redact-server-signer-keys.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/common-sdk-base": patch
+---
+
+Add server signer sensitive fields (derivedKeyBytes, secretKey, keypair) to the SENSITIVE_KEYS redaction set so they are masked in log output.

--- a/packages/common/base/src/logger/utils.test.ts
+++ b/packages/common/base/src/logger/utils.test.ts
@@ -20,4 +20,16 @@ describe("redactSensitiveFields", () => {
         const result = redactSensitiveFields(input) as Record<string, unknown>;
         expect(result.jwt).toBe("[REDACTED]");
     });
+
+    it("should redact server signer sensitive fields", () => {
+        const input = {
+            derivedKeyBytes: new Uint8Array(32),
+            secretKey: new Uint8Array(64),
+            keypair: { publicKey: "abc", secretKey: new Uint8Array(64) },
+        };
+        const result = redactSensitiveFields(input) as Record<string, unknown>;
+        expect(result.derivedKeyBytes).toBe("[REDACTED]");
+        expect(result.secretKey).toBe("[REDACTED]");
+        expect(result.keypair).toBe("[REDACTED]");
+    });
 });

--- a/packages/common/base/src/logger/utils.ts
+++ b/packages/common/base/src/logger/utils.ts
@@ -28,6 +28,9 @@ const SENSITIVE_KEYS = new Set([
     "credential",
     "authdata",
     "bearer",
+    "derivedkeybytes",
+    "secretkey",
+    "keypair",
 ]);
 
 const MAX_REDACTION_DEPTH = 10;


### PR DESCRIPTION
## Description

Addresses [WAL-10253](https://linear.app/crossmint/issue/WAL-10253/redact-new-server-signer-sensitive-keys-in-logs).

The `SENSITIVE_KEYS` set in the logger did not include fields introduced by server signers, meaning private key material could appear unredacted in log output. This adds:

- `derivedkeybytes` — covers `ServerInternalSignerConfig.derivedKeyBytes`
- `secretkey` — covers `StellarServerSigner.secretKey`
- `keypair` — covers `SolanaServerSigner.keypair` (which contains `.secretKey`)

Category: improvements
Product Area: security, wallets

## Test plan

- Unit test added in `utils.test.ts` verifying all three new fields (`derivedKeyBytes`, `secretKey`, `keypair`) are redacted to `[REDACTED]` by `redactSensitiveFields`.
- Existing tests still pass (14/14).
- Lint passes (`pnpm lint`).

## Package updates

- `@crossmint/common-sdk-base`: patch — changeset added via `.changeset/redact-server-signer-keys.md`

Link to Devin session: https://crossmint.devinenterprise.com/sessions/424d0441e1b2451b89cc3a345fdc8b52
Requested by: @albertoelias-crossmint
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/crossmint-sdk/pull/1907" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->