### PR TITLE
docs: add react-checkout to SDK reference docs generation workflow

### DIFF
--- a/.github/workflows/sdk-reference-docs-generate.yml
+++ b/.github/workflows/sdk-reference-docs-generate.yml
@@ -20,12 +20,14 @@ on:
             - "packages/client/ui/react-native/tsconfig.typedoc.json"
             - "packages/client/ui/scripts/**"
             - "packages/client/react-base/src/**"
+            - "packages/client/base/src/types/embed/**"
+            - "packages/client/base/src/types/hosted/**"
     workflow_dispatch:
         inputs:
             packages:
-                description: "Comma-separated list of packages to generate docs for (react-ui, react-native, node-wallets). Defaults to all."
+                description: "Comma-separated list of packages to generate docs for (react-ui, react-native, node-wallets, react-checkout). Defaults to all."
                 required: false
-                default: "react-ui,react-native,node-wallets"
+                default: "react-ui,react-native,node-wallets,react-checkout"
                 type: string
 
 permissions:
@@ -52,12 +54,13 @@ jobs:
             - name: Parse package selection
               id: packages
               env:
-                  PACKAGES_INPUT: ${{ inputs.packages || 'react-ui,react-native,node-wallets' }}
+                  PACKAGES_INPUT: ${{ inputs.packages || 'react-ui,react-native,node-wallets,react-checkout' }}
               run: |
                   PACKAGES="$PACKAGES_INPUT"
                   echo "react_ui=false" >> $GITHUB_OUTPUT
                   echo "react_native=false" >> $GITHUB_OUTPUT
                   echo "node_wallets=false" >> $GITHUB_OUTPUT
+                  echo "react_checkout=false" >> $GITHUB_OUTPUT
                   if echo ",$PACKAGES," | grep -q ",react-ui,"; then
                     echo "react_ui=true" >> $GITHUB_OUTPUT
                   fi
@@ -67,11 +70,19 @@ jobs:
                   if echo ",$PACKAGES," | grep -q ",node-wallets,"; then
                     echo "node_wallets=true" >> $GITHUB_OUTPUT
                   fi
+                  if echo ",$PACKAGES," | grep -q ",react-checkout,"; then
+                    echo "react_checkout=true" >> $GITHUB_OUTPUT
+                  fi
 
-            - name: Generate React UI docs
+            - name: Generate React UI docs (wallets)
               if: steps.packages.outputs.react_ui == 'true'
               working-directory: packages/client/ui/react-ui
-              run: pnpm generate:docs
+              run: pnpm generate:docs --product wallets
+
+            - name: Generate React UI docs (checkout)
+              if: steps.packages.outputs.react_checkout == 'true'
+              working-directory: packages/client/ui/react-ui
+              run: pnpm generate:docs --product checkout
 
             - name: Generate React Native docs
               if: steps.packages.outputs.react_native == 'true'
@@ -95,10 +106,12 @@ jobs:
                   REACT_UI_ENABLED: ${{ steps.packages.outputs.react_ui }}
                   REACT_NATIVE_ENABLED: ${{ steps.packages.outputs.react_native }}
                   NODE_WALLETS_ENABLED: ${{ steps.packages.outputs.node_wallets }}
+                  CHECKOUT_ENABLED: ${{ steps.packages.outputs.react_checkout }}
               run: |
                   mkdir -p sdk-reference/wallets/react
                   mkdir -p sdk-reference/wallets/react-native
                   mkdir -p sdk-reference/wallets/typescript
+                  mkdir -p sdk-reference/checkout/react
 
                   if [ "$REACT_UI_ENABLED" == "true" ] && [ -d packages/client/ui/react-ui/docs/wallets ]; then
                     cp -r packages/client/ui/react-ui/docs/wallets/. sdk-reference/wallets/react/
@@ -110,6 +123,10 @@ jobs:
 
                   if [ "$NODE_WALLETS_ENABLED" == "true" ] && [ -d packages/wallets/docs ]; then
                     cp -r packages/wallets/docs/. sdk-reference/wallets/typescript/
+                  fi
+
+                  if [ "$CHECKOUT_ENABLED" == "true" ] && [ -d packages/client/ui/react-ui/docs/checkout ]; then
+                    cp -r packages/client/ui/react-ui/docs/checkout/. sdk-reference/checkout/react/
                   fi
 
             - name: Verify at least one package was generated
@@ -142,4 +159,4 @@ jobs:
                   token: ${{ steps.generate_app_token.outputs.token }}
                   repository: Paella-Labs/crossbit-main
                   event-type: sdk-reference-docs-update
-                  client-payload: '{"run_id": "${{ github.run_id }}", "packages": ${{ toJSON(inputs.packages || ''react-ui,react-native,node-wallets'') }}, "source_ref": ${{ toJSON(github.ref_name) }}}'
+                  client-payload: '{"run_id": "${{ github.run_id }}", "packages": ${{ toJSON(inputs.packages || ''react-ui,react-native,node-wallets,react-checkout'') }}, "source_ref": ${{ toJSON(github.ref_name) }}}'


### PR DESCRIPTION
## Description

Wires `react-checkout` into the `sdk-reference-docs-generate.yml` CI pipeline so checkout docs are automatically generated alongside wallets docs.

Changes to `.github/workflows/sdk-reference-docs-generate.yml`:
- Add `react-checkout` to package selection defaults and `workflow_dispatch` description
- Add path triggers for checkout type definition files (`packages/client/base/src/types/embed/**`, `packages/client/base/src/types/hosted/**`)
- Collect generated checkout docs as workflow artifacts under `sdk-reference/checkout/react/`

Stacked on #1917 — merge that first.

Linear: [DVRL-1248](https://linear.app/crossmint/issue/DVRL-1248/add-the-checkout-generation-into-the-pipeline)

## Test plan

* Workflow syntax verified — only adds a new package option and artifact collection step following the existing wallets pattern
* No runtime code changes

## Package updates

None — workflow-only change

Link to Devin session: https://crossmint.devinenterprise.com/sessions/c1a700641cd84d469d207f44f0c0b4c0
Requested by: @jmderby