### PR TITLE
fix(wallets): block device signer on browsers without storage partitioning

### DIFF
--- a/.changeset/block-device-signer-unpartitioned-storage.md
+++ b/.changeset/block-device-signer-unpartitioned-storage.md
@@ -7,5 +7,4 @@ feat: block device signer on browsers without third-party storage partitioning
 
 - `IframeDeviceSignerKeyStorage` now throws `UnsupportedBrowserError` in its constructor when the browser lacks third-party storage partitioning (Chrome < 115, Firefox < 103, or unknown browsers)
 - `CrossmintWalletProvider` catches the error gracefully, logs it, and falls back to non-device signers
-- Exports `hasPartitionedStorage()` utility so consumers can check browser support ahead of time
 - Exports `UnsupportedBrowserError` for consumers to handle programmatically

--- a/.changeset/block-device-signer-unpartitioned-storage.md
+++ b/.changeset/block-device-signer-unpartitioned-storage.md
@@ -1,0 +1,11 @@
+---
+"@crossmint/wallets-sdk": minor
+"@crossmint/client-sdk-react-ui": patch
+---
+
+feat: block device signer on browsers without third-party storage partitioning
+
+- `IframeDeviceSignerKeyStorage` now throws `UnsupportedBrowserError` in its constructor when the browser lacks third-party storage partitioning (Chrome < 115, Firefox < 103, or unknown browsers)
+- `CrossmintWalletProvider` catches the error gracefully, logs it, and falls back to non-device signers
+- Exports `hasPartitionedStorage()` utility so consumers can check browser support ahead of time
+- Exports `UnsupportedBrowserError` for consumers to handle programmatically

--- a/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.test.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.test.tsx
@@ -3,6 +3,20 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { CrossmintWalletProvider } from "./CrossmintWalletProvider";
 
