### PR TITLE
fix(wallets): block signature approval on Stellar wallets (EVM-only)

### DIFF
--- a/.changeset/signatures-evm-only.md
+++ b/.changeset/signatures-evm-only.md
@@ -1,0 +1,13 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+fix: block signature approval on Stellar wallets (EVM-only)
+
+Message signing/approval is only implemented for EVM smart wallets: there is no
+signature-creation entry point for Stellar (only `EVMWallet` exposes
+`signMessage`/`signTypedData`), and the Stellar external-wallet and non-custodial
+signers reject `signMessage`. The approval guard previously blocked only Solana,
+letting Stellar fall through to an unusable path. It now blocks Stellar too, so
+`approve({ signatureId })` on a Stellar wallet throws the accurate
+"Approving signatures is only supported for EVM smart wallets" error.

--- a/packages/wallets/src/chains/adapters/stellar.ts
+++ b/packages/wallets/src/chains/adapters/stellar.ts
@@ -7,7 +7,7 @@ import type { AddSignerChain, AddSignerContext, ChainAdapter } from "../chain-ad
 export const stellarChainAdapter: ChainAdapter = {
     nativeToken: "xlm",
     walletLocatorPrefix: "me:stellar:smart",
-    supportsSignatures: true,
+    supportsSignatures: false,
 
     addSignerChain(_chain: Chain): AddSignerChain | undefined {
         return undefined;

--- a/packages/wallets/src/chains/chain-adapter.test.ts
+++ b/packages/wallets/src/chains/chain-adapter.test.ts
@@ -27,7 +27,7 @@ describe("chain-adapter", () => {
         it.each([
             ["base-sepolia", true],
             ["solana", false],
-            ["stellar", true],
+            ["stellar", false],
         ] as const)("%s -> %s", (chain, supports) => {
             expect(getChainAdapter(chain).supportsSignatures).toBe(supports);
         });


### PR DESCRIPTION
## What

Signature approval (`approve({ signatureId })`) is only meaningfully implemented for **EVM** smart wallets. This makes the SDK's behavior match that reality by blocking Stellar too, so the existing `"Approving signatures is only supported for EVM smart wallets"` error becomes accurate instead of misleading.

One-line behavior change: the Stellar `ChainAdapter`'s `supportsSignatures` flips `true → false`.

## Why

Investigated the full signature path:
- **No creation entry point for Stellar** — `createSignature` is only ever called by `EVMWallet.signMessage` / `signTypedData`; neither the base `Wallet` nor `StellarWallet` exposes a message-signing method.
- **Stellar signers reject it** — `StellarExternalWalletSigner.signMessage` and the non-custodial Stellar signer both throw "not implemented"; `StellarServerSigner.signMessage` exists only because `signTransaction` delegates to it.
- The `approveSignatureInternal` guard previously blocked **only Solana** (the original `isSolanaWallet` check), so Stellar fell through to this unusable path.

Transaction approval on Stellar is unaffected — `supportsSignatures` gates only `approveSignatureInternal`, not `approveTransactionInternal`.

## Notes

- **Stacked on #1926** (`wallets/chain-adapter`) because the Stellar adapter only exists there. Will retarget to `main` once #1926 merges.
- No consumer in the monorepo approves Stellar signatures; no existing test assumed it passed. Only the adapter parity test changes (`stellar → false`).
- Changeset included (patch).

## Test plan

- `pnpm --filter @crossmint/wallets-sdk test:vitest` → **605 passed / 0 failed / 68 skipped**
- biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/crossmint-sdk/pull/1927" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->