### PR TITLE
refactor(wallets): extract ServerSignerResolver from wallet.ts

### DIFF
--- a/.changeset/server-signer-resolver.md
+++ b/.changeset/server-signer-resolver.md
@@ -1,0 +1,7 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+refactor: extract ServerSignerResolver from wallet.ts
+
+Moves server-signer key derivation, the dual primary/legacy derivation caches, and the secure-wipe discipline out of `wallet.ts` into a dedicated `ServerSignerResolver` (`signers/server/resolver.ts`). `wallet.ts` now delegates derivation, locator resolution, recovery resolution, and key-material assembly to the resolver. Internal refactor — no behavior or public API changes.

--- a/packages/wallets/src/signers/server/resolver.test.ts
+++ b/packages/wallets/src/signers/server/resolver.test.ts
@@ -1,0 +1,245 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiSourcedServerSignerConfig, ServerSignerConfig } from "../types";
+import { deriveServerSignerCandidates } from "../server";
+import { ServerSignerResolver } from "./resolver";
+vi.mock("../server", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("../server")>();
+    return { ...actual, deriveServerSignerCandidates: vi.fn() };
+});
+const mockedCandidates = vi.mocked(deriveServerSignerCandidates);
+type CandidateSpec = { address: string; fill: number };
+type Slot = "primary" | "legacy";
+type Derived = { derivedKeyBytes: Uint8Array; derivedAddress: string };
+type RecordedCandidates = { primary: Derived; legacy: Derived | null };
+const slot = (s: CandidateSpec) => ({ derivedKeyBytes: new Uint8Array(32).fill(s.fill), derivedAddress: s.address });
+const installCandidates = (
+    bySecret: Record<string, { primary: CandidateSpec; legacy: CandidateSpec | null }>
+): RecordedCandidates[] => {
+    const recorded: RecordedCandidates[] = [];
+    mockedCandidates.mockImplementation(((signer: { secret?: string }) => {
+        const spec = bySecret[signer?.secret ?? ""];
+        if (spec == null) {
+            throw new Error(`test setup: no candidate spec for secret "${signer?.secret}"`);
+        }
+        const out = { primary: slot(spec.primary), legacy: spec.legacy == null ? null : slot(spec.legacy) };
+        recorded.push(out);
+        return out;
+    }) as any);
+    return recorded;
+};
+const installDual = () =>
+    installCandidates({ s: { primary: { address: "0xPrimary", fill: 7 }, legacy: { address: "0xLegacy", fill: 9 } } });
+const isZeroed = (buf: Uint8Array): boolean => buf.length > 0 && buf.every((b) => b === 0);
+const everyByteIs = (buf: Uint8Array, value: number): boolean => buf.length === 32 && buf.every((b) => b === value);
+const expectWipedAndKept = (rec: RecordedCandidates, wiped: Slot, survivor: Slot, survivorFill: number) => {
+    expect(isZeroed(rec[wiped]!.derivedKeyBytes)).toBe(true);
+    expect(everyByteIs(rec[survivor]!.derivedKeyBytes, survivorFill)).toBe(true);
+};
+const fullConfig = (secret: string): ServerSignerConfig => ({ type: "server", secret });
+const apiConfig = (address: string): ApiSourcedServerSignerConfig => ({ type: "server", address });
+const makeResolver = (overrides?: {
+    apiRecoveryAddress?: string | null;
+    apiDelegatedAddresses?: string[];
+    knownOnChainAddresses?: string[];
+}): ServerSignerResolver =>
+    new ServerSignerResolver({
+        chain: "base-sepolia",
+        projectId: "proj_test_123",
+        environment: "staging",
+        apiRecoveryAddress: overrides?.apiRecoveryAddress ?? null,
+        apiDelegatedAddresses: overrides?.apiDelegatedAddresses ?? [],
+        knownOnChainAddresses: () => overrides?.knownOnChainAddresses ?? [],
+    });
+const cacheRecovery = (r: ServerSignerResolver, rec: RecordedCandidates[], secret: string) => {
+    expect(r.resolveForUseSigner(fullConfig(secret), [], () => true)).toEqual({ kind: "recovery" });
+    return rec[rec.length - 1];
+};
+const cacheDelegated = (r: ServerSignerResolver, rec: RecordedCandidates[], secret: string, loc: string) => {
+    expect(r.resolveForUseSigner(fullConfig(secret), [loc], () => false)).toEqual({ kind: "delegated" });
+    return rec[rec.length - 1];
+};
+describe("ServerSignerResolver", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+    it("deriveCandidates derives primary and legacy via the helper with chain, projectId, and environment", () => {
+        installCandidates({ s: { primary: { address: "0xP", fill: 7 }, legacy: { address: "0xL", fill: 9 } } });
+        const { primary, legacy } = makeResolver().deriveCandidates(fullConfig("s"));
+        expect(primary.derivedAddress).toBe("0xP");
+        expect(legacy?.derivedAddress).toBe("0xL");
+        const ctx = ["base-sepolia", "proj_test_123", "staging"];
+        expect(mockedCandidates).toHaveBeenNthCalledWith(1, fullConfig("s"), ...ctx);
+    });
+    describe("resolveDerivation", () => {
+        it("returns the cached recovery resolution for api-sourced config", () => {
+            const recorded = installCandidates({ rec: { primary: { address: "0xRec", fill: 5 }, legacy: null } });
+            const resolver = makeResolver({ apiRecoveryAddress: "0xRec" });
+            cacheRecovery(resolver, recorded, "rec");
+            const resolved = resolver.resolveDerivation(apiConfig("0xRec"));
+            expect(resolved.derivedAddress).toBe("0xRec");
+            expect(everyByteIs(resolved.derivedKeyBytes, 5)).toBe(true);
+        });
+        it("throws the exact message when api-sourced config has no cached recovery resolution", () => {
+            expect(() => makeResolver().resolveDerivation(apiConfig("0xSome"))).toThrow(
+                "Cannot resolve server signer derivation: no secret available and no cached recovery resolution. " +
+                    'Call wallet.useSigner({ type: "server", secret: ... }) first.'
+            );
+        });
+        it("returns the cache hit and wipes both fresh candidates", () => {
+            const resolver = makeResolver({ apiRecoveryAddress: "0xRecPrimary" });
+            const recorded = installCandidates({
+                rec: { primary: { address: "0xRecPrimary", fill: 7 }, legacy: { address: "0xRecLegacy", fill: 9 } },
+            });
+            cacheRecovery(resolver, recorded, "rec");
+            const cached = recorded[0].primary;
+            expect(resolver.resolveDerivation(fullConfig("rec"))).toBe(cached);
+            expect(isZeroed(recorded[1].primary.derivedKeyBytes)).toBe(true);
+            expect(isZeroed(recorded[1].legacy!.derivedKeyBytes)).toBe(true);
+            expect(everyByteIs(cached.derivedKeyBytes, 7)).toBe(true);
+        });
+        it.each([
+            ["legacy matches apiRecoveryAddress", { apiRecoveryAddress: "0xLegacy" }],
+            ["legacy is a known on-chain address", { knownOnChainAddresses: ["0xLegacy"] }],
+        ] as const)("picks legacy and wipes primary when %s", (_t, o) => {
+            const recorded = installDual();
+            expect(makeResolver(o).resolveDerivation(fullConfig("s")).derivedAddress).toBe("0xLegacy");
+            expectWipedAndKept(recorded[0], "primary", "legacy", 9);
+        });
+        it("picks primary and wipes legacy otherwise", () => {
+            const recorded = installDual();
+            expect(makeResolver().resolveDerivation(fullConfig("s")).derivedAddress).toBe("0xPrimary");
+            expectWipedAndKept(recorded[0], "legacy", "primary", 7);
+        });
+    });
+    it("apiLocator formats the resolved derived address as a server locator", () => {
+        installCandidates({ s: { primary: { address: "0xPrimary", fill: 7 }, legacy: null } });
+        expect(makeResolver().apiLocator(fullConfig("s"))).toBe("server:0xPrimary");
+    });
+    describe("resolveForUseSigner", () => {
+        it.each([
+            ["server:0xPrimary", "legacy", "primary", 7],
+            ["server:0xLegacy", "primary", "legacy", 9],
+        ] as const)("returns delegated, wipes non-selected, keeps selected (%s)", (loc, w, s, f) => {
+            const recorded = installDual();
+            const r = makeResolver().resolveForUseSigner(fullConfig("s"), [loc], () => false);
+            expect(r).toEqual({ kind: "delegated" });
+            expectWipedAndKept(recorded[0], w, s, f);
+        });
+        it("caches the selected delegated candidate so a later resolveDerivation cache-hit returns it", () => {
+            const recorded = installCandidates({ s: { primary: { address: "0xPrimary", fill: 7 }, legacy: null } });
+            const resolver = makeResolver();
+            const cached = cacheDelegated(resolver, recorded, "s", "server:0xPrimary").primary;
+            installCandidates({ s: { primary: { address: "0xPrimary", fill: 7 }, legacy: null } });
+            expect(resolver.resolveDerivation(fullConfig("s"))).toBe(cached);
+        });
+        it("returns recovery and caches the recovery slot when not registered but isRecovery is true", () => {
+            installCandidates({ s: { primary: { address: "0xPrimary", fill: 7 }, legacy: null } });
+            const resolver = makeResolver();
+            expect(resolver.resolveForUseSigner(fullConfig("s"), [], () => true)).toEqual({ kind: "recovery" });
+            expect(resolver.hasRecoveryResolution).toBe(true);
+        });
+        it("returns the dual-locator unregistered message and wipes both candidates", () => {
+            const recorded = installCandidates({
+                s: { primary: { address: "0xPrimaryAddr", fill: 7 }, legacy: { address: "0xLegacyAddr", fill: 9 } },
+            });
+            const r = makeResolver().resolveForUseSigner(fullConfig("s"), [], () => false);
+            const message = 'Signer "server:0xPrimaryAddr" or "server:0xLegacyAddr" is not registered in this wallet.';
+            expect(r).toEqual({ kind: "unregistered", message });
+            expect(isZeroed(recorded[0].primary.derivedKeyBytes)).toBe(true);
+            expect(isZeroed(recorded[0].legacy!.derivedKeyBytes)).toBe(true);
+        });
+        it("returns the single-locator unregistered message and wipes the primary when there is no legacy", () => {
+            const recorded = installCandidates({ s: { primary: { address: "0xOnlyPrimary", fill: 7 }, legacy: null } });
+            const r = makeResolver().resolveForUseSigner(fullConfig("s"), [], () => false);
+            const message = 'Signer "server:0xOnlyPrimary" is not registered in this wallet.';
+            expect(r).toEqual({ kind: "unregistered", message });
+            expect(isZeroed(recorded[0].primary.derivedKeyBytes)).toBe(true);
+        });
+        it("does not consult isRecovery when a candidate is already registered", () => {
+            installCandidates({ s: { primary: { address: "0xPrimary", fill: 7 }, legacy: null } });
+            const isRecovery = vi.fn(() => true);
+            makeResolver().resolveForUseSigner(fullConfig("s"), ["server:0xPrimary"], isRecovery);
+            expect(isRecovery).not.toHaveBeenCalled();
+        });
+        it.each([
+            ["legacy matches apiRecoveryAddress", "0xLegacy", "primary", "legacy", 9],
+            ["primary otherwise", "0xPrimary", "legacy", "primary", 7],
+        ] as const)("caches the recovery slot and wipes the non-selected candidate (%s)", (_t, rec, w, s, f) => {
+            const recorded = installDual();
+            const resolver = makeResolver({ apiRecoveryAddress: rec });
+            expect(resolver.resolveForUseSigner(fullConfig("s"), [], () => true)).toEqual({ kind: "recovery" });
+            expect(resolver.resolvedRecoveryAddress).toBe(rec);
+            expectWipedAndKept(recorded[0], w, s, f);
+        });
+    });
+    it("keyMaterialForAssembly returns a copy of cached bytes the caller can wipe without corrupting the cache", () => {
+        const recorded = installCandidates({ rec: { primary: { address: "0xRec", fill: 5 }, legacy: null } });
+        const resolver = makeResolver({ apiRecoveryAddress: "0xRec" });
+        const cached = cacheRecovery(resolver, recorded, "rec").primary;
+        installCandidates({ rec: { primary: { address: "0xRec", fill: 5 }, legacy: null } });
+        const first = resolver.keyMaterialForAssembly(fullConfig("rec"));
+        expect(first.derivedKeyBytes).not.toBe(cached.derivedKeyBytes);
+        expect(everyByteIs(first.derivedKeyBytes, 5)).toBe(true);
+        first.derivedKeyBytes.fill(0);
+        expect(everyByteIs(cached.derivedKeyBytes, 5)).toBe(true);
+        installCandidates({ rec: { primary: { address: "0xRec", fill: 5 }, legacy: null } });
+        const second = resolver.keyMaterialForAssembly(fullConfig("rec"));
+        expect(second.derivedKeyBytes).not.toBe(first.derivedKeyBytes);
+        expect(everyByteIs(second.derivedKeyBytes, 5)).toBe(true);
+    });
+    it("keyMaterialForAssembly wipes the resolved derivation when it is neither cached slot, after copying", () => {
+        const recorded = installDual();
+        const material = makeResolver().keyMaterialForAssembly(fullConfig("s"));
+        expect(material.derivedAddress).toBe("0xPrimary");
+        expect(everyByteIs(material.derivedKeyBytes, 7)).toBe(true);
+        expect(isZeroed(recorded[0].primary.derivedKeyBytes)).toBe(true);
+        expect(isZeroed(recorded[0].legacy!.derivedKeyBytes)).toBe(true);
+    });
+    it("candidateAddresses returns the api-sourced address for api-sourced config without deriving", () => {
+        expect(makeResolver().candidateAddresses(apiConfig("0xApiAddr"))).toEqual(["0xApiAddr"]);
+        expect(mockedCandidates).not.toHaveBeenCalled();
+    });
+    it.each([
+        ["collects both addresses and wipes both", { address: "0xLegacy", fill: 9 }, ["0xPrimary", "0xLegacy"]],
+        ["returns only the primary address and wipes it when no legacy", null, ["0xPrimary"]],
+    ] as [string, CandidateSpec | null, string[]][])("candidateAddresses derives, %s", (_t, legacy, expected) => {
+        const recorded = installCandidates({ s: { primary: { address: "0xPrimary", fill: 7 }, legacy } });
+        expect(makeResolver().candidateAddresses(fullConfig("s"))).toEqual(expected);
+        expect(isZeroed(recorded[0].primary.derivedKeyBytes)).toBe(true);
+        const leg = recorded[0].legacy;
+        expect(leg == null || isZeroed(leg.derivedKeyBytes)).toBe(true);
+    });
+    it("resetDelegatedCache wipes and clears the delegated cache while preserving the recovery cache", () => {
+        const recorded = installCandidates({ rec: { primary: { address: "0xRec", fill: 5 }, legacy: null } });
+        const resolver = makeResolver({ apiRecoveryAddress: "0xRec" });
+        const recoveryCached = cacheRecovery(resolver, recorded, "rec").primary;
+        const dRec = installCandidates({ del: { primary: { address: "0xDel", fill: 3 }, legacy: null } });
+        expect(everyByteIs(cacheDelegated(resolver, dRec, "del", "server:0xDel").primary.derivedKeyBytes, 3)).toBe(
+            true
+        );
+        resolver.resetDelegatedCache();
+        expect(isZeroed(dRec[0].primary.derivedKeyBytes)).toBe(true);
+        expect(resolver.hasRecoveryResolution).toBe(true);
+        expect(everyByteIs(recoveryCached.derivedKeyBytes, 5)).toBe(true);
+        expect(resolver.resolveDerivation(apiConfig("0xRec"))).toBe(recoveryCached);
+    });
+    it("hasRecoveryResolution reflects whether the recovery cache is populated", () => {
+        const recorded = installCandidates({ rec: { primary: { address: "0xRec", fill: 5 }, legacy: null } });
+        const resolver = makeResolver({ apiRecoveryAddress: "0xRec" });
+        expect(resolver.hasRecoveryResolution).toBe(false);
+        cacheRecovery(resolver, recorded, "rec");
+        expect(resolver.hasRecoveryResolution).toBe(true);
+    });
+    it("resolvedRecoveryAddress is null until cached, then exposes the resolved derived address", () => {
+        const recorded = installCandidates({ rec: { primary: { address: "0xRec", fill: 5 }, legacy: null } });
+        const resolver = makeResolver({ apiRecoveryAddress: "0xRec" });
+        expect(resolver.resolvedRecoveryAddress).toBeNull();
+        cacheRecovery(resolver, recorded, "rec");
+        expect(resolver.resolvedRecoveryAddress).toBe("0xRec");
+    });
+    it("exposes the constructor-provided api recovery and delegated addresses", () => {
+        const resolver = makeResolver({ apiRecoveryAddress: "0xRec", apiDelegatedAddresses: ["0xDelA", "0xDelB"] });
+        expect(resolver.apiRecoveryAddress).toBe("0xRec");
+        expect(resolver.apiDelegatedAddresses).toEqual(["0xDelA", "0xDelB"]);
+    });
+});