+const { MockUnsupportedBrowserError, mockIframeDeviceSignerKeyStorage } = vi.hoisted(() => {
+    class MockUnsupportedBrowserError extends Error {
+        code = "wallet:environment-invalid";
+        constructor(message: string) {
+            super(message);
+            this.name = "UnsupportedBrowserError";
+        }
+    }
+    return {
+        MockUnsupportedBrowserError,
+        mockIframeDeviceSignerKeyStorage: vi.fn(() => ({ destroy: vi.fn() })),
+    };
+});
+
 vi.mock("@crossmint/client-sdk-react-base", () => ({
     useCrossmint: vi.fn(() => ({
         crossmint: { apiKey: "test-api-key" },
@@ -13,9 +27,8 @@ vi.mock("@crossmint/client-sdk-react-base", () => ({
 }));
 
 vi.mock("@crossmint/wallets-sdk", () => ({
-    IframeDeviceSignerKeyStorage: vi.fn(() => ({
-        destroy: vi.fn(),
-    })),
+    IframeDeviceSignerKeyStorage: mockIframeDeviceSignerKeyStorage,
+    UnsupportedBrowserError: MockUnsupportedBrowserError,
 }));
 
 vi.mock("@/components/auth/PasskeyPrompt", () => ({
@@ -124,5 +137,23 @@ describe("CrossmintWalletProvider", () => {
             </CrossmintWalletProvider>
         );
         expect(screen.getByTestId("wallet-base-provider")).toBeDefined();
+    });
+
+    it("renders without crashing when browser lacks storage partitioning", () => {
+        const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+        mockIframeDeviceSignerKeyStorage.mockImplementationOnce(() => {
+            throw new MockUnsupportedBrowserError("Unsupported browser");
+        });
+
+        render(
+            <CrossmintWalletProvider>
+                <div data-testid="test-child">Test Child</div>
+            </CrossmintWalletProvider>
+        );
+
+        expect(screen.getByTestId("wallet-base-provider")).toBeDefined();
+        expect(screen.getByTestId("test-child")).toBeDefined();
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Unsupported browser"));
+        consoleSpy.mockRestore();
     });
 });

--- a/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.test.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.test.tsx
@@ -153,7 +153,10 @@ describe("CrossmintWalletProvider", () => {
 
         expect(screen.getByTestId("wallet-base-provider")).toBeDefined();
         expect(screen.getByTestId("test-child")).toBeDefined();
-        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Unsupported browser"));
+        expect(consoleSpy).toHaveBeenCalledWith(
+            expect.stringContaining("Unsupported browser"),
+            expect.any(MockUnsupportedBrowserError)
+        );
         consoleSpy.mockRestore();
     });
 });

--- a/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.test.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { CrossmintWalletProvider } from "./CrossmintWalletProvider";
 
-const { MockUnsupportedBrowserError, mockIframeDeviceSignerKeyStorage } = vi.hoisted(() => {
+const { MockUnsupportedBrowserError, mockIframeDeviceSignerKeyStorage, mockLogger } = vi.hoisted(() => {
     class MockUnsupportedBrowserError extends Error {
         code = "wallet:environment-invalid";
         constructor(message: string) {
@@ -14,6 +14,7 @@ const { MockUnsupportedBrowserError, mockIframeDeviceSignerKeyStorage } = vi.hoi
     return {
         MockUnsupportedBrowserError,
         mockIframeDeviceSignerKeyStorage: vi.fn(() => ({ destroy: vi.fn() })),
+        mockLogger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     };
 });
 
@@ -21,9 +22,14 @@ vi.mock("@crossmint/client-sdk-react-base", () => ({
     useCrossmint: vi.fn(() => ({
         crossmint: { apiKey: "test-api-key" },
     })),
+    useLogger: vi.fn(() => mockLogger),
     CrossmintWalletBaseProvider: ({ children }: { children: React.ReactNode }) => (
         <div data-testid="wallet-base-provider">{children}</div>
     ),
+}));
+
+vi.mock("./CrossmintProvider", () => ({
+    LoggerContext: {},
 }));
 
 vi.mock("@crossmint/wallets-sdk", () => ({
@@ -140,7 +146,6 @@ describe("CrossmintWalletProvider", () => {
     });
 
     it("renders without crashing when browser lacks storage partitioning", () => {
-        const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
         mockIframeDeviceSignerKeyStorage.mockImplementationOnce(() => {
             throw new MockUnsupportedBrowserError("Unsupported browser");
         });
@@ -153,10 +158,9 @@ describe("CrossmintWalletProvider", () => {
 
         expect(screen.getByTestId("wallet-base-provider")).toBeDefined();
         expect(screen.getByTestId("test-child")).toBeDefined();
-        expect(consoleSpy).toHaveBeenCalledWith(
+        expect(mockLogger.error).toHaveBeenCalledWith(
             expect.stringContaining("Unsupported browser"),
-            expect.any(MockUnsupportedBrowserError)
+            expect.objectContaining({ error: expect.any(MockUnsupportedBrowserError) })
         );
-        consoleSpy.mockRestore();
     });
 });

--- a/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
@@ -55,7 +55,7 @@ export function CrossmintWalletProvider({
             return new IframeDeviceSignerKeyStorage(crossmint.apiKey);
         } catch (error) {
             if (error instanceof UnsupportedBrowserError) {
-                console.error(`[Crossmint] ${error.message}`);
+                console.error(`[Crossmint] ${error.message}`, error);
                 return undefined;
             }
             throw error;

--- a/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
@@ -6,7 +6,7 @@ import {
     type CreateOnLogin,
     useCrossmint,
 } from "@crossmint/client-sdk-react-base";
-import { IframeDeviceSignerKeyStorage } from "@crossmint/wallets-sdk";
+import { IframeDeviceSignerKeyStorage, UnsupportedBrowserError } from "@crossmint/wallets-sdk";
 
 import { PasskeyPrompt } from "@/components/auth/PasskeyPrompt";
 import { EmailSignersDialog } from "@/components/signers/EmailSignersDialog";
@@ -50,13 +50,20 @@ export function CrossmintWalletProvider({
 }: CrossmintWalletProviderProps) {
     const { crossmint } = useCrossmint("CrossmintWalletProvider must be used within CrossmintProvider");
 
-    const deviceSignerKeyStorage = useMemo(
-        () => new IframeDeviceSignerKeyStorage(crossmint.apiKey),
-        [crossmint.apiKey]
-    );
+    const deviceSignerKeyStorage = useMemo(() => {
+        try {
+            return new IframeDeviceSignerKeyStorage(crossmint.apiKey);
+        } catch (error) {
+            if (error instanceof UnsupportedBrowserError) {
+                console.error(`[Crossmint] ${error.message}`);
+                return undefined;
+            }
+            throw error;
+        }
+    }, [crossmint.apiKey]);
 
     useEffect(() => {
-        return () => deviceSignerKeyStorage.destroy();
+        return () => deviceSignerKeyStorage?.destroy();
     }, [deviceSignerKeyStorage]);
 
     const renderUI = useMemo(() => createRenderWebUI(showOtpSignerPrompt), [showOtpSignerPrompt]);

--- a/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintWalletProvider.tsx
@@ -5,7 +5,9 @@ import {
     type UIRenderProps,
     type CreateOnLogin,
     useCrossmint,
+    useLogger,
 } from "@crossmint/client-sdk-react-base";
+import { LoggerContext } from "./CrossmintProvider";
 import { IframeDeviceSignerKeyStorage, UnsupportedBrowserError } from "@crossmint/wallets-sdk";
 
 import { PasskeyPrompt } from "@/components/auth/PasskeyPrompt";
@@ -49,13 +51,14 @@ export function CrossmintWalletProvider({
     callbacks,
 }: CrossmintWalletProviderProps) {
     const { crossmint } = useCrossmint("CrossmintWalletProvider must be used within CrossmintProvider");
+    const logger = useLogger(LoggerContext);
 
     const deviceSignerKeyStorage = useMemo(() => {
         try {
             return new IframeDeviceSignerKeyStorage(crossmint.apiKey);
         } catch (error) {
             if (error instanceof UnsupportedBrowserError) {
-                console.error(`[Crossmint] ${error.message}`, error);
+                logger.error(`[Crossmint] ${error.message}`, { error });
                 return undefined;
             }
             throw error;

--- a/packages/wallets/src/index.ts
+++ b/packages/wallets/src/index.ts
@@ -2,7 +2,7 @@
 export { createCrossmint, CrossmintWallets } from "./sdk";
 
 // Errors
-export { WalletNotAvailableError, InvalidTransferAmountError } from "./utils/errors";
+export { WalletNotAvailableError, InvalidTransferAmountError, UnsupportedBrowserError } from "./utils/errors";
 
 // API
 export { ApiClient as WalletsApiClient, type RegisterSignerPasskeyParams, type Scope, type TransferScope } from "./api";
@@ -75,4 +75,5 @@ export type { CreateServerSignerParams, ServerSigner } from "./utils/server-sign
 
 // Device Signer Key Storage Interface
 export { DeviceSignerKeyStorage, IframeDeviceSignerKeyStorage, createDeviceSigner } from "./utils/device-signers";
+export { hasPartitionedStorage } from "./utils/device-signers/storage-partitioning";
 export type { BiometricRequestHandler } from "./utils/device-signers";

--- a/packages/wallets/src/index.ts
+++ b/packages/wallets/src/index.ts
@@ -75,5 +75,4 @@ export type { CreateServerSignerParams, ServerSigner } from "./utils/server-sign
 
 // Device Signer Key Storage Interface
 export { DeviceSignerKeyStorage, IframeDeviceSignerKeyStorage, createDeviceSigner } from "./utils/device-signers";
-export { hasPartitionedStorage } from "./utils/device-signers/storage-partitioning";
 export type { BiometricRequestHandler } from "./utils/device-signers";

--- a/packages/wallets/src/utils/device-signers/IframeDeviceSignerKeyStorage.ts
+++ b/packages/wallets/src/utils/device-signers/IframeDeviceSignerKeyStorage.ts
@@ -48,7 +48,7 @@ export class IframeDeviceSignerKeyStorage extends DeviceSignerKeyStorage {
     constructor(apiKey: string) {
         super(apiKey);
 
-        if (!hasPartitionedStorage()) {
+        if (typeof window !== "undefined" && !hasPartitionedStorage()) {
             throw new UnsupportedBrowserError(
                 "Device signer requires a browser with third-party storage partitioning (Chrome ≥ 115, Firefox ≥ 103, or Safari). " +
                     "Without storage partitioning, different embedders of the same iframe can share IndexedDB, " +

--- a/packages/wallets/src/utils/device-signers/IframeDeviceSignerKeyStorage.ts
+++ b/packages/wallets/src/utils/device-signers/IframeDeviceSignerKeyStorage.ts
@@ -2,6 +2,8 @@ import { getEnvironmentForKey, APIKeyEnvironmentPrefix, WithLoggerContext } from
 import { WebAuthnP256 } from "ox";
 import { DeviceSignerKeyStorage } from "./DeviceSignerKeyStorage";
 import { walletsLogger } from "../../logger";
+import { hasPartitionedStorage } from "./storage-partitioning";
+import { UnsupportedBrowserError } from "../errors";
 
 const DEVICE_SIGNER_URL_MAP: Record<APIKeyEnvironmentPrefix, string> = {
     [APIKeyEnvironmentPrefix.DEVELOPMENT]: "https://development.devicekey.store", // "http://localhost:3002"
@@ -45,6 +47,15 @@ export class IframeDeviceSignerKeyStorage extends DeviceSignerKeyStorage {
 
     constructor(apiKey: string) {
         super(apiKey);
+
+        if (!hasPartitionedStorage()) {
+            throw new UnsupportedBrowserError(
+                "Device signer requires a browser with third-party storage partitioning (Chrome ≥ 115, Firefox ≥ 103, or Safari). " +
+                    "Without storage partitioning, different embedders of the same iframe can share IndexedDB, " +
+                    "allowing cross-site key access. See https://developer.chrome.com/blog/storage-partitioning"
+            );
+        }
+
         const environment = getEnvironmentForKey(apiKey);
         if (environment == null) {
             throw new Error("Unable to determine environment from API key");

--- a/packages/wallets/src/utils/device-signers/storage-partitioning.test.ts
+++ b/packages/wallets/src/utils/device-signers/storage-partitioning.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { hasPartitionedStorage } from "./storage-partitioning";
+
+function setUserAgent(ua: string): void {
+    vi.stubGlobal("navigator", { userAgent: ua });
+}
+
+describe("hasPartitionedStorage", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    describe("Chromium-based browsers", () => {
+        it("returns false for Chrome < 115", () => {
+            setUserAgent(
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36"
+            );
+            expect(hasPartitionedStorage()).toBe(false);
+        });
+
+        it("returns true for Chrome 115 (exact boundary)", () => {
+            setUserAgent(
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36"
+            );
+            expect(hasPartitionedStorage()).toBe(true);
+        });
+
+        it("returns true for Chrome > 115", () => {
+            setUserAgent(
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+            );
+            expect(hasPartitionedStorage()).toBe(true);
+        });
+
+        it("returns true for Edge (Chromium-based, version >= 115)", () => {
+            setUserAgent(
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0"
+            );
+            expect(hasPartitionedStorage()).toBe(true);
+        });
+
+        it("returns false for Edge (Chromium-based, version < 115)", () => {
+            setUserAgent(
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36 Edg/110.0.0.0"
+            );
+            expect(hasPartitionedStorage()).toBe(false);
+        });
+    });
+
+    describe("Firefox", () => {
+        it("returns false for Firefox < 103", () => {
+            setUserAgent("Mozilla/5.0 (Windows NT 10.0; rv:102.0) Gecko/20100101 Firefox/102.0");
+            expect(hasPartitionedStorage()).toBe(false);
+        });
+
+        it("returns true for Firefox 103 (exact boundary)", () => {
+            setUserAgent("Mozilla/5.0 (Windows NT 10.0; rv:103.0) Gecko/20100101 Firefox/103.0");
+            expect(hasPartitionedStorage()).toBe(true);
+        });
+
+        it("returns true for Firefox > 103", () => {
+            setUserAgent("Mozilla/5.0 (Windows NT 10.0; rv:121.0) Gecko/20100101 Firefox/121.0");
+            expect(hasPartitionedStorage()).toBe(true);
+        });
+    });
+
+    describe("Safari", () => {
+        it("returns true for Safari", () => {
+            setUserAgent(
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15"
+            );
+            expect(hasPartitionedStorage()).toBe(true);
+        });
+    });
+
+    describe("edge cases", () => {
+        it("returns false for unknown user agent", () => {
+            setUserAgent("SomeCustomBot/1.0");
+            expect(hasPartitionedStorage()).toBe(false);
+        });
+
+        it("returns false for empty user agent", () => {
+            setUserAgent("");
+            expect(hasPartitionedStorage()).toBe(false);
+        });
+
+        it("returns false when navigator is undefined", () => {
+            vi.stubGlobal("navigator", undefined);
+            expect(hasPartitionedStorage()).toBe(false);
+        });
+    });
+});

--- a/packages/wallets/src/utils/device-signers/storage-partitioning.ts
+++ b/packages/wallets/src/utils/device-signers/storage-partitioning.ts
@@ -1,0 +1,50 @@
+/**
+ * Minimum Chromium version that enables third-party storage partitioning by default.
+ * Before Chrome 115, different embedders of the same iframe origin share the same
+ * IndexedDB, which lets an attacker-controlled page access delegated keys.
+ * See https://developer.chrome.com/blog/storage-partitioning
+ */
+const MIN_CHROMIUM_VERSION = 115;
+const MIN_FIREFOX_VERSION = 103;
+
+/**
+ * Detects whether the current browser provides third-party storage partitioning.
+ * Returns `true` when the environment is safe to operate in, `false` otherwise.
+ *
+ * Detection strategy:
+ * - Chromium-based browsers (Chrome, Edge, Opera, etc.): require version >= 115.
+ * - Firefox: ships State Partitioning (dFPI) by default since v103.
+ * - Safari: ships ITP-based storage partitioning.
+ * - Unknown browsers: blocked (fail-safe).
+ */
+export function hasPartitionedStorage(): boolean {
+    if (typeof navigator === "undefined") {
+        return false;
+    }
+
+    const ua = navigator.userAgent;
+
+    // Chromium-based browsers (Chrome, Edge, Opera, Brave, etc.)
+    // all include "Chrome/<version>" in their UA string.
+    const chromiumMatch = ua.match(/Chrome\/(\d+)/);
+    if (chromiumMatch != null) {
+        return parseInt(chromiumMatch[1], 10) >= MIN_CHROMIUM_VERSION;
+    }
+
+    // Firefox ships State Partitioning (dFPI) enabled by default since v103.
+    const firefoxMatch = ua.match(/Firefox\/(\d+)/);
+    if (firefoxMatch != null) {
+        return parseInt(firefoxMatch[1], 10) >= MIN_FIREFOX_VERSION;
+    }
+
+    // Safari ships ITP-based storage partitioning since Safari 11 (2017).
+    // No version gate — any Safari old enough to lack ITP would also lack the
+    // Web Crypto APIs this signer depends on, so it cannot operate regardless.
+    // Safari's UA contains "Safari/" but NOT "Chrome/" (already handled above).
+    if (/Safari\/\d+/.test(ua)) {
+        return true;
+    }
+
+    // Unknown browser — fail-safe: refuse to operate.
+    return false;
+}

--- a/packages/wallets/src/utils/device-signers/storage-partitioning.ts
+++ b/packages/wallets/src/utils/device-signers/storage-partitioning.ts
@@ -23,6 +23,9 @@ export function hasPartitionedStorage(): boolean {
     }
 
     const ua = navigator.userAgent;
+    if (!ua) {
+        return false;
+    }
 
     // Chromium-based browsers (Chrome, Edge, Opera, Brave, etc.)
     // all include "Chrome/<version>" in their UA string.

--- a/packages/wallets/src/utils/errors.ts
+++ b/packages/wallets/src/utils/errors.ts
@@ -75,6 +75,18 @@ export class DeviceSignerNotSupportedError extends CrossmintSDKError {
     }
 }
 
+/**
+ * Thrown when the browser does not support third-party storage partitioning,
+ * making it unsafe to store device-signer keys in IndexedDB. Consumers should
+ * either prompt the user to upgrade their browser or fall back to a non-device
+ * signer (e.g. recovery signer).
+ */
+export class UnsupportedBrowserError extends CrossmintSDKError {
+    constructor(message: string, details?: string) {
+        super(message, WalletErrorCode.ENVIRONMENT_INVALID, details);
+    }
+}
+
 export class InvalidMessageFormatError extends CrossmintSDKError {
     constructor(message: string, details?: string) {
         super(message, WalletErrorCode.MESSAGE_INVALID, details);
@@ -212,4 +224,5 @@ export type WalletError =
     | TransactionHashNotFoundError
     | TransactionFailedError
     | PendingApprovalsError
-    | InvalidAddressError;
+    | InvalidAddressError
+    | UnsupportedBrowserError;


### PR DESCRIPTION
## Description

Browsers without third-party storage partitioning allow different embedders of the same iframe origin to share IndexedDB. This means a malicious page embedding the device signer iframe could access delegated keys stored by a legitimate page. This PR blocks device signer initialization on such browsers.

**Detection logic** (`hasPartitionedStorage()`):
- Chromium ≥ 115: storage partitioning enabled by default
- Firefox ≥ 103: dFPI (State Partitioning) enabled by default
- Safari: ITP provides storage partitioning in all relevant versions
- Unknown browsers: fail-safe blocked

**SDK integration**:
```
IframeDeviceSignerKeyStorage constructor
  → hasPartitionedStorage() ? continue : throw UnsupportedBrowserError
```

`CrossmintWalletProvider` catches `UnsupportedBrowserError`, logs it via `console.error`, and passes `undefined` storage — the wallet falls back to recovery signer transparently. The check is SSR-safe (skipped when `window` is undefined).

Resolves [WAL-10244](https://linear.app/crossmint/issue/WAL-10244/block-device-signer-usage-on-unpartitioned-storage-browsers)

## Test plan

* Unit tests for `hasPartitionedStorage()` covering Chrome < 115, = 115, > 115; Firefox < 103, = 103, > 103; Safari; Edge (Chromium); unknown UA; empty UA; undefined navigator (12 tests)
* Unit test for `CrossmintWalletProvider` verifying it renders without crashing when `IframeDeviceSignerKeyStorage` throws `UnsupportedBrowserError`, and that the error is logged
* All existing `@crossmint/wallets-sdk` tests pass (349 passed)
* All `react-ui` tests pass (21 passed)
* `pnpm lint` passes

## Package updates

* `@crossmint/wallets-sdk`: minor — new `UnsupportedBrowserError` export, constructor guard in `IframeDeviceSignerKeyStorage`
* `@crossmint/client-sdk-react-ui`: patch — graceful error handling in `CrossmintWalletProvider`
* Changeset added: `.changeset/block-device-signer-unpartitioned-storage.md`

Link to Devin session: https://crossmint.devinenterprise.com/sessions/41a35561e9f949ddbfc340dec8abae46
Requested by: @albertoelias-crossmint
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/crossmint-sdk/pull/1912" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->