### PR TITLE
feat(wallets): add deployImmediately flag to addSigner with default true

### DIFF
--- a/.changeset/add-deploy-immediately-flag.md
+++ b/.changeset/add-deploy-immediately-flag.md
@@ -1,0 +1,9 @@
+---
+"@crossmint/wallets-sdk": minor
+---
+
+feat: add `deployImmediately` option to `addSigner` for EVM wallets
+
+When adding a signer to an EVM wallet, `deployImmediately` (default: `true`) causes the
+signer to be registered on-chain immediately via a transaction, mirroring the Solana/Stellar
+behavior. Set to `false` to use the previous lazy signature-request flow.

--- a/packages/wallets/src/api/types.ts
+++ b/packages/wallets/src/api/types.ts
@@ -96,6 +96,7 @@ export type RegisterSignerParams = {
     signer: SignerLocator | RegisterSignerPasskeyParams | SignerConfigForChain<Chain>;
     chain?: RegisterSignerChain;
     scopes?: Scope[];
+    deployImmediately?: boolean;
 };
 export type RegisterSignerResponse = DelegatedSignerV2025DtoClass | WalletsV2025ControllerCreateDelegatedSigner2Error;
 export type RemoveSignerParams = {

--- a/packages/wallets/src/utils/signer-mapping.ts
+++ b/packages/wallets/src/utils/signer-mapping.ts
@@ -78,7 +78,11 @@ export function mapApiSignerToSigner(apiSigner: APISigner, chain: Chain): Signer
         return { ...base, status, ...(scopes != null && { scopes }) } as Signer;
     }
 