--- a/packages/wallets/src/signers/server/resolver.ts
+++ b/packages/wallets/src/signers/server/resolver.ts
@@ -1,0 +1,188 @@
+import type { Chain } from "../../chains/chains";
+import { secureWipe } from "../../utils/secure-wipe";
+import {
+    type ApiSourcedServerSignerConfig,
+    type DerivedServerSigner,
+    type ServerSignerConfig,
+    type ServerSignerLocator,
+    isApiSourcedServerSignerConfig,
+} from "../types";
+import { deriveServerSignerCandidates as deriveServerSignerCandidatesHelper } from "../server";
+
+export class ServerSignerResolver {
+    readonly #chain: Chain;
+    readonly #projectId: string;
+    readonly #environment: string;
+    readonly #apiRecoveryAddress: string | null;
+    readonly #apiDelegatedAddresses: string[];
+    readonly #knownOnChainAddresses: () => string[];
+
+    #resolvedServerSigner: DerivedServerSigner | null = null;
+    #resolvedRecoveryServerSigner: DerivedServerSigner | null = null;
+
+    constructor(params: {
+        chain: Chain;
+        projectId: string;
+        environment: string;
+        apiRecoveryAddress: string | null;
+        apiDelegatedAddresses: string[];
+        knownOnChainAddresses: () => string[];
+    }) {
+        this.#chain = params.chain;
+        this.#projectId = params.projectId;
+        this.#environment = params.environment;
+        this.#apiRecoveryAddress = params.apiRecoveryAddress;
+        this.#apiDelegatedAddresses = params.apiDelegatedAddresses;
+        this.#knownOnChainAddresses = params.knownOnChainAddresses;
+    }
+
+    deriveCandidates(config: ServerSignerConfig): { primary: DerivedServerSigner; legacy: DerivedServerSigner | null } {
+        return deriveServerSignerCandidatesHelper(config, this.#chain, this.#projectId, this.#environment);
+    }
+
+    resolveDerivation(config: ServerSignerConfig | ApiSourcedServerSignerConfig): DerivedServerSigner {
+        if (isApiSourcedServerSignerConfig(config)) {
+            if (this.#resolvedRecoveryServerSigner != null) {
+                return this.#resolvedRecoveryServerSigner;
+            }
+            throw new Error(
+                "Cannot resolve server signer derivation: no secret available and no cached recovery resolution. " +
+                    'Call wallet.useSigner({ type: "server", secret: ... }) first.'
+            );
+        }
+
+        const { primary, legacy } = this.deriveCandidates(config);
+        const cached = this.#resolvedServerSigner ?? this.#resolvedRecoveryServerSigner;
+        if (cached != null) {
+            const cachedAddr = cached.derivedAddress;
+            if (cachedAddr === primary.derivedAddress || (legacy != null && cachedAddr === legacy.derivedAddress)) {
+                secureWipe(primary.derivedKeyBytes, legacy?.derivedKeyBytes);
+                return cached;
+            }
+        }
+
+        if (legacy != null) {
+            if (legacy.derivedAddress === this.#apiRecoveryAddress) {
+                secureWipe(primary.derivedKeyBytes);
+                return legacy;
+            }
+            if (this.#knownOnChainAddresses().includes(legacy.derivedAddress)) {
+                secureWipe(primary.derivedKeyBytes);
+                return legacy;
+            }
+            secureWipe(legacy.derivedKeyBytes);
+        }
+        return primary;
+    }
+
+    apiLocator(config: ServerSignerConfig | ApiSourcedServerSignerConfig): ServerSignerLocator {
+        return `server:${this.resolveDerivation(config).derivedAddress}`;
+    }
+
+    /**
+     * Resolves a server signer with a SINGLE candidate derivation: the same derivation drives the
+     * registered check, the recovery selection, and the unregistered wipe, so key material is
+     * derived (and wiped) exactly once. `isRecovery` is consulted only after the registered check fails.
+     */
+    resolveForUseSigner(
+        config: ServerSignerConfig,
+        registeredLocators: string[],
+        isRecovery: () => boolean
+    ): { kind: "delegated" } | { kind: "recovery" } | { kind: "unregistered"; message: string } {
+        const { primary, legacy } = this.deriveCandidates(config);
+        if (this.#selectRegistered(primary, legacy, registeredLocators) != null) {
+            return { kind: "delegated" };
+        }
+        if (isRecovery()) {
+            this.#selectRecovery(primary, legacy);
+            return { kind: "recovery" };
+        }
+        const tried =
+            legacy != null
+                ? `"server:${primary.derivedAddress}" or "server:${legacy.derivedAddress}"`
+                : `"server:${primary.derivedAddress}"`;
+        secureWipe(primary.derivedKeyBytes, legacy?.derivedKeyBytes);
+        return { kind: "unregistered", message: `Signer ${tried} is not registered in this wallet.` };
+    }
+
+    #selectRegistered(
+        primary: DerivedServerSigner,
+        legacy: DerivedServerSigner | null,
+        registeredLocators: string[]
+    ): DerivedServerSigner | null {
+        if (registeredLocators.includes(`server:${primary.derivedAddress}`)) {
+            this.#resolvedServerSigner = primary;
+            this.#wipeNonSelectedCandidate(primary, legacy);
+            return primary;
+        }
+        if (legacy != null && registeredLocators.includes(`server:${legacy.derivedAddress}`)) {
+            this.#resolvedServerSigner = legacy;
+            this.#wipeNonSelectedCandidate(legacy, primary);
+            return legacy;
+        }
+        return null;
+    }
+
+    #selectRecovery(primary: DerivedServerSigner, legacy: DerivedServerSigner | null): DerivedServerSigner {
+        if (this.#apiRecoveryAddress != null && legacy != null && legacy.derivedAddress === this.#apiRecoveryAddress) {
+            this.#resolvedRecoveryServerSigner = legacy;
+            this.#wipeNonSelectedCandidate(legacy, primary);
+            return legacy;
+        }
+        this.#resolvedRecoveryServerSigner = primary;
+        this.#wipeNonSelectedCandidate(primary, legacy);
+        return primary;
+    }
+
+    keyMaterialForAssembly(config: ServerSignerConfig | ApiSourcedServerSignerConfig): {
+        derivedKeyBytes: Uint8Array;
+        derivedAddress: string;
+    } {
+        const resolved = this.resolveDerivation(config);
+        const keyBytesCopy = new Uint8Array(resolved.derivedKeyBytes);
+        if (resolved !== this.#resolvedServerSigner && resolved !== this.#resolvedRecoveryServerSigner) {
+            secureWipe(resolved.derivedKeyBytes);
+        }
+        return { derivedKeyBytes: keyBytesCopy, derivedAddress: resolved.derivedAddress };
+    }
+
+    candidateAddresses(config: ServerSignerConfig | ApiSourcedServerSignerConfig): string[] {
+        if (isApiSourcedServerSignerConfig(config)) {
+            return [config.address];
+        }
+        const { primary, legacy } = this.deriveCandidates(config);
+        const addresses = [primary.derivedAddress];
+        if (legacy != null) {
+            addresses.push(legacy.derivedAddress);
+        }
+        secureWipe(primary.derivedKeyBytes, legacy?.derivedKeyBytes);
+        return addresses;
+    }
+
+    resetDelegatedCache(): void {
+        secureWipe(this.#resolvedServerSigner?.derivedKeyBytes);
+        this.#resolvedServerSigner = null;
+    }
+
+    get hasRecoveryResolution(): boolean {
+        return this.#resolvedRecoveryServerSigner != null;
+    }
+
+    get resolvedRecoveryAddress(): string | null {
+        return this.#resolvedRecoveryServerSigner?.derivedAddress ?? null;
+    }
+
+    get apiRecoveryAddress(): string | null {
+        return this.#apiRecoveryAddress;
+    }
+
+    get apiDelegatedAddresses(): string[] {
+        return this.#apiDelegatedAddresses;
+    }
+
+    #wipeNonSelectedCandidate(selected: DerivedServerSigner, other: DerivedServerSigner | null): void {
+        if (other != null && other !== selected) {
+            secureWipe(other.derivedKeyBytes);
+        }
+    }
+}

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -68,11 +68,7 @@ import {
 } from "../signers/types";
 import { assembleSigner } from "../signers";
 import { NonCustodialSigner } from "../signers/non-custodial";
