### PR TITLE
docs: add checkout product to SDK reference docs generation

### DIFF
--- a/.changeset/checkout-sdk-reference.md
+++ b/.changeset/checkout-sdk-reference.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+---
+
+Add checkout product to SDK reference docs generation pipeline

--- a/.github/workflows/sdk-reference-docs-generate.yml
+++ b/.github/workflows/sdk-reference-docs-generate.yml
@@ -25,9 +25,9 @@ on:
     workflow_dispatch:
         inputs:
             packages:
-                description: "Comma-separated list of packages to generate docs for (react-ui, react-native, node-wallets, checkout). Defaults to all."
+                description: "Comma-separated list of packages to generate docs for (react-ui, react-native, node-wallets, react-checkout). Defaults to all."
                 required: false
-                default: "react-ui,react-native,node-wallets,checkout"
+                default: "react-ui,react-native,node-wallets,react-checkout"
                 type: string
 
 permissions:
@@ -54,13 +54,13 @@ jobs:
             - name: Parse package selection
               id: packages
               env:
-                  PACKAGES_INPUT: ${{ inputs.packages || 'react-ui,react-native,node-wallets,checkout' }}
+                  PACKAGES_INPUT: ${{ inputs.packages || 'react-ui,react-native,node-wallets,react-checkout' }}
               run: |
                   PACKAGES="$PACKAGES_INPUT"
                   echo "react_ui=false" >> $GITHUB_OUTPUT
                   echo "react_native=false" >> $GITHUB_OUTPUT
                   echo "node_wallets=false" >> $GITHUB_OUTPUT
-                  echo "checkout=false" >> $GITHUB_OUTPUT
+                  echo "react_checkout=false" >> $GITHUB_OUTPUT
                   if echo ",$PACKAGES," | grep -q ",react-ui,"; then
                     echo "react_ui=true" >> $GITHUB_OUTPUT
                   fi
@@ -70,8 +70,8 @@ jobs:
                   if echo ",$PACKAGES," | grep -q ",node-wallets,"; then
                     echo "node_wallets=true" >> $GITHUB_OUTPUT
                   fi
-                  if echo ",$PACKAGES," | grep -q ",checkout,"; then
-                    echo "checkout=true" >> $GITHUB_OUTPUT
+                  if echo ",$PACKAGES," | grep -q ",react-checkout,"; then
+                    echo "react_checkout=true" >> $GITHUB_OUTPUT
                   fi
 
             - name: Generate React UI docs (wallets)
@@ -80,7 +80,7 @@ jobs:
               run: pnpm generate:docs --product wallets
 
             - name: Generate React UI docs (checkout)
-              if: steps.packages.outputs.checkout == 'true'
+              if: steps.packages.outputs.react_checkout == 'true'
               working-directory: packages/client/ui/react-ui
               run: pnpm generate:docs --product checkout
 
@@ -106,7 +106,7 @@ jobs:
                   REACT_UI_ENABLED: ${{ steps.packages.outputs.react_ui }}
                   REACT_NATIVE_ENABLED: ${{ steps.packages.outputs.react_native }}
                   NODE_WALLETS_ENABLED: ${{ steps.packages.outputs.node_wallets }}
-                  CHECKOUT_ENABLED: ${{ steps.packages.outputs.checkout }}
+                  CHECKOUT_ENABLED: ${{ steps.packages.outputs.react_checkout }}
               run: |
                   mkdir -p sdk-reference/wallets/react
                   mkdir -p sdk-reference/wallets/react-native
@@ -159,4 +159,4 @@ jobs:
                   token: ${{ steps.generate_app_token.outputs.token }}
                   repository: Paella-Labs/crossbit-main
                   event-type: sdk-reference-docs-update
-                  client-payload: '{"run_id": "${{ github.run_id }}", "packages": ${{ toJSON(inputs.packages || ''react-ui,react-native,node-wallets,checkout'') }}, "source_ref": ${{ toJSON(github.ref_name) }}}'
+                  client-payload: '{"run_id": "${{ github.run_id }}", "packages": ${{ toJSON(inputs.packages || ''react-ui,react-native,node-wallets,react-checkout'') }}, "source_ref": ${{ toJSON(github.ref_name) }}}'