-    // For EVM, status comes from the chains field
+    // For EVM, status comes from the transaction field (deployImmediately) or chains field
+    if ("transaction" in apiSigner && apiSigner.transaction != null) {
+        return { ...base, status: apiSigner.transaction.status, ...(scopes != null && { scopes }) } as Signer;
+    }
+
     if ("chains" in apiSigner && apiSigner.chains != null && Object.keys(apiSigner.chains).length > 0) {
         const chainEntry = apiSigner.chains[chain];
         if (chainEntry == null) {

--- a/packages/wallets/src/utils/signer-mapping.ts
+++ b/packages/wallets/src/utils/signer-mapping.ts
@@ -99,17 +99,20 @@ export function getPendingSignerOperation(
     apiSigner: APISigner,
     chain: Chain
 ): { type: "signature" | "transaction"; id: string } | null {
+    // Check for a pending transaction first (Solana/Stellar always, EVM with deployImmediately)
+    if (
+        "transaction" in apiSigner &&
+        apiSigner.transaction != null &&
+        (apiSigner.transaction.status === "pending" || apiSigner.transaction.status === "awaiting-approval")
+    ) {
+        return { type: "transaction", id: apiSigner.transaction.id };
+    }
+
     if (chain === "solana" || chain === "stellar") {
-        if (
-            "transaction" in apiSigner &&
-            apiSigner.transaction != null &&
-            (apiSigner.transaction.status === "pending" || apiSigner.transaction.status === "awaiting-approval")
-        ) {
-            return { type: "transaction", id: apiSigner.transaction.id };
-        }
         return null;
     }
 
+    // EVM signature flow (deployImmediately: false)
     if ("chains" in apiSigner && apiSigner.chains != null) {
         const chainEntry = apiSigner.chains[chain];
         if (chainEntry != null && (chainEntry.status === "pending" || chainEntry.status === "awaiting-approval")) {

--- a/packages/wallets/src/wallets/types.ts
+++ b/packages/wallets/src/wallets/types.ts
@@ -58,7 +58,7 @@ export type MigrateOptions = Partial<PrepareOnly> & {
 
 export type AddSignerReturnType<C extends Chain> = C extends "solana" | "stellar"
     ? Signer & { transactionId: string }
-    : Signer & { signatureId?: string };
+    : Signer & { signatureId?: string; transactionId?: string };
 
 export type RemoveSignerReturnType = { transactionId: string; status?: "success" };
 

--- a/packages/wallets/src/wallets/types.ts
+++ b/packages/wallets/src/wallets/types.ts
@@ -38,6 +38,12 @@ export type SignatureInputOptions = PrepareOnly;
 
 export type AddSignerOptions = PrepareOnly & {
     scopes?: Scope[];
+    /**
+     * If true, the signer is registered on-chain immediately via a transaction (EVM only).
+     * If false, the signer is registered lazily via a signature request.
+     * Defaults to true.
+     */
+    deployImmediately?: boolean;
 };
 
 export type RemoveSignerOptions = PrepareOnly;

--- a/packages/wallets/src/wallets/wallet.test.ts
+++ b/packages/wallets/src/wallets/wallet.test.ts
@@ -665,6 +665,70 @@ describe("Wallet - addSigner()", () => {
             expect(result.status).toBe("success");
         });
 
+        it("passes deployImmediately: true by default for EVM", async () => {
+            const mockRegisterResponse = {
+                type: "external-wallet",
+                address: "0x456",
+                locator: "external-wallet:0x456",
+                transaction: {
+                    id: "txn-456",
+                    status: "pending",
+                },
+            };
+
+            const mockTransactionResponse = {
+                id: "txn-456",
+                status: "success",
+                onChain: {
+                    txId: "0xhash",
+                    explorerLink: "https://basescan.org/tx/0xhash",
+                },
+            };
+
+            mockApiClient.registerSigner.mockResolvedValue(mockRegisterResponse as any);
+            mockApiClient.getTransaction.mockResolvedValue(mockTransactionResponse as any);
+
+            const addPromise = evmWallet.addSigner({ type: "external-wallet", address: "0x456" });
+            await vi.runAllTimersAsync();
+            await addPromise;
+
+            expect(mockApiClient.registerSigner).toHaveBeenCalledWith(
+                "me:evm:smart",
+                expect.objectContaining({
+                    signer: "external-wallet:0x456",
+                    chain: "base-sepolia",
+                    deployImmediately: true,
+                })
+            );
+        });
+
+        it("passes deployImmediately: false when explicitly set", async () => {
+            const mockRegisterResponse = {
+                type: "external-wallet",
+                address: "0x456",
+                locator: "external-wallet:0x456",
+                chains: {
+                    "base-sepolia": {
+                        id: "sig-123",
+                        status: "success",
+                    },
+                },
+            };
+
+            mockApiClient.registerSigner.mockResolvedValue(mockRegisterResponse as any);
+
+            await evmWallet.addSigner({ type: "external-wallet", address: "0x456" }, { deployImmediately: false });
+
+            expect(mockApiClient.registerSigner).toHaveBeenCalledWith(
+                "me:evm:smart",
+                expect.objectContaining({
+                    signer: "external-wallet:0x456",
+                    chain: "base-sepolia",
+                    deployImmediately: false,
+                })
+            );
+        });
+
         it("returns signatureId with prepareOnly", async () => {
             const mockRegisterResponse = {
                 type: "external-wallet",
@@ -682,7 +746,7 @@ describe("Wallet - addSigner()", () => {
 
             const result = await evmWallet.addSigner(
                 { type: "external-wallet", address: "0x456" },
-                { prepareOnly: true }
+                { prepareOnly: true, deployImmediately: false }
             );
 
             expect(result.signatureId).toBe("sig-123");
@@ -836,33 +900,17 @@ describe("Wallet - addSigner()", () => {
             );
         });
 
-        it("throws error when Solana response missing transaction", async () => {
+        it("throws error when response missing both transaction and chains", async () => {
             const mockRegisterResponse = {
                 type: "external-wallet",
                 address: "ABC123",
                 locator: "external-wallet:ABC123",
-                chains: {},
             };
 
             mockApiClient.registerSigner.mockResolvedValue(mockRegisterResponse as any);
 
             await expect(solanaWallet.addSigner({ type: "external-wallet", address: "ABC123" })).rejects.toThrow(
-                "Expected transaction in response for Solana/Stellar chain"
-            );
-        });
-
-        it("throws error when EVM response missing chains", async () => {
-            const mockRegisterResponse = {
-                type: "external-wallet",
-                address: "0x456",
-                locator: "external-wallet:0x456",
-                transaction: { id: "txn-123" },
-            };
-
-            mockApiClient.registerSigner.mockResolvedValue(mockRegisterResponse as any);
-
-            await expect(evmWallet.addSigner({ type: "external-wallet", address: "0x456" })).rejects.toThrow(
-                "Expected chains in response for EVM chain"
+                "Expected transaction or chains in register signer response"
             );
         });
     });

--- a/packages/wallets/src/wallets/wallet.test.ts
+++ b/packages/wallets/src/wallets/wallet.test.ts
@@ -923,16 +923,31 @@ describe("Wallet - addSigner()", () => {
             );
         });
 
-        it("throws error when response missing both transaction and chains", async () => {
+        it("throws error when Solana response missing transaction", async () => {
             const mockRegisterResponse = {
                 type: "external-wallet",
                 address: "ABC123",
                 locator: "external-wallet:ABC123",
+                chains: {},
             };
 
             mockApiClient.registerSigner.mockResolvedValue(mockRegisterResponse as any);
 
             await expect(solanaWallet.addSigner({ type: "external-wallet", address: "ABC123" })).rejects.toThrow(
+                "Expected transaction in response for Solana/Stellar chain"
+            );
+        });
+
+        it("throws error when EVM response missing both transaction and chains", async () => {
+            const mockRegisterResponse = {
+                type: "external-wallet",
+                address: "0x456",
+                locator: "external-wallet:0x456",
+            };
+
+            mockApiClient.registerSigner.mockResolvedValue(mockRegisterResponse as any);
+
+            await expect(evmWallet.addSigner({ type: "external-wallet", address: "0x456" })).rejects.toThrow(
                 "Expected transaction or chains in register signer response"
             );
         });

--- a/packages/wallets/src/wallets/wallet.test.ts
+++ b/packages/wallets/src/wallets/wallet.test.ts
@@ -749,6 +749,7 @@ describe("Wallet - addSigner()", () => {
 
             expect(result.transactionId).toBe("txn-789");
             expect(result.type).toBe("external-wallet");
+            expect(result.status).toBe("pending");
         });
 
         it("returns signatureId with prepareOnly and deployImmediately: false", async () => {

--- a/packages/wallets/src/wallets/wallet.test.ts
+++ b/packages/wallets/src/wallets/wallet.test.ts
@@ -729,7 +729,29 @@ describe("Wallet - addSigner()", () => {
             );
         });
 
-        it("returns signatureId with prepareOnly", async () => {
+        it("returns transactionId with prepareOnly and deployImmediately (default)", async () => {
+            const mockRegisterResponse = {
+                type: "external-wallet",
+                address: "0x456",
+                locator: "external-wallet:0x456",
+                transaction: {
+                    id: "txn-789",
+                    status: "pending",
+                },
+            };
+
+            mockApiClient.registerSigner.mockResolvedValue(mockRegisterResponse as any);
+
+            const result = await evmWallet.addSigner(
+                { type: "external-wallet", address: "0x456" },
+                { prepareOnly: true }
+            );
+
+            expect(result.transactionId).toBe("txn-789");
+            expect(result.type).toBe("external-wallet");
+        });
+
+        it("returns signatureId with prepareOnly and deployImmediately: false", async () => {
             const mockRegisterResponse = {
                 type: "external-wallet",
                 address: "0x456",

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -805,6 +805,11 @@ export class Wallet<C extends Chain> {
 
             if ("transaction" in response && response.transaction != null) {
                 pendingOperation = { type: "transaction", id: response.transaction.id };
+            } else if (this.chain === "solana" || this.chain === "stellar") {
+                walletsLogger.error("wallet.addSigner.error", {
+                    error: "Expected transaction in response for Solana/Stellar chain",
+                });
+                throw new Error("Expected transaction in response for Solana/Stellar chain");
             } else if ("chains" in response) {
                 if (response.chains?.[this.chain]?.status === "failed") {
                     walletsLogger.error("wallet.addSigner.failed", {

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -774,10 +774,14 @@ export class Wallet<C extends Chain> {
                           }
                         : getSignerLocator(resolvedSigner);
 
+            const deployImmediately =
+                this.chain !== "solana" && this.chain !== "stellar" ? options?.deployImmediately ?? true : undefined;
+
             const response = await this.#apiClient.registerSigner(this.walletLocator, {
                 signer: signerInput as RegisterSignerParams["signer"],
                 chain: this.getSignerRegistrationChain(),
                 ...(options?.scopes != null && { scopes: options.scopes }),
+                ...(deployImmediately != null && { deployImmediately }),
             });
 
             if ("error" in response) {
@@ -799,21 +803,9 @@ export class Wallet<C extends Chain> {
             // Extract the pending operation from the registration response
             let pendingOperation: { type: "signature" | "transaction"; id: string } | null = null;
 
-            if (this.chain === "solana" || this.chain === "stellar") {
-                if (!("transaction" in response) || response.transaction == null) {
-                    walletsLogger.error("wallet.addSigner.error", {
-                        error: "Expected transaction in response for Solana/Stellar chain",
-                    });
-                    throw new Error("Expected transaction in response for Solana/Stellar chain");
-                }
+            if ("transaction" in response && response.transaction != null) {
                 pendingOperation = { type: "transaction", id: response.transaction.id };
-            } else {
-                if (!("chains" in response)) {
-                    walletsLogger.error("wallet.addSigner.error", {
-                        error: "Expected chains in response for EVM chain",
-                    });
-                    throw new Error("Expected chains in response for EVM chain");
-                }
+            } else if ("chains" in response) {
                 if (response.chains?.[this.chain]?.status === "failed") {
                     walletsLogger.error("wallet.addSigner.failed", {
                         chain: this.chain,
@@ -827,6 +819,11 @@ export class Wallet<C extends Chain> {
                     );
                 }
                 pendingOperation = getPendingSignerOperation(response, this.chain);
+            } else {
+                walletsLogger.error("wallet.addSigner.error", {
+                    error: "Expected transaction or chains in register signer response",
+                });
+                throw new Error("Expected transaction or chains in register signer response");
             }
 
             return this.completeSignerRegistration(registeredSigner, pendingOperation, options);


### PR DESCRIPTION
## Description

Adds a `deployImmediately` option to `wallet.addSigner()` for EVM wallets. When `true` (the new default), the signer is registered on-chain immediately via a transaction — matching how Solana/Stellar already behave — instead of the previous lazy typed-data signature-request flow.

This is the SDK counterpart to [Paella-Labs/crossbit-main#26626](https://github.com/Paella-Labs/crossbit-main/pull/26626), which adds the backend support for this flag.

**Changes:**
- `RegisterSignerParams` gains optional `deployImmediately?: boolean`
- `AddSignerOptions` gains optional `deployImmediately?: boolean` (defaults to `true` for EVM)
- `AddSignerReturnType` for EVM widened to include `transactionId?: string`
- Response handling in `addSigner` is now response-driven: checks for `transaction` first, preserves Solana/Stellar guard, then falls back to `chains`
- `mapApiSignerToSigner` propagates `transaction.status` for EVM (no false "success" before confirmation)
- `getPendingSignerOperation` is response-driven: checks `transaction` first (any chain) for correct retry/idempotency
- Flag is only sent for EVM chains (not Solana/Stellar)

## Test plan

- Unit tests (`wallet.test.ts`):
  - Verifies `deployImmediately: true` is passed by default for EVM add-signer calls
  - Verifies `deployImmediately: false` can be explicitly set
  - Verifies EVM transaction-flow response is handled correctly (like Solana/Stellar)
  - Verifies `prepareOnly: true` + `deployImmediately: true` returns `{ transactionId, status: "pending" }`
  - Verifies `prepareOnly: true` + `deployImmediately: false` returns `{ signatureId }`
  - Verifies Solana missing transaction still throws
  - Verifies EVM missing both `transaction` and `chains` throws
  - All 397 tests pass

## Package updates

- `@crossmint/wallets-sdk`: minor (changeset added)

Link to Devin session: https://crossmint.devinenterprise.com/sessions/8e002024ca984142a4f351c4d9adfb18
Requested by: @maxsch-xmint