-import {
-    type DerivedServerSigner,
-    deriveServerSignerCandidates as deriveServerSignerCandidatesHelper,
-} from "../signers/server";
-import { secureWipe } from "../utils/secure-wipe";
+import { ServerSignerResolver } from "../signers/server/resolver";
 import { walletsLogger } from "../logger";
 
 import { getSignerLocator } from "../utils/signer-locator";
@@ -107,9 +103,7 @@ export class Wallet<C extends Chain> {
     #initialSigners: SignerConfigForChain<C>[];
     #needsRecovery = false;
     #deviceSignerApproved = false;
-    #resolvedServerSigner: DerivedServerSigner | null = null;
-    #resolvedRecoveryServerSigner: DerivedServerSigner | null = null;
-    #apiRecoveryServerSignerAddress: string | null = null;
+    #serverSignerResolver: ServerSignerResolver;
     #apiDelegatedServerSignerAddresses: string[] = [];
     #signerInitialization: Promise<void>;
     #recovering: Promise<void> | null = null;
@@ -140,13 +134,30 @@ export class Wallet<C extends Chain> {
         this.#options = options;
         this.alias = alias;
         this.#recovery = recovery;
+        let apiRecoveryAddress: string | null = null;
         if (apiRecoveryServerSignerAddress != null) {
-            this.#apiRecoveryServerSignerAddress = apiRecoveryServerSignerAddress;
+            apiRecoveryAddress = apiRecoveryServerSignerAddress;
         } else if (recovery.type === "server" && isApiSourcedServerSignerConfig(recovery)) {
-            this.#apiRecoveryServerSignerAddress = recovery.address;
+            apiRecoveryAddress = recovery.address;
         }
         this.#apiDelegatedServerSignerAddresses = apiDelegatedServerSignerAddresses ?? [];
         this.#initialSigners = signers ?? [];
+        this.#serverSignerResolver = new ServerSignerResolver({
+            chain,
+            projectId: this.#apiClient.projectId,
+            environment: this.#apiClient.environment,
+            apiRecoveryAddress,
+            apiDelegatedAddresses: this.#apiDelegatedServerSignerAddresses,
+            knownOnChainAddresses: () => [
+                ...this.#initialSigners
+                    .filter(
+                        (s): s is SignerConfigForChain<C> & ApiSourcedServerSignerConfig =>
+                            s.type === "server" && isApiSourcedServerSignerConfig(s)
+                    )
+                    .map((s) => s.address),
+                ...this.#apiDelegatedServerSignerAddresses,
+            ],
+        });
         this.#signer = signer; // Can be set by useSigner
         this.#signerInitialization = this.initDefaultSigner();
     }
