### PR TITLE
feat(payment-method-management): add allowedModes + allowedPaymentMethodTypes props and bank-account-us return variant

### DIFF
--- a/.changeset/offramp-bank-account-pm-props.md
+++ b/.changeset/offramp-bank-account-pm-props.md
@@ -2,9 +2,9 @@
 "@crossmint/client-sdk-base": minor
 ---
 
-payment-method-management: add `mode` and `allowedPaymentMethodTypes` props and a `bank-account-us` return variant.
+payment-method-management: add `allow` and `allowedPaymentMethodTypes` props and a `bank-account-us` return variant.
 
-- `mode?: "new-only" | "new-and-existing"` (default `new-and-existing`).
+- `allow?: Array<"new" | "existing">` (default `["new"]`) — which sections render: `"new"` shows the "add new" form, `"existing"` shows the saved-methods list.
 - `allowedPaymentMethodTypes?: ("card" | "bank-account-us")[]` (default `["card"]`).
 - `CrossmintPaymentMethod` is now a discriminated union on `type`. The new `bank-account-us` variant carries only a safe display summary (`paymentMethodId` + `bankAccount: { accountSuffix, bankName, accountType }`); no token id or raw account number.
 

--- a/.changeset/offramp-bank-account-pm-props.md
+++ b/.changeset/offramp-bank-account-pm-props.md
@@ -1,0 +1,11 @@
+---
+"@crossmint/client-sdk-base": minor
+---
+
+payment-method-management: add `mode` and `allowedPaymentMethodTypes` props and a `bank-account-us` return variant.
+
+- `mode?: "new-only" | "new-and-existing"` (default `new-and-existing`).
+- `allowedPaymentMethodTypes?: ("card" | "bank-account-us")[]` (default `["card"]`).
+- `CrossmintPaymentMethod` is now a discriminated union on `type`. The new `bank-account-us` variant carries only a safe display summary (`paymentMethodId` + `bankAccount: { accountSuffix, bankName, accountType }`); no token id or raw account number.
+
+Type-breaking for consumers of `onPaymentMethodSelected`: a payment method must now be narrowed on `type` before reading variant-specific fields (e.g. `pm.card` is only valid after `pm.type === "card"`). Existing card-only integrations that already narrow, or that do not read variant fields, are unaffected.

--- a/.changeset/offramp-bank-account-pm-props.md
+++ b/.changeset/offramp-bank-account-pm-props.md
@@ -2,9 +2,9 @@
 "@crossmint/client-sdk-base": minor
 ---
 
-payment-method-management: add `allow` and `allowedPaymentMethodTypes` props and a `bank-account-us` return variant.
+payment-method-management: add `allowedModes` and `allowedPaymentMethodTypes` props and a `bank-account-us` return variant.
 
-- `allow?: Array<"new" | "existing">` (default `["new"]`) — which sections render: `"new"` shows the "add new" form, `"existing"` shows the saved-methods list.
+- `allowedModes?: Array<"new" | "existing">` (default `["new"]`) — which sections render: `"new"` shows the "add new" form, `"existing"` shows the saved-methods list.
 - `allowedPaymentMethodTypes?: ("card" | "bank-account-us")[]` (default `["card"]`).
 - `CrossmintPaymentMethod` is now a discriminated union on `type`. The new `bank-account-us` variant carries only a safe display summary (`paymentMethodId` + `bankAccount: { accountSuffix, bankName, accountType }`); no token id or raw account number.
 