--- a/.github/workflows/sdk-reference-docs-generate.yml
+++ b/.github/workflows/sdk-reference-docs-generate.yml
@@ -20,12 +20,14 @@ on:
             - "packages/client/ui/react-native/tsconfig.typedoc.json"
             - "packages/client/ui/scripts/**"
             - "packages/client/react-base/src/**"
+            - "packages/client/base/src/types/embed/**"
+            - "packages/client/base/src/types/hosted/**"
     workflow_dispatch:
         inputs:
             packages:
                 description: "Comma-separated list of packages to generate docs for (react-ui, react-native, node-wallets). Defaults to all."
                 required: false
-                default: "react-ui,react-native,node-wallets"
+                default: "react-ui,react-native,node-wallets,checkout"
                 type: string
 
 permissions:
@@ -52,12 +54,13 @@ jobs:
             - name: Parse package selection
               id: packages
               env:
-                  PACKAGES_INPUT: ${{ inputs.packages || 'react-ui,react-native,node-wallets' }}
+                  PACKAGES_INPUT: ${{ inputs.packages || 'react-ui,react-native,node-wallets,checkout' }}
               run: |
                   PACKAGES="$PACKAGES_INPUT"
                   echo "react_ui=false" >> $GITHUB_OUTPUT
                   echo "react_native=false" >> $GITHUB_OUTPUT
                   echo "node_wallets=false" >> $GITHUB_OUTPUT
+                  echo "checkout=false" >> $GITHUB_OUTPUT
                   if echo ",$PACKAGES," | grep -q ",react-ui,"; then
                     echo "react_ui=true" >> $GITHUB_OUTPUT
                   fi
@@ -67,11 +70,19 @@ jobs:
                   if echo ",$PACKAGES," | grep -q ",node-wallets,"; then
                     echo "node_wallets=true" >> $GITHUB_OUTPUT
                   fi
+                  if echo ",$PACKAGES," | grep -q ",checkout,"; then
+                    echo "checkout=true" >> $GITHUB_OUTPUT
+                  fi
 
-            - name: Generate React UI docs
+            - name: Generate React UI docs (wallets)
               if: steps.packages.outputs.react_ui == 'true'
               working-directory: packages/client/ui/react-ui
-              run: pnpm generate:docs
+              run: pnpm generate:docs --product wallets
+
+            - name: Generate React UI docs (checkout)
+              if: steps.packages.outputs.checkout == 'true'
+              working-directory: packages/client/ui/react-ui
+              run: pnpm generate:docs --product checkout
 
             - name: Generate React Native docs
               if: steps.packages.outputs.react_native == 'true'
@@ -95,10 +106,12 @@ jobs:
                   REACT_UI_ENABLED: ${{ steps.packages.outputs.react_ui }}
                   REACT_NATIVE_ENABLED: ${{ steps.packages.outputs.react_native }}
                   NODE_WALLETS_ENABLED: ${{ steps.packages.outputs.node_wallets }}
+                  CHECKOUT_ENABLED: ${{ steps.packages.outputs.checkout }}
               run: |
                   mkdir -p sdk-reference/wallets/react
                   mkdir -p sdk-reference/wallets/react-native
                   mkdir -p sdk-reference/wallets/typescript
+                  mkdir -p sdk-reference/checkout/react
 
                   if [ "$REACT_UI_ENABLED" == "true" ] && [ -d packages/client/ui/react-ui/docs/wallets ]; then
                     cp -r packages/client/ui/react-ui/docs/wallets/. sdk-reference/wallets/react/
@@ -110,6 +123,10 @@ jobs:
 
                   if [ "$NODE_WALLETS_ENABLED" == "true" ] && [ -d packages/wallets/docs ]; then
                     cp -r packages/wallets/docs/. sdk-reference/wallets/typescript/