@@ -309,7 +320,7 @@ export class Wallet<C extends Chain> {
     }
 
     protected static getApiRecoveryServerSignerAddress<C extends Chain>(wallet: Wallet<C>): string | undefined {
-        return wallet.#apiRecoveryServerSignerAddress ?? undefined;
+        return wallet.#serverSignerResolver.apiRecoveryAddress ?? undefined;
     }
 
     protected static getApiDelegatedServerSignerAddresses<C extends Chain>(wallet: Wallet<C>): string[] {
@@ -329,74 +340,10 @@ export class Wallet<C extends Chain> {
     }
 
     /**
-     * Derive both primary ("evm") and legacy (chain-specific) server signer candidates.
-     */
-    private deriveServerSignerCandidates(signer: ServerSignerConfig) {
-        return deriveServerSignerCandidatesHelper(
-            signer,
-            this.chain,
-            this.#apiClient.projectId,
-            this.#apiClient.environment
-        );
-    }
-
-    /**
-     * Resolve which derivation (primary "evm" or legacy chain-specific) to use for a server signer.
-     * Priority: cached resolution (with address verification) → legacy if it matches a known
-     * on-chain address → primary.
-     */
-    private resolveServerSignerDerivation(
-        signer: ServerSignerConfig | ApiSourcedServerSignerConfig
-    ): DerivedServerSigner {
-        // API-sourced config (stripped recovery): use the dedicated recovery cache.
-        if (isApiSourcedServerSignerConfig(signer)) {
-            if (this.#resolvedRecoveryServerSigner != null) {
-                return this.#resolvedRecoveryServerSigner;
-            }
-            throw new Error(
-                "Cannot resolve server signer derivation: no secret available and no cached recovery resolution. " +
-                    'Call wallet.useSigner({ type: "server", secret: ... }) first.'
-            );
-        }
-
-        // Full config with secret: derive candidates and check if any existing cache
-        // (delegated or recovery) already holds a matching derivation.
-        const { primary, legacy } = this.deriveServerSignerCandidates(signer);
-        const cached = this.#resolvedServerSigner ?? this.#resolvedRecoveryServerSigner;
-        if (cached != null) {
-            const cachedAddr = cached.derivedAddress;
-            if (cachedAddr === primary.derivedAddress || (legacy != null && cachedAddr === legacy.derivedAddress)) {
-                secureWipe(primary.derivedKeyBytes, legacy?.derivedKeyBytes);
-                return cached;
-            }
-        }
-
-        // No cache or cache from a different secret — apply heuristic picking.
-        if (legacy != null) {
-            if (legacy.derivedAddress === this.#apiRecoveryServerSignerAddress) {
-                secureWipe(primary.derivedKeyBytes);
-                return legacy;
-            }
-            if (
-                this.#initialSigners.some(
-                    (s) =>
-                        s.type === "server" && isApiSourcedServerSignerConfig(s) && s.address === legacy.derivedAddress
-                ) ||
-                this.#apiDelegatedServerSignerAddresses.includes(legacy.derivedAddress)
-            ) {
-                secureWipe(primary.derivedKeyBytes);
-                return legacy;
-            }
-            secureWipe(legacy.derivedKeyBytes);
-        }
-        return primary;
-    }
-
-    /**
      * Resolve a ServerSignerConfig to an API locator string.
      */
     protected resolveServerSignerApiLocator(signer: ServerSignerConfig): string {
-        return `server:${this.resolveServerSignerDerivation(signer).derivedAddress}`;
+        return this.#serverSignerResolver.apiLocator(signer);
     }
 
     /**
@@ -928,11 +875,10 @@ export class Wallet<C extends Chain> {
     public async useSigner(signer: SignerConfigForChain<C>): Promise<void> {
         walletsLogger.info("wallet.useSigner.start");
         // Reset the delegated signer cache when processing a fresh server signer.
-        // #resolvedRecoveryServerSigner is intentionally preserved — it's set once during
+        // The recovery resolution is intentionally preserved — it's set once during
         // recovery resolution and must survive across useSigner calls.
         if (signer.type === "server") {
-            secureWipe(this.#resolvedServerSigner?.derivedKeyBytes);
-            this.#resolvedServerSigner = null;
+            this.#serverSignerResolver.resetDelegatedCache();
         }
         this.validateSignerInput(signer);
 
@@ -961,7 +907,7 @@ export class Wallet<C extends Chain> {
         // Passkeys are excluded because isRecoverySigner matches by type only, which could
         // incorrectly match a delegated passkey.
         // Server signers are excluded so they always flow through the server signer block below,
-        // which sets #resolvedServerSigner to the correct (primary or legacy) key.
+        // which resolves the correct (primary or legacy) derivation.
         if (signer.type !== "passkey" && signer.type !== "server" && this.isRecoverySigner(signer)) {
             this.#needsRecovery = false;
             return true;
@@ -1001,59 +947,25 @@ export class Wallet<C extends Chain> {
     }
 
     /**
-     * Resolve a server signer: try primary ("evm") derivation first, fall back to legacy
-     * (chain-specific) derivation when checking registration. Sets #resolvedServerSigner
-     * to whichever derivation is on-chain. Returns true if the signer is the admin (recovery) signer.
+     * Resolve a server signer: prefer a derivation already registered on-chain, else fall back
+     * to the recovery (admin) signer. Returns true if the signer is the admin (recovery) signer.
      */
     private async resolveServerSigner(signer: ServerSignerConfig): Promise<boolean> {
-        const { primary, legacy } = this.deriveServerSignerCandidates(signer);
         const existingSigners = await this.signers();
-        if (existingSigners.some((s) => s.locator === `server:${primary.derivedAddress}`)) {
-            this.#resolvedServerSigner = primary;
-            this.wipeNonSelectedCandidate(primary, legacy);
-            this.#needsRecovery = false;
-            return false;
-        }
-        if (legacy != null && existingSigners.some((s) => s.locator === `server:${legacy.derivedAddress}`)) {
-            this.#resolvedServerSigner = legacy;
-            this.wipeNonSelectedCandidate(legacy, primary);
-            this.#needsRecovery = false;
-            return false;
-        }
-        // Neither found as delegated — check if this is the recovery (admin) signer.
-        if (this.isRecoverySigner(signer as SignerConfigForChain<C>)) {
-            // Resolve which derivation matches the on-chain recovery address.
-            // #apiRecoveryServerSignerAddress is captured once from the original API response
-            // and survives across isRecoverySigner upgrades and repeated useSigner calls.
-            if (
-                this.#apiRecoveryServerSignerAddress != null &&
-                legacy != null &&
-                legacy.derivedAddress === this.#apiRecoveryServerSignerAddress
-            ) {
-                this.#resolvedRecoveryServerSigner = legacy;
-                this.wipeNonSelectedCandidate(legacy, primary);
-            } else {
-                this.#resolvedRecoveryServerSigner = primary;
-                this.wipeNonSelectedCandidate(primary, legacy);
-            }
-            this.stripSecretFromRecovery();
-            this.#needsRecovery = false;
-            return true;
-        }
-        const tried =
-            legacy != null
-                ? `"server:${primary.derivedAddress}" or "server:${legacy.derivedAddress}"`
-                : `"server:${primary.derivedAddress}"`;
-        secureWipe(primary.derivedKeyBytes, legacy?.derivedKeyBytes);
-        throw new Error(`Signer ${tried} is not registered in this wallet.`);
-    }
-
-    /**
-     * Wipe the derivedKeyBytes of the non-selected candidate to reduce key material in memory.
-     */
-    private wipeNonSelectedCandidate(selected: DerivedServerSigner, other: DerivedServerSigner | null): void {
-        if (other != null && other !== selected) {
-            secureWipe(other.derivedKeyBytes);
+        const registeredLocators = existingSigners.map((s) => s.locator);
+        const resolution = this.#serverSignerResolver.resolveForUseSigner(signer, registeredLocators, () =>
+            this.isRecoverySigner(signer as SignerConfigForChain<C>)
+        );
+        switch (resolution.kind) {
+            case "delegated":
+                this.#needsRecovery = false;
+                return false;
+            case "recovery":
+                this.stripSecretFromRecovery();
+                this.#needsRecovery = false;
+                return true;
+            case "unregistered":
+                throw new Error(resolution.message);
         }
     }
 