--- a/packages/client/base/src/services/payment-method-management/paymentMethodManagementService.test.ts
+++ b/packages/client/base/src/services/payment-method-management/paymentMethodManagementService.test.ts
@@ -16,19 +16,19 @@ function makeService() {
 }
 
 describe("paymentMethodManagementService.getUrl", () => {
-    it("serializes mode and allowedPaymentMethodTypes into the iframe URL (array survives round-trip)", () => {
+    it("serializes allow and allowedPaymentMethodTypes into the iframe URL (array survives round-trip)", () => {
         const service = makeService();
 
         const url = service.iframe.getUrl({
             jwt: "jwt-token",
-            mode: "new-only",
+            allow: ["new"],
             allowedPaymentMethodTypes: ["bank-account-us"],
         });
 
         const params = new URL(url).searchParams;
         expect(params.get("jwt")).toBe("jwt-token");
         expect(params.get("apiKey")).toBe("ck_staging_test");
-        expect(params.get("mode")).toBe("new-only");
+        expect(JSON.parse(params.get("allow") ?? "null")).toEqual(["new"]);
         // appendObjectToQueryParams JSON.stringifies arrays into a single param.
         expect(JSON.parse(params.get("allowedPaymentMethodTypes") ?? "null")).toEqual(["bank-account-us"]);
     });
@@ -51,7 +51,7 @@ describe("paymentMethodManagementService.getUrl", () => {
         const url = service.iframe.getUrl({ jwt: "jwt-token" });
 
         const params = new URL(url).searchParams;
-        expect(params.has("mode")).toBe(false);
+        expect(params.has("allow")).toBe(false);
         expect(params.has("allowedPaymentMethodTypes")).toBe(false);
     });
 
@@ -67,9 +67,9 @@ describe("paymentMethodManagementService.getUrl", () => {
 });
 
 describe("CrossmintPaymentMethodManagement types", () => {
-    it("keeps mode and allowedPaymentMethodTypes optional", () => {
-        expectTypeOf<CrossmintPaymentMethodManagementProps["mode"]>().toEqualTypeOf<
-            "new-only" | "new-and-existing" | undefined
+    it("keeps allow and allowedPaymentMethodTypes optional", () => {
+        expectTypeOf<CrossmintPaymentMethodManagementProps["allow"]>().toEqualTypeOf<
+            Array<"new" | "existing"> | undefined
         >();
         expectTypeOf<CrossmintPaymentMethodManagementProps["allowedPaymentMethodTypes"]>().toEqualTypeOf<
             ("card" | "bank-account-us")[] | undefined

--- a/packages/client/base/src/services/payment-method-management/paymentMethodManagementService.test.ts
+++ b/packages/client/base/src/services/payment-method-management/paymentMethodManagementService.test.ts
@@ -1,0 +1,103 @@
+import type { CrossmintApiClient } from "@crossmint/common-sdk-base";
+import { describe, expect, expectTypeOf, it } from "vitest";
+import type {
+    CrossmintPaymentMethod,
+    CrossmintPaymentMethodManagementProps,
+} from "@/types/payment-method-management/CrossmintPaymentMethodManagementProps";
+import { createPaymentMethodManagementService } from "./paymentMethodManagementService";
+
+function makeService() {
+    const apiClient = {
+        buildUrl: (path: string) => `https://staging.crossmint.com/api${path}`,
+        crossmint: { apiKey: "ck_staging_test" },
+        internalConfig: { sdkMetadata: { name: "test-sdk", version: "0.0.0" } },
+    } as unknown as CrossmintApiClient;
+    return createPaymentMethodManagementService({ apiClient });
+}
+
+describe("paymentMethodManagementService.getUrl", () => {
+    it("serializes mode and allowedPaymentMethodTypes into the iframe URL (array survives round-trip)", () => {
+        const service = makeService();
+
+        const url = service.iframe.getUrl({
+            jwt: "jwt-token",
+            mode: "new-only",
+            allowedPaymentMethodTypes: ["bank-account-us"],
+        });
+
+        const params = new URL(url).searchParams;
+        expect(params.get("jwt")).toBe("jwt-token");
+        expect(params.get("apiKey")).toBe("ck_staging_test");
+        expect(params.get("mode")).toBe("new-only");
+        // appendObjectToQueryParams JSON.stringifies arrays into a single param.
+        expect(JSON.parse(params.get("allowedPaymentMethodTypes") ?? "null")).toEqual(["bank-account-us"]);
+    });
+
+    it("preserves a multi-entry allowedPaymentMethodTypes array through the query param", () => {
+        const service = makeService();
+
+        const url = service.iframe.getUrl({
+            jwt: "jwt-token",
+            allowedPaymentMethodTypes: ["card", "bank-account-us"],
+        });
+
+        const raw = new URL(url).searchParams.get("allowedPaymentMethodTypes");
+        expect(JSON.parse(raw ?? "null")).toEqual(["card", "bank-account-us"]);
+    });
+
+    it("omits optional props that are not provided", () => {
+        const service = makeService();
+
+        const url = service.iframe.getUrl({ jwt: "jwt-token" });
+
+        const params = new URL(url).searchParams;
+        expect(params.has("mode")).toBe(false);
+        expect(params.has("allowedPaymentMethodTypes")).toBe(false);
+    });
+});
+
+describe("CrossmintPaymentMethodManagement types", () => {
+    it("keeps mode and allowedPaymentMethodTypes optional", () => {
+        expectTypeOf<CrossmintPaymentMethodManagementProps["mode"]>().toEqualTypeOf<
+            "new-only" | "new-and-existing" | undefined
+        >();
+        expectTypeOf<CrossmintPaymentMethodManagementProps["allowedPaymentMethodTypes"]>().toEqualTypeOf<
+            ("card" | "bank-account-us")[] | undefined
+        >();
+        // jwt-only construction must remain valid (props stay optional).
+        const minimal: CrossmintPaymentMethodManagementProps = { jwt: "x" };
+        expect(minimal.jwt).toBe("x");
+    });
+
+    it("is a discriminated union narrowable on type", () => {
+        const card: CrossmintPaymentMethod = {
+            type: "card",
+            paymentMethodId: "pm_card",
+            card: {
+                source: { type: "basis-theory-token", id: "tok_1" },
+                brand: "visa",
+                last4: "4242",
+                expiration: { month: "12", year: "2030" },
+            },
+        };
+        const bank: CrossmintPaymentMethod = {
+            type: "bank-account-us",
+            paymentMethodId: "pm_bank",
+            bankAccount: { accountSuffix: "6789", bankName: "Wells Fargo", accountType: "checking" },
+        };
+
+        function summarize(pm: CrossmintPaymentMethod): string {
+            if (pm.type === "bank-account-us") {
+                expectTypeOf(pm.bankAccount.accountSuffix).toBeString();
+                // @ts-expect-error - bank variant has no `card` field
+                pm.card;
+                return pm.bankAccount.accountSuffix;
+            }
+            expectTypeOf(pm.card.source.id).toBeString();
+            return pm.card.last4;
+        }
+
+        expect(summarize(card)).toBe("4242");
+        expect(summarize(bank)).toBe("6789");
+    });
+});

--- a/packages/client/base/src/services/payment-method-management/paymentMethodManagementService.test.ts
+++ b/packages/client/base/src/services/payment-method-management/paymentMethodManagementService.test.ts
@@ -54,6 +54,16 @@ describe("paymentMethodManagementService.getUrl", () => {
         expect(params.has("mode")).toBe(false);
         expect(params.has("allowedPaymentMethodTypes")).toBe(false);
     });
+
+    it("drops an empty allowedPaymentMethodTypes so the iframe applies the default", () => {
+        const service = makeService();
+
+        const url = service.iframe.getUrl({ jwt: "jwt-token", allowedPaymentMethodTypes: [] });
+
+        // An empty array must not serialize as `[]` (which the iframe would read as
+        // "offer no types"); the key is dropped so the documented default applies.
+        expect(new URL(url).searchParams.has("allowedPaymentMethodTypes")).toBe(false);
+    });
 });
 
 describe("CrossmintPaymentMethodManagement types", () => {

--- a/packages/client/base/src/services/payment-method-management/paymentMethodManagementService.test.ts
+++ b/packages/client/base/src/services/payment-method-management/paymentMethodManagementService.test.ts
@@ -16,19 +16,19 @@ function makeService() {
 }
 
 describe("paymentMethodManagementService.getUrl", () => {
-    it("serializes allow and allowedPaymentMethodTypes into the iframe URL (array survives round-trip)", () => {
+    it("serializes allowedModes and allowedPaymentMethodTypes into the iframe URL (array survives round-trip)", () => {
         const service = makeService();
 
         const url = service.iframe.getUrl({
             jwt: "jwt-token",
-            allow: ["new"],
+            allowedModes: ["new"],
             allowedPaymentMethodTypes: ["bank-account-us"],
         });
 
         const params = new URL(url).searchParams;
         expect(params.get("jwt")).toBe("jwt-token");
         expect(params.get("apiKey")).toBe("ck_staging_test");
-        expect(JSON.parse(params.get("allow") ?? "null")).toEqual(["new"]);
+        expect(JSON.parse(params.get("allowedModes") ?? "null")).toEqual(["new"]);
         // appendObjectToQueryParams JSON.stringifies arrays into a single param.
         expect(JSON.parse(params.get("allowedPaymentMethodTypes") ?? "null")).toEqual(["bank-account-us"]);
     });
@@ -51,7 +51,7 @@ describe("paymentMethodManagementService.getUrl", () => {
         const url = service.iframe.getUrl({ jwt: "jwt-token" });
 
         const params = new URL(url).searchParams;
-        expect(params.has("allow")).toBe(false);
+        expect(params.has("allowedModes")).toBe(false);
         expect(params.has("allowedPaymentMethodTypes")).toBe(false);
     });
 
@@ -67,8 +67,8 @@ describe("paymentMethodManagementService.getUrl", () => {
 });
 
 describe("CrossmintPaymentMethodManagement types", () => {
-    it("keeps allow and allowedPaymentMethodTypes optional", () => {
-        expectTypeOf<CrossmintPaymentMethodManagementProps["allow"]>().toEqualTypeOf<
+    it("keeps allowedModes and allowedPaymentMethodTypes optional", () => {
+        expectTypeOf<CrossmintPaymentMethodManagementProps["allowedModes"]>().toEqualTypeOf<
             Array<"new" | "existing"> | undefined
         >();
         expectTypeOf<CrossmintPaymentMethodManagementProps["allowedPaymentMethodTypes"]>().toEqualTypeOf<

--- a/packages/client/base/src/services/payment-method-management/paymentMethodManagementService.ts
+++ b/packages/client/base/src/services/payment-method-management/paymentMethodManagementService.ts
@@ -20,12 +20,12 @@ export function createPaymentMethodManagementService({ apiClient }: PaymentMetho
         // skips falsy values, and `![]` is false), which the iframe would read as
         // "render nothing" instead of applying the documented default. Drop these
         // keys when empty so the iframe defaults apply (`allowedPaymentMethodTypes`
-        // → `["card"]`, `allow` → `["new"]`).
-        const { allowedPaymentMethodTypes, allow, ...rest } = props;
+        // → `["card"]`, `allowedModes` → `["new"]`).
+        const { allowedPaymentMethodTypes, allowedModes, ...rest } = props;
         const serializableProps = {
             ...rest,
             ...(allowedPaymentMethodTypes?.length ? { allowedPaymentMethodTypes } : {}),
-            ...(allow?.length ? { allow } : {}),
+            ...(allowedModes?.length ? { allowedModes } : {}),
         };
 
         appendObjectToQueryParams(queryParams, serializableProps);

--- a/packages/client/base/src/services/payment-method-management/paymentMethodManagementService.ts
+++ b/packages/client/base/src/services/payment-method-management/paymentMethodManagementService.ts
@@ -16,12 +16,17 @@ export function createPaymentMethodManagementService({ apiClient }: PaymentMetho
         const urlWithPath = apiClient.buildUrl("/sdk/unstable/payment-method-management");
         const queryParams = new URLSearchParams();
 
-        // An empty `allowedPaymentMethodTypes` array would serialize as `[]`
-        // (appendObjectToQueryParams only skips falsy values, and `![]` is false),
-        // which the iframe would read as "offer no types" instead of the documented
-        // `["card"]` default. Drop the key when empty so the default applies.
-        const { allowedPaymentMethodTypes, ...rest } = props;
-        const serializableProps = allowedPaymentMethodTypes?.length ? props : rest;
+        // An empty array would serialize as `[]` (appendObjectToQueryParams only
+        // skips falsy values, and `![]` is false), which the iframe would read as
+        // "render nothing" instead of applying the documented default. Drop these
+        // keys when empty so the iframe defaults apply (`allowedPaymentMethodTypes`
+        // → `["card"]`, `allow` → `["new"]`).
+        const { allowedPaymentMethodTypes, allow, ...rest } = props;
+        const serializableProps = {
+            ...rest,
+            ...(allowedPaymentMethodTypes?.length ? { allowedPaymentMethodTypes } : {}),
+            ...(allow?.length ? { allow } : {}),
+        };
 
         appendObjectToQueryParams(queryParams, serializableProps);
 

--- a/packages/client/base/src/services/payment-method-management/paymentMethodManagementService.ts
+++ b/packages/client/base/src/services/payment-method-management/paymentMethodManagementService.ts
@@ -16,7 +16,14 @@ export function createPaymentMethodManagementService({ apiClient }: PaymentMetho
         const urlWithPath = apiClient.buildUrl("/sdk/unstable/payment-method-management");
         const queryParams = new URLSearchParams();
 
-        appendObjectToQueryParams(queryParams, props);
+        // An empty `allowedPaymentMethodTypes` array would serialize as `[]`
+        // (appendObjectToQueryParams only skips falsy values, and `![]` is false),
+        // which the iframe would read as "offer no types" instead of the documented
+        // `["card"]` default. Drop the key when empty so the default applies.
+        const { allowedPaymentMethodTypes, ...rest } = props;
+        const serializableProps = allowedPaymentMethodTypes?.length ? props : rest;
+
+        appendObjectToQueryParams(queryParams, serializableProps);
 
         queryParams.append("apiKey", apiClient.crossmint.apiKey);
         queryParams.append("sdkMetadata", JSON.stringify(apiClient["internalConfig"].sdkMetadata));

--- a/packages/client/base/src/types/payment-method-management/CrossmintPaymentMethodManagementProps.ts
+++ b/packages/client/base/src/types/payment-method-management/CrossmintPaymentMethodManagementProps.ts
@@ -1,12 +1,37 @@
 import type { EmbeddedCheckoutV3Appearance } from "../embed";
 
+/**
+ * Which payment-method types the management UI offers in its "add new" section.
+ * Bounded by the vault proxy's tokenizable types; LM0 ships rendering for a
+ * single allowed type (the first supported entry).
+ */
+export type PaymentMethodManagementAllowedType = "card" | "bank-account-us";
+
 export interface CrossmintPaymentMethodManagementProps {
     jwt: string;
     appearance?: PaymentMethodManagementAppearance;
+    /**
+     * `new-and-existing` (default) shows saved methods and an "add new" section.
+     * `new-only` shows only the "add new" section: no saved-methods fetch, no
+     * auto-open/auto-select of an existing method.
+     */
+    mode?: "new-only" | "new-and-existing";
+    /**
+     * Filter array of which method types the "add new" section offers
+     * (default `["card"]`). LM0 renders the first supported entry; passing more
+     * than one type does not yet render a type picker.
+     */
+    allowedPaymentMethodTypes?: PaymentMethodManagementAllowedType[];
     onPaymentMethodSelected?: (paymentMethod: CrossmintPaymentMethod) => void | Promise<void>;
 }
 
-export type CrossmintPaymentMethod = {
+/**
+ * A payment method surfaced to the integrator via `onPaymentMethodSelected`.
+ * Discriminated on `type`; narrow before reading variant-specific fields.
+ */
+export type CrossmintPaymentMethod = CrossmintCardPaymentMethod | CrossmintBankAccountUSPaymentMethod;
+
+export type CrossmintCardPaymentMethod = {
     type: "card";
     paymentMethodId: string;
     card: {
@@ -22,6 +47,24 @@ export type CrossmintPaymentMethod = {
             // 4 digit year
             year: string;
         };
+    };
+    default?: boolean;
+    display?: {
+        imageUrl?: string;
+    };
+};
+
+/**
+ * US bank account. Carries only a safe display summary; intentionally omits any
+ * token id or raw account number (the vault tokenizes those server-side).
+ */
+export type CrossmintBankAccountUSPaymentMethod = {
+    type: "bank-account-us";
+    paymentMethodId: string;
+    bankAccount: {
+        accountSuffix: string;
+        bankName: string;
+        accountType: "checking" | "savings";
     };
     default?: boolean;
     display?: {

--- a/packages/client/base/src/types/payment-method-management/CrossmintPaymentMethodManagementProps.ts
+++ b/packages/client/base/src/types/payment-method-management/CrossmintPaymentMethodManagementProps.ts
@@ -11,11 +11,13 @@ export interface CrossmintPaymentMethodManagementProps {
     jwt: string;
     appearance?: PaymentMethodManagementAppearance;
     /**
-     * `new-and-existing` (default) shows saved methods and an "add new" section.
-     * `new-only` shows only the "add new" section: no saved-methods fetch, no
-     * auto-open/auto-select of an existing method.
+     * Which sections the management UI renders. `["new"]` (default) shows only
+     * the "add new" section: no saved-methods fetch, no auto-open/auto-select of
+     * an existing method. Include `"existing"` to also show the saved-methods
+     * section. (`["new"]` ≡ the old `new-only`; `["new","existing"]` ≡ the old
+     * `new-and-existing`.)
      */
-    mode?: "new-only" | "new-and-existing";
+    allow?: Array<"new" | "existing">;
     /**
      * Filter array of which method types the "add new" section offers
      * (default `["card"]`). LM0 renders the first supported entry; passing more

--- a/packages/client/base/src/types/payment-method-management/CrossmintPaymentMethodManagementProps.ts
+++ b/packages/client/base/src/types/payment-method-management/CrossmintPaymentMethodManagementProps.ts
@@ -14,10 +14,9 @@ export interface CrossmintPaymentMethodManagementProps {
      * Which sections the management UI renders. `["new"]` (default) shows only
      * the "add new" section: no saved-methods fetch, no auto-open/auto-select of
      * an existing method. Include `"existing"` to also show the saved-methods
-     * section. (`["new"]` ≡ the old `new-only`; `["new","existing"]` ≡ the old
-     * `new-and-existing`.)
+     * section.
      */
-    allow?: Array<"new" | "existing">;
+    allowedModes?: Array<"new" | "existing">;
     /**
      * Filter array of which method types the "add new" section offers
      * (default `["card"]`). LM0 renders the first supported entry; passing more


### PR DESCRIPTION
Adds two optional props and a return-type variant to `<CrossmintPaymentMethodManagement>` (`packages/client/base/src/types/payment-method-management/CrossmintPaymentMethodManagementProps.ts`).

## What's in it
- `allowedModes?: Array<"new" | "existing">` (default `["new"]`) — which sections render: `"new"` shows the "add new" form; include `"existing"` to also show the saved-methods section.
- `allowedPaymentMethodTypes?: ("card" | "bank-account-us")[]` (default `["card"]`). Renders the first supported entry; a multi-type picker is not yet rendered.
- `CrossmintPaymentMethod` is now a discriminated union on `type` with a `bank-account-us` variant: `paymentMethodId` + `bankAccount: { accountSuffix, bankName, accountType }`. No token id, no raw account number.
- Props serialize into the iframe URL via the existing query-param builder (empty arrays dropped so the iframe defaults apply).

Backward-compatible: both props are optional with the prior defaults; the card variant is identical to the previous single shape, so existing card integrators are unaffected (a consumer that read `pm.card` without first narrowing on `pm.type` now needs to narrow — the intended cost of the union).

The iframe that renders the bank UI these props target is merged (Paella-Labs/crossbit-main#26629). The modes param serializes as `allowedModes`, matching the param the iframe parses; `allowedPaymentMethodTypes` and the emitted `bank-account-us` payload match the iframe field-for-field.