+                  fi
+
+                  if [ "$CHECKOUT_ENABLED" == "true" ] && [ -d packages/client/ui/react-ui/docs/checkout ]; then
+                    cp -r packages/client/ui/react-ui/docs/checkout/. sdk-reference/checkout/react/
                   fi
 
             - name: Verify at least one package was generated
@@ -142,4 +159,4 @@ jobs:
                   token: ${{ steps.generate_app_token.outputs.token }}
                   repository: Paella-Labs/crossbit-main
                   event-type: sdk-reference-docs-update
-                  client-payload: '{"run_id": "${{ github.run_id }}", "packages": ${{ toJSON(inputs.packages || ''react-ui,react-native,node-wallets'') }}, "source_ref": ${{ toJSON(github.ref_name) }}}'
+                  client-payload: '{"run_id": "${{ github.run_id }}", "packages": ${{ toJSON(inputs.packages || ''react-ui,react-native,node-wallets,checkout'') }}, "source_ref": ${{ toJSON(github.ref_name) }}}'

--- a/.github/workflows/sdk-reference-docs-generate.yml
+++ b/.github/workflows/sdk-reference-docs-generate.yml
@@ -25,7 +25,7 @@ on:
     workflow_dispatch:
         inputs:
             packages:
-                description: "Comma-separated list of packages to generate docs for (react-ui, react-native, node-wallets). Defaults to all."
+                description: "Comma-separated list of packages to generate docs for (react-ui, react-native, node-wallets, checkout). Defaults to all."
                 required: false
                 default: "react-ui,react-native,node-wallets,checkout"
                 type: string

--- a/packages/client/ui/react-ui/examples.json
+++ b/packages/client/ui/react-ui/examples.json
@@ -40,5 +40,30 @@
         "code": "import { ExportPrivateKeyButton } from \"@crossmint/client-sdk-react-ui\";\n\nfunction WalletSettings() {\n    return (\n        <div>\n            <h3>Export Private Key</h3>\n            <ExportPrivateKeyButton\n                appearance={{\n                    colors: { border: \"#e2e8f0\" },\n                    borderRadius: \"12px\",\n                }}\n            />\n        </div>\n    );\n}",
         "language": "tsx",
         "note": "Only works with email and phone signers. Will not render for passkey or external wallet signers."
+    },
+    "checkoutProviderSetup": {
+        "code": "import {\n    CrossmintProvider,\n    CrossmintCheckoutProvider,\n} from \"@crossmint/client-sdk-react-ui\";\n\nfunction App() {\n    return (\n        <CrossmintProvider apiKey=\"YOUR_CLIENT_API_KEY\">\n            <CrossmintCheckoutProvider>\n                {/* Your checkout components */}\n            </CrossmintCheckoutProvider>\n        </CrossmintProvider>\n    );\n}",
+        "language": "tsx"
+    },
+    "checkoutQuickExample": {
+        "code": "import { CrossmintEmbeddedCheckout } from \"@crossmint/client-sdk-react-ui\";\n\nfunction CheckoutPage() {\n    return (\n        <CrossmintEmbeddedCheckout\n            lineItems={{\n                collectionLocator: \"crossmint:YOUR_COLLECTION_ID\",\n            }}\n            payment={{\n                crypto: { enabled: true },\n                fiat: { enabled: true },\n            }}\n        />\n    );\n}",
+        "language": "tsx"
+    },
+    "CrossmintCheckoutProvider": {
+        "code": "import {\n    CrossmintProvider,\n    CrossmintCheckoutProvider,\n} from \"@crossmint/client-sdk-react-ui\";\n\nfunction App() {\n    return (\n        <CrossmintProvider apiKey=\"YOUR_CLIENT_API_KEY\">\n            <CrossmintCheckoutProvider>\n                {/* Your checkout components */}\n            </CrossmintCheckoutProvider>\n        </CrossmintProvider>\n    );\n}",
+        "language": "tsx",
+        "note": "CrossmintCheckoutProvider must be nested inside CrossmintProvider."
+    },
+    "useCrossmintCheckout": {
+        "code": "import { useCrossmintCheckout } from \"@crossmint/client-sdk-react-ui\";\n\nfunction OrderStatus() {\n    const { order } = useCrossmintCheckout();\n\n    if (!order) return <p>No active order</p>;\n\n    return (\n        <div>\n            <p>Order ID: {order.orderId}</p>\n            <p>Phase: {order.phase}</p>\n        </div>\n    );\n}",
+        "language": "tsx"
+    },
+    "CrossmintEmbeddedCheckout": {
+        "code": "import { CrossmintEmbeddedCheckout } from \"@crossmint/client-sdk-react-ui\";\n\nfunction Checkout() {\n    return (\n        <CrossmintEmbeddedCheckout\n            lineItems={{\n                collectionLocator: \"crossmint:YOUR_COLLECTION_ID\",\n            }}\n            payment={{\n                crypto: { enabled: true },\n                fiat: { enabled: true },\n            }}\n            recipient={{ email: \"buyer@example.com\" }}\n        />\n    );\n}",
+        "language": "tsx"
+    },
+    "CrossmintHostedCheckout": {
+        "code": "import { CrossmintHostedCheckout } from \"@crossmint/client-sdk-react-ui\";\n\nfunction BuyButton() {\n    return (\n        <CrossmintHostedCheckout\n            lineItems={{\n                collectionLocator: \"crossmint:YOUR_COLLECTION_ID\",\n            }}\n            payment={{\n                crypto: { enabled: true },\n                fiat: { enabled: true },\n            }}\n        />\n    );\n}",
+        "language": "tsx"
     }
 }