@@ -1063,15 +975,16 @@ export class Wallet<C extends Chain> {
      * retained in memory for the wallet's lifetime.
      */
     private stripSecretFromRecovery(): void {
+        const resolvedRecoveryAddress = this.#serverSignerResolver.resolvedRecoveryAddress;
         if (
             this.#recovery != null &&
             this.#recovery.type === "server" &&
             !isApiSourcedServerSignerConfig(this.#recovery) &&
-            this.#resolvedRecoveryServerSigner != null
+            resolvedRecoveryAddress != null
         ) {
             this.#recovery = {
                 type: "server",
-                address: this.#resolvedRecoveryServerSigner.derivedAddress,
+                address: resolvedRecoveryAddress,
             } as RecoverySignerConfigForChain<C>;
         }
     }
@@ -1111,7 +1024,7 @@ export class Wallet<C extends Chain> {
 
     private async withRecoverySigner<T>(operation: () => Promise<T>): Promise<T> {
         const originalSigner = this.signer;
-        if (isApiSourcedServerSignerConfig(this.#recovery) && this.#resolvedRecoveryServerSigner == null) {
+        if (isApiSourcedServerSignerConfig(this.#recovery) && !this.#serverSignerResolver.hasRecoveryResolution) {
             throw new Error(
                 "Cannot assemble server signer: no secret available. " +
                     'Call wallet.useSigner({ type: "server", secret: ... }) first with the recovery server secret.'
@@ -1368,7 +1281,7 @@ export class Wallet<C extends Chain> {
         pendingOperation: { type: "signature" | "transaction"; id: string }
     ): Promise<void> {
         const originalSigner = this.#signer;
-        if (isApiSourcedServerSignerConfig(this.#recovery) && this.#resolvedRecoveryServerSigner == null) {
+        if (isApiSourcedServerSignerConfig(this.#recovery) && !this.#serverSignerResolver.hasRecoveryResolution) {
             throw new Error(
                 "Cannot resume pending approval: no secret available. " +
                     'Call wallet.useSigner({ type: "server", secret: ... }) first with the recovery server secret.'
@@ -1599,21 +1512,8 @@ export class Wallet<C extends Chain> {
         // For server signers, the API-sourced recovery config has no secret, so we
         // can't derive a locator from it. Compare using the address field instead.
         if (signerConfig.type === "server" && recovery.type === "server") {
-            const resolveAddresses = (config: ServerSignerConfig | ApiSourcedServerSignerConfig): string[] => {
-                if (isApiSourcedServerSignerConfig(config)) {
-                    return [config.address];
-                }
-                const { primary, legacy } = this.deriveServerSignerCandidates(config);
-                const addresses = [primary.derivedAddress];
-                if (legacy != null) {
-                    addresses.push(legacy.derivedAddress);
-                }
-                secureWipe(primary.derivedKeyBytes, legacy?.derivedKeyBytes);
-                return addresses;
-            };
-
-            const signerAddresses = resolveAddresses(signerConfig);
-            const recoveryAddresses = resolveAddresses(recovery);
+            const signerAddresses = this.#serverSignerResolver.candidateAddresses(signerConfig);
+            const recoveryAddresses = this.#serverSignerResolver.candidateAddresses(recovery);
 
             // Match if any signer address matches any recovery address
             const matches = signerAddresses.some((a) => recoveryAddresses.includes(a));
@@ -1805,18 +1705,13 @@ export class Wallet<C extends Chain> {
                 } as InternalSignerConfig<C>;
             case "server": {
                 const serverConfig = config as ServerSignerConfig | ApiSourcedServerSignerConfig;
-                const resolved = this.resolveServerSignerDerivation(serverConfig);
-                // Copy the derived key bytes so the signer adapter can safely wipe its copy
-                // without corrupting the cached #resolvedServerSigner reference.
-                const keyBytesCopy = new Uint8Array(resolved.derivedKeyBytes);
-                if (resolved !== this.#resolvedServerSigner && resolved !== this.#resolvedRecoveryServerSigner) {
-                    secureWipe(resolved.derivedKeyBytes);
-                }
+                const { derivedKeyBytes, derivedAddress } =
+                    this.#serverSignerResolver.keyMaterialForAssembly(serverConfig);
                 return {
                     type: "server",
-                    derivedKeyBytes: keyBytesCopy,
-                    locator: `server:${resolved.derivedAddress}` as ServerSignerLocator,
-                    address: resolved.derivedAddress,
+                    derivedKeyBytes,
+                    locator: `server:${derivedAddress}` as ServerSignerLocator,
+                    address: derivedAddress,
                 } as InternalSignerConfig<C>;
             }
             default:
@@ -1840,7 +1735,7 @@ export class Wallet<C extends Chain> {
             case "device":
                 return this.#options?.deviceSignerKeyStorage != null;
             case "server":
-                return !isApiSourcedServerSignerConfig(config) || this.#resolvedRecoveryServerSigner != null;
+                return !isApiSourcedServerSignerConfig(config) || this.#serverSignerResolver.hasRecoveryResolution;
             case "external-wallet":
                 return "onSign" in config && typeof config.onSign === "function";
             default:


### PR DESCRIPTION
## What

Phase 3 (first of two) of the `wallet.ts` decomposition. Extracts server-signer key derivation, the dual primary/legacy derivation caches, and the #1911 secure-wipe discipline into a dedicated `ServerSignerResolver` (`signers/server/resolver.ts`). **Pure refactor, no behavior change.** wallet.ts drops ~100 lines (net +55/−160 here).

`wallet.ts` now delegates to the resolver for: candidate derivation, locator resolution, the single-derivation `useSigner` resolution (`resolveForUseSigner`), recovery resolution, key-material assembly, and the recovery-config guards (`hasRecoveryResolution`).

## Review surface

The wallet.ts diff is small (+55/−160); the bulk is the new `resolver.ts` (188 lines) + its colocated tests. Worth focusing on:
- **Wipe ordering** — every `secureWipe` from the original is reproduced at the same point; cached candidates are never wiped by the assembly path; `keyMaterialForAssembly` returns a copy. The resolver tests pin each wipe (zeroed loser / intact survivor) and the exact error strings.
- **Single-derivation `resolveForUseSigner`** — replaces what would have been two separate derive calls, so key material is derived (and wiped) exactly once, matching the original `resolveServerSigner` flow.
- **`stripSecretFromRecovery` stays in Wallet** (it mutates `#recovery`) and reads the resolved recovery address from the resolver.
- **`from()` rewrap** — the chain subclasses' `getApiRecoveryServerSignerAddress`/`getApiDelegatedServerSignerAddresses` still return the same values, now via the resolver.

## Notes

- An adversarial review focused on wipe ordering / dual-cache semantics passed; validated against the local server-signer-hygiene characterization suite (21 Wallet-level tests, unchanged).
- Two test-only public methods that an earlier draft exposed (`resolveFromRegistered`/`resolveAsRecovery`) were dropped — production uses `resolveForUseSigner`, and exposing the split primitives invited the double-derivation they exist to avoid.
- Changeset included (patch, internal refactor).

## Test plan

- `pnpm --filter @crossmint/wallets-sdk test:vitest` → **640 passed / 0 failed / 68 skipped**
- `tsc --noEmit` clean; build green; biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/crossmint-sdk/pull/1931" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->