### PR TITLE
refactor(wallets): remove custom hexToBytes in server key derivation

### DIFF
--- a/packages/wallets/src/utils/server-key-derivation.ts
+++ b/packages/wallets/src/utils/server-key-derivation.ts
@@ -1,6 +1,6 @@
 import { hkdf } from "@noble/hashes/hkdf";
 import { sha256 } from "@noble/hashes/sha2";
-import { bytesToHex } from "@noble/hashes/utils";
+import { bytesToHex, hexToBytes } from "@noble/hashes/utils";
 
 const HKDF_SALT = "crossmint";
 const SECRET_PREFIX = "xmsk1_";
@@ -61,18 +61,4 @@ function getAlgorithmForChain(chain: string): string {
         return "ed25519";
     }
     return "secp256k1";
-}
-
-function hexToBytes(hex: string): Uint8Array {
-    if (hex.length % 2 !== 0) {
-        throw new Error(`Invalid hex string: odd length (${hex.length})`);
-    }
-    if (!/^[0-9a-fA-F]+$/.test(hex)) {
-        throw new Error("Invalid hex string: contains non-hex characters");
-    }
-    const bytes = new Uint8Array(hex.length / 2);
-    for (let i = 0; i < hex.length; i += 2) {
-        bytes[i / 2] = parseInt(hex.slice(i, i + 2), 16);
-    }
-    return bytes;
 }


### PR DESCRIPTION
## Description

`server-key-derivation.ts` had a hand-rolled `hexToBytes` while already importing `bytesToHex` from `@noble/hashes/utils`. The same package exports `hexToBytes`, so this replaces the local implementation with the shared one — removing ~13 lines of redundant code.

Resolves [WAL-10252](https://linear.app/crossmint/issue/WAL-10252/remove-custom-hextobytes-in-server-key-derivation)

## Test plan

* Existing `server-key-derivation.test.ts` suite passes unchanged (all `deriveKeyBytes` and `deriveAlias` tests green), confirming the `@noble/hashes/utils.hexToBytes` is a drop-in replacement.
* `pnpm lint` passes with no new diagnostics.

## Package updates

No dependency changes — `@noble/hashes/utils` was already a dependency.

Link to Devin session: https://crossmint.devinenterprise.com/sessions/fa4586c7500646a6973abe0d6bb8d603
Requested by: @albertoelias-crossmint
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/crossmint-sdk/pull/1908" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->