--- a/packages/client/ui/react-ui/scripts/generate-reference.mjs
+++ b/packages/client/ui/react-ui/scripts/generate-reference.mjs
@@ -42,6 +42,32 @@ see the [previous version of this page](/sdk-reference/wallets/v0/react/{page}) 
             quickExampleIntro: "Once providers are set up, use hooks to access wallet state:",
         },
     },
+    checkout: {
+        outdir: "checkout",
+        navPrefix: "sdk-reference/checkout/react",
+        title: "React SDK",
+        description: "React SDK reference for Crossmint checkout",
+        packageName: "@crossmint/client-sdk-react-ui",
+        npmUrl: "https://www.npmjs.com/package/@crossmint/client-sdk-react-ui",
+        installSnippet: "client-sdk-react-ui-installation-cmd.mdx",
+        intro: "The Crossmint React SDK (`@crossmint/client-sdk-react-ui`) provides React components and hooks for integrating Crossmint checkout into your application. It supports both embedded checkout (inline iframe) and hosted checkout (popup/new-tab button).",
+        exports: [
+            "CrossmintProvider",
+            "CrossmintCheckoutProvider",
+            "useCrossmintCheckout",
+            "CrossmintEmbeddedCheckout",
+            "CrossmintHostedCheckout",
+        ],
+        descriptions: {
+            CrossmintProvider: "SDK initialization (required for all Crossmint features)",
+            CrossmintCheckoutProvider: "Checkout order state management",
+        },
+        getStartedExamples: {
+            setup: "checkoutProviderSetup",
+            quickExample: "checkoutQuickExample",
+            quickExampleIntro: "Once providers are set up, use the checkout components to accept payments:",
+        },
+    },
 };
 
 generate({

--- a/packages/client/ui/react-ui/tsconfig.typedoc.json
+++ b/packages/client/ui/react-ui/tsconfig.typedoc.json
@@ -7,6 +7,8 @@
             "@/*": ["src/*"],
             "@crossmint/client-sdk-react-base": ["../../react-base/src/index.ts"],
             "@crossmint/client-sdk-react-base/*": ["../../react-base/src/*"],
+            "@crossmint/client-sdk-base": ["../../base/src/index.ts"],
+            "@crossmint/client-sdk-base/*": ["../../base/src/*"],
             "@crossmint/wallets-sdk": ["../../../wallets/src/index.ts"],
             "@crossmint/wallets-sdk/*": ["../../../wallets/src/*"]
         },

--- a/packages/client/ui/react-ui/tsconfig.typedoc.json
+++ b/packages/client/ui/react-ui/tsconfig.typedoc.json
@@ -1,7 +1,6 @@
 {
     "extends": "../../../../tsconfig.base.json",
     "compilerOptions": {
-        "rootDir": "src",
         "baseUrl": ".",
         "paths": {
             "@/*": ["src/*"],
@@ -10,13 +9,21 @@
             "@crossmint/client-sdk-base": ["../../base/src/index.ts"],
             "@crossmint/client-sdk-base/*": ["../../base/src/*"],
             "@crossmint/wallets-sdk": ["../../../wallets/src/index.ts"],
-            "@crossmint/wallets-sdk/*": ["../../../wallets/src/*"]
+            "@crossmint/wallets-sdk/*": ["../../../wallets/src/*"],
+            "@crossmint/common-sdk-base": ["../../../common/base/src/index.ts"],
+            "@crossmint/common-sdk-base/*": ["../../../common/base/src/*"]
         },
         "jsx": "react-jsx",
         "module": "commonjs",
         "esModuleInterop": true,
         "skipLibCheck": true
     },
-    "include": ["src/**/*"],
+    "include": [
+        "src/**/*",
+        "../../base/src/**/*",
+        "../../react-base/src/**/*",
+        "../../../wallets/src/**/*",
+        "../../../common/base/src/**/*"
+    ],
     "exclude": ["__tests__"]
 }

--- a/packages/client/ui/react-ui/typedoc.json
+++ b/packages/client/ui/react-ui/typedoc.json
@@ -1,5 +1,9 @@
 {
-    "entryPoints": ["src/index.ts"],
+    "entryPoints": [
+        "src/index.ts",
+        "../../base/src/types/embed/v3/CrossmintEmbeddedCheckoutV3Props.ts",
+        "../../base/src/types/hosted/v3/CrossmintHostedCheckoutV3Props.ts"
+    ],
     "tsconfig": "tsconfig.typedoc.json",
     "json": "api.json",
     "skipErrorChecking": true,

--- a/packages/client/ui/react-ui/typedoc.json
+++ b/packages/client/ui/react-ui/typedoc.json
@@ -2,7 +2,8 @@
     "entryPoints": [
         "src/index.ts",
         "../../base/src/types/embed/v3/CrossmintEmbeddedCheckoutV3Props.ts",
-        "../../base/src/types/hosted/v3/CrossmintHostedCheckoutV3Props.ts"
+        "../../base/src/types/hosted/v3/CrossmintHostedCheckoutV3Props.ts",
+        "../../../common/base/src/types/uiconfig.ts"
     ],
     "tsconfig": "tsconfig.typedoc.json",
     "json": "api.json",

--- a/packages/client/ui/scripts/generate-reference.mjs
+++ b/packages/client/ui/scripts/generate-reference.mjs
@@ -5,8 +5,9 @@
  * Pipeline: TypeDoc (api.json) + examples.json → Mintlify MDX pages
  *
  * Props, methods, and descriptions are auto-extracted from source JSDoc.
- * MANUAL_RETURNS and EXPANDABLE_CHILDREN are the only hardcoded sections —
- * needed because TypeDoc can't resolve types across packages in our monorepo.
+ * Expandable sub-properties are auto-resolved from TypeDoc type references
+ * where possible. MANUAL_RETURNS and FALLBACK_EXPANDABLE_CHILDREN handle
+ * edge cases where TypeDoc can't resolve types (e.g. cross-package generics).
  *
  * This module exports a `generate(config)` function used by platform-specific
  * callers in react-ui/ and react-native/.
@@ -20,10 +21,9 @@ import { join, resolve } from "path";
 // =============================================================================
 
 /**
- * Expandable sub-properties for props/returns that reference cross-package types
- * TypeDoc can't inline. Keyed by the property name within a component/hook.
- *
- * createOnLogin and getOrCreateWallet share the same WalletArgsFor<Chain> shape.
+ * Fallback expandable sub-properties for generic cross-package types that
+ * TypeDoc can't resolve even with path mappings (e.g. WalletArgsFor<Chain>).
+ * The auto-resolver handles most cases; these are only used when it fails.
  */
 const WALLET_CREATE_ARGS_CHILDREN = [
     {
@@ -297,19 +297,86 @@ function buildFieldsSection(
 }
 
 /**
- * Attaches expandable children to props/return members whose names
- * have a matching entry. This enriches cross-package reference types
- * with expandable sub-property documentation.
+ * Auto-resolves expandable children from TypeDoc type references.
+ * For each member whose type is a reference to a known interface/type-alias
+ * with properties, attaches those properties as `children` for rendering
+ * as expandable sub-fields.
+ *
+ * Falls back to the manual `expandableChildren` map for types that
+ * TypeDoc can't resolve (e.g. cross-package generics like WalletArgsFor<Chain>).
  */
-function attachExpandableChildren(members, expandableChildren) {
+function attachExpandableChildren(members, expandableChildren, { byId, allExports }) {
     if (!members?.length) return members;
     return members.map((m) => {
-        const children = expandableChildren[m.name];
-        if (children && !m.children?.length) {
-            return { ...m, children };
+        // Already has children (e.g. from inline reflection type) — skip
+        if (m.children?.length) return m;
+
+        // Try auto-resolving from TypeDoc type reference
+        const resolved = autoResolveChildren(m.type, { byId, allExports });
+        if (resolved?.length) {
+            return { ...m, children: resolved };
         }
+
+        // Fallback: use manual expandableChildren map (keyed by prop name)
+        const manual = expandableChildren[m.name];
+        if (manual) {
+            return { ...m, children: manual };
+        }
+
         return m;
     });
+}
+
+/**
+ * Given a TypeDoc type descriptor, attempts to resolve it to a list of
+ * child property members. Works for:
+ * - Direct references to interfaces/type-aliases with children
+ * - Reflection types (inline object types)
+ * - Intersection types (merges properties from all branches)
+ *
+ * Returns null if the type can't be resolved to properties.
+ */
+function autoResolveChildren(type, { byId, allExports }) {
+    if (!type) return null;
+
+    if (type.type === "reflection" && type.declaration?.children?.length) {
+        return type.declaration.children;
+    }
+
+    if (type.type === "reference" && type.target != null) {
+        // Try numeric ID first
+        if (typeof type.target === "number") {
+            const resolved = byId.get(type.target);
+            if (resolved?.children?.length) return resolved.children;
+            // Type alias with a nested type (e.g. type Foo = { ... })
+            if (resolved?.type?.type === "reflection" && resolved.type.declaration?.children?.length) {
+                return resolved.type.declaration.children;
+            }
+        }
+
+        // Fallback: look up by name in flattened exports
+        const name = type.target?.qualifiedName || type.name;
+        if (name) {
+            const matches = (allExports || []).filter((c) => c.name === name && (c.kind === 256 || c.kind === 2097152));
+            for (const match of matches) {
+                if (match.children?.length) return match.children;
+                if (match.type?.type === "reflection" && match.type.declaration?.children?.length) {
+                    return match.type.declaration.children;
+                }
+            }
+        }
+    }
+
+    if (type.type === "intersection" && type.types?.length) {
+        const merged = [];
+        for (const t of type.types) {
+            const children = autoResolveChildren(t, { byId, allExports });
+            if (children) merged.push(...children);
+        }
+        return merged.length ? merged : null;
+    }
+
+    return null;
 }
 
 // =============================================================================
@@ -353,6 +420,18 @@ export function generate(config) {
     // TypeDoc JSON helpers (scoped to this api.json)
     // =========================================================================
 
+    // When multiple entry points are used, TypeDoc wraps exports in module
+    // nodes (kind: 2). Flatten all top-level modules so findByName can locate
+    // exports regardless of module structure.
+    const allExports = [];
+    for (const child of api.children || []) {
+        if (child.kind === 2 && child.children?.length) {
+            allExports.push(...child.children);
+        } else {
+            allExports.push(child);
+        }
+    }
+
     const byId = new Map();
     (function index(node) {
         if (node.id != null) byId.set(node.id, node);
@@ -360,7 +439,7 @@ export function generate(config) {
     })(api);
 
     function findByName(name, kind) {
-        return api.children.find((c) => c.name === name && (kind == null || c.kind === kind));
+        return allExports.find((c) => c.name === name && (kind == null || c.kind === kind));
     }
 
     // =========================================================================
@@ -386,28 +465,77 @@ export function generate(config) {
                 allProps.push(...t.declaration.children);
             } else if (t.type === "intersection") {
                 t.types.forEach(collectProps);
+            } else if (t.type === "union") {
+                // For union types (A | B), merge all unique props from all branches.
+                // Props typed as `never` (serialized as "undefined") are discriminators — skip them.
+                // Props present in all branches keep their required status; others become optional.
+                const isNeverType = (prop) =>
+                    prop.type?.type === "intrinsic" && (prop.type.name === "undefined" || prop.type.name === "never");
+
+                const branchProps = [];
+                for (const ut of t.types) {
+                    const branch = [];
+                    const saved = allProps;
+                    allProps = branch;
+                    collectProps(ut);
+                    allProps = saved;
+                    branchProps.push(branch.filter((p) => !isNeverType(p)));
+                }
+                const seen = new Map();
+                const branchCount = branchProps.length;
+                for (const branch of branchProps) {
+                    for (const prop of branch) {
+                        if (!seen.has(prop.name)) {
+                            seen.set(prop.name, { prop, count: 1 });
+                        } else {
+                            seen.get(prop.name).count++;
+                        }
+                    }
+                }
+                // Props not in all branches become optional
+                for (const { prop, count } of seen.values()) {
+                    if (count < branchCount && !prop.flags?.isOptional) {
+                        allProps.push({ ...prop, flags: { ...prop.flags, isOptional: true } });
+                    } else {
+                        allProps.push(prop);
+                    }
+                }
             } else if (t.type === "reference" && t.target != null) {
                 const resolved = typeof t.target === "number" ? byId.get(t.target) : null;
                 if (resolved?.children) {
                     allProps.push(...resolved.children);
                     return;
                 }
+                // If resolved is a type alias, check its underlying type
+                if (resolved?.type) {
+                    collectProps(resolved.type);
+                    return;
+                }
                 // Fallback: target is an object descriptor or unresolved.
                 // Look up by qualifiedName/name; prefer the variant that has children.
                 const name = t.target?.qualifiedName || t.name;
                 if (name) {
-                    const matches = api.children.filter(
+                    const matches = allExports.filter(
                         (c) => c.name === name && (c.kind === KIND.INTERFACE || c.kind === KIND.TYPE_ALIAS)
                     );
                     const withChildren = matches.find((m) => m.children?.length);
                     if (withChildren) {
                         allProps.push(...withChildren.children);
+                    } else {
+                        // Try resolving the type alias's underlying type
+                        const withType = matches.find((m) => m.type);
+                        if (withType) collectProps(withType.type);
                     }
                 }
             }
         }
         collectProps(type);
-        return allProps;
+        // Deduplicate by name (keep first occurrence)
+        const unique = new Map();
+        for (const p of allProps) {
+            if (!unique.has(p.name)) unique.set(p.name, p);
+        }
+        return [...unique.values()];
     }
 
     function extractReturnMembers(node) {
@@ -423,7 +551,7 @@ export function generate(config) {
             // Look up the type by name; prefer the variant that has children.
             const name = retType.target?.qualifiedName || retType.name;
             if (name) {
-                const matches = api.children.filter(
+                const matches = allExports.filter(
                     (c) => c.name === name && (c.kind === KIND.INTERFACE || c.kind === KIND.TYPE_ALIAS)
                 );
                 const withChildren = matches.find((m) => m.children?.length);
@@ -592,7 +720,7 @@ export function generate(config) {
             }
 
             let props = extractProps(node);
-            props = attachExpandableChildren(props, expandableChildren);
+            props = attachExpandableChildren(props, expandableChildren, { byId, allExports });
             const fields = buildFieldsSection(props, { skipChildren: true });
             if (fields) {
                 emit("### Props");
@@ -650,7 +778,7 @@ export function generate(config) {
             // Manual returns take priority — they exist precisely because
             // TypeDoc can't resolve the cross-package types
             let members = manualReturns[name] || extractReturnMembers(node);
-            members = attachExpandableChildren(members, expandableChildren);
+            members = attachExpandableChildren(members, expandableChildren, { byId, allExports });
             const fields = buildFieldsSection(members, { expandableTitle: "parameters", showRequired: false });
             if (fields) {
                 emit("### Returns");
@@ -727,7 +855,7 @@ export function generate(config) {
             }
 
             let props = extractProps(node);
-            props = attachExpandableChildren(props, expandableChildren);
+            props = attachExpandableChildren(props, expandableChildren, { byId, allExports });
             const fields = buildFieldsSection(props, { skipChildren: true });
             if (fields) {
                 emit("### Props");


### PR DESCRIPTION
## Description

Adds checkout as a new product to the SDK reference docs generation pipeline, alongside wallets. This allows the same `generate-reference.mjs` engine to produce Mintlify MDX pages for checkout components (`CrossmintEmbeddedCheckout`, `CrossmintHostedCheckout`), providers (`CrossmintCheckoutProvider`), and hooks (`useCrossmintCheckout`).

Also enhances the shared generator engine to **auto-resolve expandable prop sub-properties** from TypeDoc type references, replacing the need for hardcoded `EXPANDABLE_CHILDREN` definitions. The generator now:
- Resolves numeric type IDs via the `byId` map
- Falls back to name-based lookup in flattened exports
- Handles union types (`A | B`) by merging unique props across branches and filtering out `never`-typed discriminators
- Keeps the existing wallets fallback for truly unresolvable generics (`WalletArgsFor<Chain>`)

Additionally, expands TypeDoc's compilation scope to include `@crossmint/common-sdk-base`, which:
- Properly resolves `UIConfig` (previously rendered as `any`) with auto-expanded children
- Resolves `CrossmintProvider` props that were previously hidden (apiKey, appId, jwt, etc.)
- Correctly displays `ConsoleLogLevel` type instead of `any`

Key changes:
```
typedoc.json             — add base + common-sdk-base type files as entry points
tsconfig.typedoc.json    — add path mappings for all cross-package types, expand include scope
generate-reference.mjs   — checkout product config + auto-resolve engine
  (react-ui/scripts/)
generate-reference.mjs   — union handling, module flattening, autoResolveChildren
  (ui/scripts/)
sdk-reference-docs-generate.yml — react-checkout package in workflow
```

## Test plan

* Ran `node scripts/generate-reference.mjs --product checkout` — generates 4 pages (62, 78, 50, 150 lines)
* Ran `node scripts/generate-reference.mjs --product wallets` — generates correctly with improved type resolution (59, 73, 130, 151 lines)
* Verified `appearance` now shows `type="UIConfig"` with auto-expanded children (borderRadius, colors, fonts, etc.) — was `type="any"` before
* Verified `CrossmintProvider` now shows all public props (apiKey, appId, jwt, etc.) — previously only showed consoleLogLevel
* Verified auto-resolved expandable children: `payment` prop correctly expands to show `crypto`, `fiat`, `defaultMethod`, `receiptEmail`
* Verified union handling: `CrossmintEmbeddedCheckoutV3Props` (ExistingOrder | NewOrder) merges props correctly, filters `never`-typed discriminators
* `pnpm lint:fix` passes

## Package updates

* `@crossmint/client-sdk-react-ui` — patch (changeset added via `.changeset/checkout-sdk-reference.md`)

Link to Devin session: https://crossmint.devinenterprise.com/sessions/c1a700641cd84d469d207f44f0c0b4c0
Requested by: @jmderby