### PR TITLE
fix: add source_repo to docs dispatch payload for crossbit-main

### DIFF
--- a/.github/workflows/sdk-reference-docs-generate.yml
+++ b/.github/workflows/sdk-reference-docs-generate.yml
@@ -161,4 +161,4 @@ jobs:
                   token: ${{ steps.generate_app_token.outputs.token }}
                   repository: Paella-Labs/crossbit-main
                   event-type: sdk-reference-docs-update
-                  client-payload: '{"run_id": "${{ github.run_id }}", "packages": ${{ toJSON(inputs.packages || ''react-ui,react-native,node-wallets,react-checkout'') }}, "source_ref": ${{ toJSON(github.ref_name) }}}'
+                  client-payload: '{"run_id": "${{ github.run_id }}", "packages": ${{ toJSON(inputs.packages || ''react-ui,react-native,node-wallets,react-checkout'') }}, "source_repo": "crossmint-sdk", "source_ref": ${{ toJSON(github.ref_name) }}}'


### PR DESCRIPTION
## Description

The crossbit-main receiver workflow (`sdk-reference-docs-sync.yml`) now routes based on `source_repo` in the dispatch payload to support multiple SDK repos (crossmint-sdk, crossmint-swift-sdk, crossmint-kotlin-sdk). While `crossmint-sdk` is already the default fallback, adding it explicitly makes the contract clear and consistent with the Swift and Kotlin SDK dispatchers.

Related: https://github.com/Paella-Labs/crossbit-main/pull/26679

## Test plan

- No functional change for crossmint-sdk — it was already the default in the receiver workflow
- Adding the explicit field makes it future-proof and consistent with the mobile SDK dispatchers

## Package updates

No package updates needed — this is a workflow-only change.

Link to Devin session: https://crossmint.devinenterprise.com/sessions/320fbfb9cade44a3b20b20a6673388db
Requested by: @jmderby