### PR TITLE
Export private key: add field needed for our export flow audit

### DIFF
--- a/.changeset/floppy-geese-kiss.md
+++ b/.changeset/floppy-geese-kiss.md
@@ -1,0 +1,6 @@
+---
+"@crossmint/client-signers": patch
+"@crossmint/wallets-sdk": patch
+---
+
+Add fields needed for our export flow

--- a/packages/client/signers/src/communications/schemas.ts
+++ b/packages/client/signers/src/communications/schemas.ts
@@ -124,10 +124,7 @@ export const ExportSignerPayloadSchema = {
                 encoding: z
                     .union([z.literal("base58"), z.literal("hex"), z.literal("strkey")])
                     .describe("Encoding format for the private key"),
-                walletAddress: z
-                    .string()
-                    .optional()
-                    .describe("Address of the wallet the signer belongs to"),
+                walletAddress: z.string().optional().describe("Address of the wallet the signer belongs to"),
                 authId: z
                     .string()
                     .optional()

--- a/packages/client/signers/src/communications/schemas.ts
+++ b/packages/client/signers/src/communications/schemas.ts
@@ -124,6 +124,14 @@ export const ExportSignerPayloadSchema = {
                 encoding: z
                     .union([z.literal("base58"), z.literal("hex"), z.literal("strkey")])
                     .describe("Encoding format for the private key"),
+                walletAddress: z
+                    .string()
+                    .optional()
+                    .describe("Address of the wallet the signer belongs to"),
+                authId: z
+                    .string()
+                    .optional()
+                    .describe("Locator of the signer being exported, e.g. 'email:foo@bar.com' or 'phone:+1...'"),
             })
             .describe("Data needed to export the signer"),
     }),

--- a/packages/wallets/src/signers/non-custodial/ncs-signer.ts
+++ b/packages/wallets/src/signers/non-custodial/ncs-signer.ts
@@ -381,6 +381,8 @@ export abstract class NonCustodialSigner implements SignerAdapter {
                 data: {
                     scheme,
                     encoding,
+                    walletAddress: this.config.address,
+                    authId: this.getAuthId(),
                 },
             },
             options: DEFAULT_EVENT_OPTIONS,


### PR DESCRIPTION
## Description

We need to land this to update our signer frame. These fields are marked as optional for backwards compatibility. Old SDK clients will not be submitting these values

<!-- Human must describe here why are we doing this change, and roughly what it does -->
<!-- Optional screenshot or video -->

## Test plan

Tested a full e2e flow

<!--
  Example:
   * Unit tests which cover functionality X, Y, Z
   * V was tested via UI tests
   * W was tested manually
-->

## Package updates

<!-- 
  List any package updates and ensure you've added the necessary changesets, running `pnpm change:add` to do so.
-->