### PR TITLE
fix(wallets): wipe server signer secret from memory after key derivation

### DIFF
--- a/.changeset/wipe-server-signer-secret-from-memory.md
+++ b/.changeset/wipe-server-signer-secret-from-memory.md
@@ -1,0 +1,10 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+fix: wipe server signer secret from memory after key derivation
+
+- After `useSigner()` resolves the server signer derivation, the plaintext master secret is stripped from the recovery config and replaced with an address-only reference
+- Non-selected derivation candidate key bytes are securely zeroed
+- Signer adapter constructors (EVM, Solana, Stellar) wipe input derived key bytes after constructing their internal key material
+- `buildInternalSignerConfig` copies derived key bytes so the cached resolution is not corrupted when adapters wipe their input

--- a/packages/wallets/src/signers/server/evm-server-signer.ts
+++ b/packages/wallets/src/signers/server/evm-server-signer.ts
@@ -1,6 +1,7 @@
 import { privateKeyToAccount } from "viem/accounts";
 import { bytesToHex } from "@noble/hashes/utils";
 import type { SignerAdapter, ServerInternalSignerConfig, ServerSignerLocator } from "../types";
+import { secureWipe } from "../../utils/secure-wipe";
 
 export class EVMServerSigner implements SignerAdapter<"server"> {
     type = "server" as const;
@@ -12,6 +13,8 @@ export class EVMServerSigner implements SignerAdapter<"server"> {
         this.account = privateKeyToAccount(`0x${bytesToHex(config.derivedKeyBytes)}`);
         this._address = this.account.address;
         this._locator = config.locator;
+        // Wipe the input derived key bytes now that the account has been constructed
+        secureWipe(config.derivedKeyBytes);
     }
 
     address() {

--- a/packages/wallets/src/signers/server/solana-server-signer.ts
+++ b/packages/wallets/src/signers/server/solana-server-signer.ts
@@ -2,6 +2,7 @@ import { Keypair, VersionedTransaction } from "@solana/web3.js";
 import base58 from "bs58";
 import nacl from "tweetnacl";
 import type { SignerAdapter, ServerInternalSignerConfig, ServerSignerLocator } from "../types";
+import { secureWipe } from "../../utils/secure-wipe";
 
 export class SolanaServerSigner implements SignerAdapter<"server"> {
     type = "server" as const;
@@ -13,6 +14,8 @@ export class SolanaServerSigner implements SignerAdapter<"server"> {
         this.keypair = Keypair.fromSeed(config.derivedKeyBytes);
         this._address = this.keypair.publicKey.toBase58();
         this._locator = config.locator;
+        // Wipe the input derived key bytes now that the keypair has been constructed
+        secureWipe(config.derivedKeyBytes);
     }
 
     address() {

--- a/packages/wallets/src/signers/server/stellar-server-signer.ts
+++ b/packages/wallets/src/signers/server/stellar-server-signer.ts
@@ -1,5 +1,6 @@
 import type { SignerAdapter, ServerInternalSignerConfig, ServerSignerLocator } from "../types";
 import { ed25519KeypairFromSeed, ed25519Sign, encodeStellarPublicKey } from "../../utils/stellar";
+import { secureWipe } from "../../utils/secure-wipe";
 
 export class StellarServerSigner implements SignerAdapter<"server"> {
     type = "server" as const;
@@ -12,6 +13,8 @@ export class StellarServerSigner implements SignerAdapter<"server"> {
         this._address = encodeStellarPublicKey(keypair.publicKey);
         this._locator = config.locator;
         this.secretKey = keypair.secretKey;
+        // Wipe the input derived key bytes now that the keypair has been constructed
+        secureWipe(config.derivedKeyBytes);
     }
 
     address() {

--- a/packages/wallets/src/utils/secure-wipe.ts
+++ b/packages/wallets/src/utils/secure-wipe.ts
@@ -1,0 +1,11 @@
+/**
+ * Securely wipe sensitive key material from memory by overwriting with zeros.
+ * Accepts Uint8Array values or null/undefined (which are silently skipped).
+ */
+export function secureWipe(...buffers: (Uint8Array | null | undefined)[]): void {
+    for (const buf of buffers) {
+        if (buf != null) {
+            buf.fill(0);
+        }
+    }
+}

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -1153,8 +1153,8 @@ export class Wallet<C extends Chain> {
     /**
      * Wipe the derivedKeyBytes of the non-selected candidate to reduce key material in memory.
      */
-    private wipeNonSelectedCandidate(_selected: DerivedServerSigner, other: DerivedServerSigner | null): void {
-        if (other != null && other !== _selected) {
+    private wipeNonSelectedCandidate(selected: DerivedServerSigner, other: DerivedServerSigner | null): void {
+        if (other != null && other !== selected) {
             secureWipe(other.derivedKeyBytes);
         }
     }
@@ -1477,7 +1477,7 @@ export class Wallet<C extends Chain> {
         pendingOperation: { type: "signature" | "transaction"; id: string }
     ): Promise<void> {
         const originalSigner = this.#signer;
-        if (isApiSourcedServerSignerConfig(this.#recovery)) {
+        if (isApiSourcedServerSignerConfig(this.#recovery) && this.#resolvedServerSigner == null) {
             throw new Error(
                 "Cannot resume pending approval: no secret available. " +
                     'Call wallet.useSigner({ type: "server", secret: ... }) first with the recovery server secret.'

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -1951,6 +1951,9 @@ export class Wallet<C extends Chain> {
                 // Copy the derived key bytes so the signer adapter can safely wipe its copy
                 // without corrupting the cached #resolvedServerSigner reference.
                 const keyBytesCopy = new Uint8Array(resolved.derivedKeyBytes);
+                if (resolved !== this.#resolvedServerSigner) {
+                    secureWipe(resolved.derivedKeyBytes);
+                }
                 return {
                     type: "server",
                     derivedKeyBytes: keyBytesCopy,

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -79,6 +79,7 @@ import {
     type DerivedServerSigner,
     deriveServerSignerCandidates as deriveServerSignerCandidatesHelper,
 } from "../signers/server";
+import { secureWipe } from "../utils/secure-wipe";
 import { walletsLogger } from "../logger";
 
 import { getSignerLocator } from "../utils/signer-locator";
@@ -284,7 +285,7 @@ export class Wallet<C extends Chain> {
             return;
         }
         try {
-            const internalConfig = this.buildInternalSignerConfig(this.#recovery as SignerConfigForChain<C>);
+            const internalConfig = this.buildInternalSignerConfig(this.#recovery);
             this.#signer = await this.assembleFullSigner(internalConfig, undefined, { isAdminSigner: true });
         } catch (error) {
             walletsLogger.warn("wallet.recover.device.unsupportedFallback.autoAssemblyFailed", {
@@ -339,29 +340,23 @@ export class Wallet<C extends Chain> {
     }
 
     /**
-     * Return the resolved server signer if it matches the given config (i.e. its address
-     * matches either the primary or legacy candidate). Returns null otherwise.
-     */
-    private matchResolvedServerSigner(signer: ServerSignerConfig): DerivedServerSigner | null {
-        if (this.#resolvedServerSigner == null) {
-            return null;
-        }
-        const { primary, legacy } = this.deriveServerSignerCandidates(signer);
-        const cachedAddr = this.#resolvedServerSigner.derivedAddress;
-        if (cachedAddr === primary.derivedAddress || (legacy != null && cachedAddr === legacy.derivedAddress)) {
-            return this.#resolvedServerSigner;
-        }
-        return null;
-    }
-
-    /**
      * Resolve which derivation (primary "evm" or legacy chain-specific) to use for a server signer.
      * Priority: cached resolution → legacy if it matches a known on-chain address → primary.
      */
-    private resolveServerSignerDerivation(signer: ServerSignerConfig): DerivedServerSigner {
-        const resolved = this.matchResolvedServerSigner(signer);
-        if (resolved != null) {
-            return resolved;
+    private resolveServerSignerDerivation(
+        signer: ServerSignerConfig | ApiSourcedServerSignerConfig
+    ): DerivedServerSigner {
+        // If the server signer has already been resolved (e.g. after useSigner), return
+        // the cached derivation directly. The secret may have already been wiped from
+        // #recovery at this point, so we must not attempt to re-derive.
+        if (this.#resolvedServerSigner != null) {
+            return this.#resolvedServerSigner;
+        }
+        if (isApiSourcedServerSignerConfig(signer)) {
+            throw new Error(
+                "Cannot resolve server signer derivation: no secret available and no cached resolution. " +
+                    'Call wallet.useSigner({ type: "server", secret: ... }) first.'
+            );
         }
         const { primary, legacy } = this.deriveServerSignerCandidates(signer);
         if (legacy != null) {
@@ -1116,11 +1111,15 @@ export class Wallet<C extends Chain> {
         const existingSigners = await this.signers();
         if (existingSigners.some((s) => s.locator === `server:${primary.derivedAddress}`)) {
             this.#resolvedServerSigner = primary;
+            this.wipeNonSelectedCandidate(primary, legacy);
+            this.stripSecretFromRecovery();
             this.#needsRecovery = false;
             return false;
         }
         if (legacy != null && existingSigners.some((s) => s.locator === `server:${legacy.derivedAddress}`)) {
             this.#resolvedServerSigner = legacy;
+            this.wipeNonSelectedCandidate(legacy, primary);
+            this.stripSecretFromRecovery();
             this.#needsRecovery = false;
             return false;
         }
@@ -1135,9 +1134,12 @@ export class Wallet<C extends Chain> {
                 legacy.derivedAddress === this.#apiRecoveryServerSignerAddress
             ) {
                 this.#resolvedServerSigner = legacy;
+                this.wipeNonSelectedCandidate(legacy, primary);
             } else {
                 this.#resolvedServerSigner = primary;
+                this.wipeNonSelectedCandidate(primary, legacy);
             }
+            this.stripSecretFromRecovery();
             this.#needsRecovery = false;
             return true;
         }
@@ -1146,6 +1148,34 @@ export class Wallet<C extends Chain> {
                 ? `"server:${primary.derivedAddress}" or "server:${legacy.derivedAddress}"`
                 : `"server:${primary.derivedAddress}"`;
         throw new Error(`Signer ${tried} is not registered in this wallet.`);
+    }
+
+    /**
+     * Wipe the derivedKeyBytes of the non-selected candidate to reduce key material in memory.
+     */
+    private wipeNonSelectedCandidate(_selected: DerivedServerSigner, other: DerivedServerSigner | null): void {
+        if (other != null && other !== _selected) {
+            secureWipe(other.derivedKeyBytes);
+        }
+    }
+
+    /**
+     * After a server signer is resolved, replace the ServerSignerConfig in #recovery with
+     * an ApiSourcedServerSignerConfig (address-only) so the plaintext secret is no longer
+     * retained in memory for the wallet's lifetime.
+     */
+    private stripSecretFromRecovery(): void {
+        if (
+            this.#recovery != null &&
+            this.#recovery.type === "server" &&
+            !isApiSourcedServerSignerConfig(this.#recovery) &&
+            this.#resolvedServerSigner != null
+        ) {
+            this.#recovery = {
+                type: "server",
+                address: this.#resolvedServerSigner.derivedAddress,
+            } as RecoverySignerConfigForChain<C>;
+        }
     }
 
     /**
@@ -1190,7 +1220,7 @@ export class Wallet<C extends Chain> {
 
     private async withRecoverySigner<T>(operation: () => Promise<T>): Promise<T> {
         const originalSigner = this.signer;
-        if (isApiSourcedServerSignerConfig(this.#recovery)) {
+        if (isApiSourcedServerSignerConfig(this.#recovery) && this.#resolvedServerSigner == null) {
             throw new Error(
                 "Cannot assemble server signer: no secret available. " +
                     'Call wallet.useSigner({ type: "server", secret: ... }) first with the recovery server secret.'
@@ -1206,7 +1236,7 @@ export class Wallet<C extends Chain> {
                     'Call wallet.useSigner({ type: "external-wallet", address: "0x...", onSign: async (tx) => ... }) first.'
             );
         }
-        const recoveryInternalConfig = this.buildInternalSignerConfig(this.#recovery as SignerConfigForChain<C>);
+        const recoveryInternalConfig = this.buildInternalSignerConfig(this.#recovery);
         this.#signer = assembleSigner(this.chain, recoveryInternalConfig, this.#options?.deviceSignerKeyStorage);
 
         try {
@@ -1463,7 +1493,7 @@ export class Wallet<C extends Chain> {
                     'Call wallet.useSigner({ type: "external-wallet", address: "0x...", onSign: async (tx) => ... }) first.'
             );
         }
-        const recoveryInternalConfig = this.buildInternalSignerConfig(this.#recovery as SignerConfigForChain<C>);
+        const recoveryInternalConfig = this.buildInternalSignerConfig(this.#recovery);
         this.#signer = assembleSigner(this.chain, recoveryInternalConfig, this.#options?.deviceSignerKeyStorage);
 
         try {
@@ -1840,7 +1870,9 @@ export class Wallet<C extends Chain> {
     /**
      * Build an InternalSignerConfig from a SignerConfigForChain.
      */
-    private buildInternalSignerConfig(config: SignerConfigForChain<C>): InternalSignerConfig<C> {
+    private buildInternalSignerConfig(
+        config: SignerConfigForChain<C> | ApiSourcedServerSignerConfig
+    ): InternalSignerConfig<C> {
         switch (config.type) {
             case "email":
                 return {
@@ -1894,12 +1926,16 @@ export class Wallet<C extends Chain> {
                     address: this.address,
                 } as InternalSignerConfig<C>;
             case "server": {
-                const { derivedKeyBytes, derivedAddress } = this.resolveServerSignerDerivation(config);
+                const serverConfig = config as ServerSignerConfig | ApiSourcedServerSignerConfig;
+                const resolved = this.resolveServerSignerDerivation(serverConfig);
+                // Copy the derived key bytes so the signer adapter can safely wipe its copy
+                // without corrupting the cached #resolvedServerSigner reference.
+                const keyBytesCopy = new Uint8Array(resolved.derivedKeyBytes);
                 return {
                     type: "server",
-                    derivedKeyBytes,
-                    locator: `server:${derivedAddress}` as ServerSignerLocator,
-                    address: derivedAddress,
+                    derivedKeyBytes: keyBytesCopy,
+                    locator: `server:${resolved.derivedAddress}` as ServerSignerLocator,
+                    address: resolved.derivedAddress,
                 } as InternalSignerConfig<C>;
             }
             default:
@@ -1923,7 +1959,7 @@ export class Wallet<C extends Chain> {
             case "device":
                 return this.#options?.deviceSignerKeyStorage != null;
             case "server":
-                return !isApiSourcedServerSignerConfig(config);
+                return !isApiSourcedServerSignerConfig(config) || this.#resolvedServerSigner != null;
             case "external-wallet":
                 return "onSign" in config && typeof config.onSign === "function";
             default:

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -346,13 +346,12 @@ export class Wallet<C extends Chain> {
     private resolveServerSignerDerivation(
         signer: ServerSignerConfig | ApiSourcedServerSignerConfig
     ): DerivedServerSigner {
-        // If the server signer has already been resolved (e.g. after useSigner), return
-        // the cached derivation directly. The secret may have already been wiped from
-        // #recovery at this point, so we must not attempt to re-derive.
-        if (this.#resolvedServerSigner != null) {
-            return this.#resolvedServerSigner;
-        }
+        // When the signer config has no secret (API-sourced / stripped recovery), we must
+        // rely on the cached resolution — there is nothing to derive from.
         if (isApiSourcedServerSignerConfig(signer)) {
+            if (this.#resolvedServerSigner != null) {
+                return this.#resolvedServerSigner;
+            }
             throw new Error(
                 "Cannot resolve server signer derivation: no secret available and no cached resolution. " +
                     'Call wallet.useSigner({ type: "server", secret: ... }) first.'

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -341,26 +341,38 @@ export class Wallet<C extends Chain> {
 
     /**
      * Resolve which derivation (primary "evm" or legacy chain-specific) to use for a server signer.
-     * Priority: cached resolution → legacy if it matches a known on-chain address → primary.
+     * Priority: cached resolution (with address verification) → legacy if it matches a known
+     * on-chain address → primary.
      */
     private resolveServerSignerDerivation(
         signer: ServerSignerConfig | ApiSourcedServerSignerConfig
     ): DerivedServerSigner {
-        // When the signer config has no secret (API-sourced / stripped recovery), we must
-        // rely on the cached resolution — there is nothing to derive from.
+        // API-sourced config (stripped recovery): verify the cached address matches.
         if (isApiSourcedServerSignerConfig(signer)) {
-            if (this.#resolvedServerSigner != null) {
+            if (this.#resolvedServerSigner != null && this.#resolvedServerSigner.derivedAddress === signer.address) {
                 return this.#resolvedServerSigner;
             }
             throw new Error(
-                "Cannot resolve server signer derivation: no secret available and no cached resolution. " +
+                "Cannot resolve server signer derivation: no secret available and no matching cached resolution. " +
                     'Call wallet.useSigner({ type: "server", secret: ... }) first.'
             );
         }
+
+        // Full config with secret: derive candidates and check if the cache already
+        // holds a matching derivation (ensures consistent picking with resolveServerSigner).
         const { primary, legacy } = this.deriveServerSignerCandidates(signer);
+        if (this.#resolvedServerSigner != null) {
+            const cachedAddr = this.#resolvedServerSigner.derivedAddress;
+            if (cachedAddr === primary.derivedAddress || (legacy != null && cachedAddr === legacy.derivedAddress)) {
+                secureWipe(primary.derivedKeyBytes, legacy?.derivedKeyBytes);
+                return this.#resolvedServerSigner;
+            }
+        }
+
+        // No cache or cache from a different secret — apply heuristic picking.
         if (legacy != null) {
-            // Use legacy if it matches the recovery address or any known on-chain signer
             if (legacy.derivedAddress === this.#apiRecoveryServerSignerAddress) {
+                secureWipe(primary.derivedKeyBytes);
                 return legacy;
             }
             if (
@@ -370,8 +382,10 @@ export class Wallet<C extends Chain> {
                 ) ||
                 this.#apiDelegatedServerSignerAddresses.includes(legacy.derivedAddress)
             ) {
+                secureWipe(primary.derivedKeyBytes);
                 return legacy;
             }
+            secureWipe(legacy.derivedKeyBytes);
         }
         return primary;
     }
@@ -1217,7 +1231,10 @@ export class Wallet<C extends Chain> {
 
     private async withRecoverySigner<T>(operation: () => Promise<T>): Promise<T> {
         const originalSigner = this.signer;
-        if (isApiSourcedServerSignerConfig(this.#recovery) && this.#resolvedServerSigner == null) {
+        if (
+            isApiSourcedServerSignerConfig(this.#recovery) &&
+            (this.#resolvedServerSigner == null || this.#resolvedServerSigner.derivedAddress !== this.#recovery.address)
+        ) {
             throw new Error(
                 "Cannot assemble server signer: no secret available. " +
                     'Call wallet.useSigner({ type: "server", secret: ... }) first with the recovery server secret.'
@@ -1474,7 +1491,10 @@ export class Wallet<C extends Chain> {
         pendingOperation: { type: "signature" | "transaction"; id: string }
     ): Promise<void> {
         const originalSigner = this.#signer;
-        if (isApiSourcedServerSignerConfig(this.#recovery) && this.#resolvedServerSigner == null) {
+        if (
+            isApiSourcedServerSignerConfig(this.#recovery) &&
+            (this.#resolvedServerSigner == null || this.#resolvedServerSigner.derivedAddress !== this.#recovery.address)
+        ) {
             throw new Error(
                 "Cannot resume pending approval: no secret available. " +
                     'Call wallet.useSigner({ type: "server", secret: ... }) first with the recovery server secret.'
@@ -1956,7 +1976,10 @@ export class Wallet<C extends Chain> {
             case "device":
                 return this.#options?.deviceSignerKeyStorage != null;
             case "server":
-                return !isApiSourcedServerSignerConfig(config) || this.#resolvedServerSigner != null;
+                return (
+                    !isApiSourcedServerSignerConfig(config) ||
+                    (this.#resolvedServerSigner != null && this.#resolvedServerSigner.derivedAddress === config.address)
+                );
             case "external-wallet":
                 return "onSign" in config && typeof config.onSign === "function";
             default:

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -1046,6 +1046,7 @@ export class Wallet<C extends Chain> {
         // derivation must be preserved so that withRecoverySigner (addSigner / removeSigner)
         // continues to use the correct primary-or-legacy key for a server recovery signer.
         if (signer.type === "server") {
+            secureWipe(this.#resolvedServerSigner?.derivedKeyBytes);
             this.#resolvedServerSigner = null;
         }
         this.validateSignerInput(signer);
@@ -1158,6 +1159,7 @@ export class Wallet<C extends Chain> {
             legacy != null
                 ? `"server:${primary.derivedAddress}" or "server:${legacy.derivedAddress}"`
                 : `"server:${primary.derivedAddress}"`;
+        secureWipe(primary.derivedKeyBytes, legacy?.derivedKeyBytes);
         throw new Error(`Signer ${tried} is not registered in this wallet.`);
     }
 
@@ -1748,6 +1750,7 @@ export class Wallet<C extends Chain> {
                 if (legacy != null) {
                     addresses.push(legacy.derivedAddress);
                 }
+                secureWipe(primary.derivedKeyBytes, legacy?.derivedKeyBytes);
                 return addresses;
             };
 

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -112,6 +112,7 @@ export class Wallet<C extends Chain> {
     #needsRecovery = false;
     #deviceSignerApproved = false;
     #resolvedServerSigner: DerivedServerSigner | null = null;
+    #resolvedRecoveryServerSigner: DerivedServerSigner | null = null;
     #apiRecoveryServerSignerAddress: string | null = null;
     #apiDelegatedServerSignerAddresses: string[] = [];
     #signerInitialization: Promise<void>;
@@ -347,25 +348,26 @@ export class Wallet<C extends Chain> {
     private resolveServerSignerDerivation(
         signer: ServerSignerConfig | ApiSourcedServerSignerConfig
     ): DerivedServerSigner {
-        // API-sourced config (stripped recovery): verify the cached address matches.
+        // API-sourced config (stripped recovery): use the dedicated recovery cache.
         if (isApiSourcedServerSignerConfig(signer)) {
-            if (this.hasCachedResolutionFor(signer)) {
-                return this.#resolvedServerSigner!;
+            if (this.#resolvedRecoveryServerSigner != null) {
+                return this.#resolvedRecoveryServerSigner;
             }
             throw new Error(
-                "Cannot resolve server signer derivation: no secret available and no matching cached resolution. " +
+                "Cannot resolve server signer derivation: no secret available and no cached recovery resolution. " +
                     'Call wallet.useSigner({ type: "server", secret: ... }) first.'
             );
         }
 
-        // Full config with secret: derive candidates and check if the cache already
-        // holds a matching derivation (ensures consistent picking with resolveServerSigner).
+        // Full config with secret: derive candidates and check if any existing cache
+        // (delegated or recovery) already holds a matching derivation.
         const { primary, legacy } = this.deriveServerSignerCandidates(signer);
-        if (this.#resolvedServerSigner != null) {
-            const cachedAddr = this.#resolvedServerSigner.derivedAddress;
+        const cached = this.#resolvedServerSigner ?? this.#resolvedRecoveryServerSigner;
+        if (cached != null) {
+            const cachedAddr = cached.derivedAddress;
             if (cachedAddr === primary.derivedAddress || (legacy != null && cachedAddr === legacy.derivedAddress)) {
                 secureWipe(primary.derivedKeyBytes, legacy?.derivedKeyBytes);
-                return this.#resolvedServerSigner;
+                return cached;
             }
         }
 
@@ -1042,9 +1044,9 @@ export class Wallet<C extends Chain> {
     })
     public async useSigner(signer: SignerConfigForChain<C>): Promise<void> {
         walletsLogger.info("wallet.useSigner.start");
-        // Only reset when processing a fresh server signer; for other signer types the cached
-        // derivation must be preserved so that withRecoverySigner (addSigner / removeSigner)
-        // continues to use the correct primary-or-legacy key for a server recovery signer.
+        // Reset the delegated signer cache when processing a fresh server signer.
+        // #resolvedRecoveryServerSigner is intentionally preserved — it's set once during
+        // recovery resolution and must survive across useSigner calls.
         if (signer.type === "server") {
             secureWipe(this.#resolvedServerSigner?.derivedKeyBytes);
             this.#resolvedServerSigner = null;
@@ -1145,10 +1147,10 @@ export class Wallet<C extends Chain> {
                 legacy != null &&
                 legacy.derivedAddress === this.#apiRecoveryServerSignerAddress
             ) {
-                this.#resolvedServerSigner = legacy;
+                this.#resolvedRecoveryServerSigner = legacy;
                 this.wipeNonSelectedCandidate(legacy, primary);
             } else {
-                this.#resolvedServerSigner = primary;
+                this.#resolvedRecoveryServerSigner = primary;
                 this.wipeNonSelectedCandidate(primary, legacy);
             }
             this.stripSecretFromRecovery();
@@ -1182,21 +1184,13 @@ export class Wallet<C extends Chain> {
             this.#recovery != null &&
             this.#recovery.type === "server" &&
             !isApiSourcedServerSignerConfig(this.#recovery) &&
-            this.#resolvedServerSigner != null
+            this.#resolvedRecoveryServerSigner != null
         ) {
             this.#recovery = {
                 type: "server",
-                address: this.#resolvedServerSigner.derivedAddress,
+                address: this.#resolvedRecoveryServerSigner.derivedAddress,
             } as RecoverySignerConfigForChain<C>;
         }
-    }
-
-    /**
-     * Check whether the cached server signer resolution matches the given API-sourced config's
-     * address. Returns true when the cache is set and its derived address equals config.address.
-     */
-    private hasCachedResolutionFor(config: ApiSourcedServerSignerConfig): boolean {
-        return this.#resolvedServerSigner != null && this.#resolvedServerSigner.derivedAddress === config.address;
     }
 
     /**
@@ -1241,7 +1235,7 @@ export class Wallet<C extends Chain> {
 
     private async withRecoverySigner<T>(operation: () => Promise<T>): Promise<T> {
         const originalSigner = this.signer;
-        if (isApiSourcedServerSignerConfig(this.#recovery) && !this.hasCachedResolutionFor(this.#recovery)) {
+        if (isApiSourcedServerSignerConfig(this.#recovery) && this.#resolvedRecoveryServerSigner == null) {
             throw new Error(
                 "Cannot assemble server signer: no secret available. " +
                     'Call wallet.useSigner({ type: "server", secret: ... }) first with the recovery server secret.'
@@ -1498,7 +1492,7 @@ export class Wallet<C extends Chain> {
         pendingOperation: { type: "signature" | "transaction"; id: string }
     ): Promise<void> {
         const originalSigner = this.#signer;
-        if (isApiSourcedServerSignerConfig(this.#recovery) && !this.hasCachedResolutionFor(this.#recovery)) {
+        if (isApiSourcedServerSignerConfig(this.#recovery) && this.#resolvedRecoveryServerSigner == null) {
             throw new Error(
                 "Cannot resume pending approval: no secret available. " +
                     'Call wallet.useSigner({ type: "server", secret: ... }) first with the recovery server secret.'
@@ -1953,7 +1947,7 @@ export class Wallet<C extends Chain> {
                 // Copy the derived key bytes so the signer adapter can safely wipe its copy
                 // without corrupting the cached #resolvedServerSigner reference.
                 const keyBytesCopy = new Uint8Array(resolved.derivedKeyBytes);
-                if (resolved !== this.#resolvedServerSigner) {
+                if (resolved !== this.#resolvedServerSigner && resolved !== this.#resolvedRecoveryServerSigner) {
                     secureWipe(resolved.derivedKeyBytes);
                 }
                 return {
@@ -1984,7 +1978,7 @@ export class Wallet<C extends Chain> {
             case "device":
                 return this.#options?.deviceSignerKeyStorage != null;
             case "server":
-                return !isApiSourcedServerSignerConfig(config) || this.hasCachedResolutionFor(config);
+                return !isApiSourcedServerSignerConfig(config) || this.#resolvedRecoveryServerSigner != null;
             case "external-wallet":
                 return "onSign" in config && typeof config.onSign === "function";
             default:

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -349,8 +349,8 @@ export class Wallet<C extends Chain> {
     ): DerivedServerSigner {
         // API-sourced config (stripped recovery): verify the cached address matches.
         if (isApiSourcedServerSignerConfig(signer)) {
-            if (this.#resolvedServerSigner != null && this.#resolvedServerSigner.derivedAddress === signer.address) {
-                return this.#resolvedServerSigner;
+            if (this.hasCachedResolutionFor(signer)) {
+                return this.#resolvedServerSigner!;
             }
             throw new Error(
                 "Cannot resolve server signer derivation: no secret available and no matching cached resolution. " +
@@ -1192,6 +1192,14 @@ export class Wallet<C extends Chain> {
     }
 
     /**
+     * Check whether the cached server signer resolution matches the given API-sourced config's
+     * address. Returns true when the cache is set and its derived address equals config.address.
+     */
+    private hasCachedResolutionFor(config: ApiSourcedServerSignerConfig): boolean {
+        return this.#resolvedServerSigner != null && this.#resolvedServerSigner.derivedAddress === config.address;
+    }
+
+    /**
      * Try to auto-select a passkey credential from registered signers.
      * Returns true if a credential was auto-selected, false if no passkey signers exist.
      * Throws if multiple passkey signers exist (user must specify an id).
@@ -1233,10 +1241,7 @@ export class Wallet<C extends Chain> {
 
     private async withRecoverySigner<T>(operation: () => Promise<T>): Promise<T> {
         const originalSigner = this.signer;
-        if (
-            isApiSourcedServerSignerConfig(this.#recovery) &&
-            (this.#resolvedServerSigner == null || this.#resolvedServerSigner.derivedAddress !== this.#recovery.address)
-        ) {
+        if (isApiSourcedServerSignerConfig(this.#recovery) && !this.hasCachedResolutionFor(this.#recovery)) {
             throw new Error(
                 "Cannot assemble server signer: no secret available. " +
                     'Call wallet.useSigner({ type: "server", secret: ... }) first with the recovery server secret.'
@@ -1493,10 +1498,7 @@ export class Wallet<C extends Chain> {
         pendingOperation: { type: "signature" | "transaction"; id: string }
     ): Promise<void> {
         const originalSigner = this.#signer;
-        if (
-            isApiSourcedServerSignerConfig(this.#recovery) &&
-            (this.#resolvedServerSigner == null || this.#resolvedServerSigner.derivedAddress !== this.#recovery.address)
-        ) {
+        if (isApiSourcedServerSignerConfig(this.#recovery) && !this.hasCachedResolutionFor(this.#recovery)) {
             throw new Error(
                 "Cannot resume pending approval: no secret available. " +
                     'Call wallet.useSigner({ type: "server", secret: ... }) first with the recovery server secret.'
@@ -1982,10 +1984,7 @@ export class Wallet<C extends Chain> {
             case "device":
                 return this.#options?.deviceSignerKeyStorage != null;
             case "server":
-                return (
-                    !isApiSourcedServerSignerConfig(config) ||
-                    (this.#resolvedServerSigner != null && this.#resolvedServerSigner.derivedAddress === config.address)
-                );
+                return !isApiSourcedServerSignerConfig(config) || this.hasCachedResolutionFor(config);
             case "external-wallet":
                 return "onSign" in config && typeof config.onSign === "function";
             default:

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -1111,14 +1111,12 @@ export class Wallet<C extends Chain> {
         if (existingSigners.some((s) => s.locator === `server:${primary.derivedAddress}`)) {
             this.#resolvedServerSigner = primary;
             this.wipeNonSelectedCandidate(primary, legacy);
-            this.stripSecretFromRecovery();
             this.#needsRecovery = false;
             return false;
         }
         if (legacy != null && existingSigners.some((s) => s.locator === `server:${legacy.derivedAddress}`)) {
             this.#resolvedServerSigner = legacy;
             this.wipeNonSelectedCandidate(legacy, primary);
-            this.stripSecretFromRecovery();
             this.#needsRecovery = false;
             return false;
         }


### PR DESCRIPTION
## Description

Resolves [WAL-10250](https://linear.app/crossmint/issue/WAL-10250/review-secret-retention-in-server-signer-memory-model).

The server signer memory model retained both the plaintext master secret and derived private key bytes in memory for the wallet's entire lifetime. The master secret is strictly more sensitive — it can derive keys for all chains/environments. This PR reduces secret exposure by wiping key material as early as possible after use.

### Changes

**Dedicated recovery cache (`wallet.ts`)**
- Split the server signer cache into two purpose-built fields:
  - `#resolvedServerSigner` — delegated signer cache, reset on each `useSigner()` call
  - `#resolvedRecoveryServerSigner` — recovery signer cache, set once during recovery resolution, never cleared
- This ensures `stripSecretFromRecovery()` is safe: the recovery key material persists in `#resolvedRecoveryServerSigner` even when `useSigner()` is called with a different (delegated) signer.

**Secret stripping (`wallet.ts`)**
- `resolveServerSigner()`: when the signer resolves as the **recovery** signer, caches to `#resolvedRecoveryServerSigner` and calls `stripSecretFromRecovery()` to replace `#recovery` with address-only config.
- `resolveServerSignerDerivation()`: for `ApiSourcedServerSignerConfig`, returns `#resolvedRecoveryServerSigner` directly. For `ServerSignerConfig`, derives candidates and checks both caches before falling through to heuristic picking. Wipes temporary candidate key bytes in all paths.
- `wipeNonSelectedCandidate()`: zeros the non-selected candidate's `derivedKeyBytes`.

**Guard updates (`wallet.ts`)**
- `withRecoverySigner()` and `resumePendingDeviceSignerApproval()`: check `#resolvedRecoveryServerSigner == null` to determine if recovery is available.
- `isAutoAssemblableSignerConfig()`: server case checks `#resolvedRecoveryServerSigner != null`.
- `buildInternalSignerConfig()`: copies `derivedKeyBytes`, then wipes the source if it's a short-lived temporary (not either cached reference).

**Key material wiping (`wallet.ts`)**
- `useSigner()`: wipes old `#resolvedServerSigner.derivedKeyBytes` before nulling.
- `resolveServerSigner()` error path: wipes both candidates before throwing.
- `isRecoverySigner()`/`resolveAddresses`: wipes candidates after extracting addresses.

**Signer adapters** (`evm-server-signer.ts`, `solana-server-signer.ts`, `stellar-server-signer.ts`)
- Constructors call `secureWipe(config.derivedKeyBytes)` after building internal key material.

**New utility** (`utils/secure-wipe.ts`)
- `secureWipe(...buffers)`: zeros `Uint8Array` buffers, skips `null`/`undefined`.

## Test plan

* Pre-existing unit tests (server-signers, server-key-derivation, signer-mapping) all pass
* Lint passes (`pnpm lint`)
* CI build & test, lint, and smoke tests all pass

## Package updates

- `@crossmint/wallets-sdk`: patch (changeset: `.changeset/wipe-server-signer-secret-from-memory.md`)

Link to Devin session: https://crossmint.devinenterprise.com/sessions/45a9e564ea2d4fd7ab2f14e4d2d62972
Requested by: @albertoelias-crossmint
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/crossmint-sdk/pull/1911" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->