### PR TITLE
refactor(wallets): SignerDescriptor registry — per-type config shaping (1/2)

### DIFF
--- a/.changeset/signer-descriptors-config.md
+++ b/.changeset/signer-descriptors-config.md
@@ -1,0 +1,7 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+refactor: introduce SignerDescriptor registry for per-signer-type config shaping
+
+Moves the synchronous per-type `switch` logic out of `wallet.ts` into a `SignerDescriptor` per signer type (`signers/descriptors/`): config validation, internal-config building, and auto-assemblability. `wallet.ts` now dispatches via `getSignerDescriptor(type)`. Internal refactor — no behavior or public API changes.

--- a/packages/wallets/src/signers/descriptors/api-key.ts
+++ b/packages/wallets/src/signers/descriptors/api-key.ts
@@ -1,0 +1,21 @@
+import type { Chain } from "../../chains/chains";
+import type { ApiSourcedServerSignerConfig, InternalSignerConfig, SignerConfigForChain, SignerLocator } from "../types";
+import type { SignerDescriptor, SignerDescriptorContext } from "./types";
+
+export const apiKeySignerDescriptor: SignerDescriptor = {
+    type: "api-key",
+    validateConfig(): void {},
+    buildInternalConfig<C extends Chain>(
+        _config: SignerConfigForChain<C> | ApiSourcedServerSignerConfig,
+        ctx: SignerDescriptorContext<C>
+    ): InternalSignerConfig<C> {
+        return {
+            type: "api-key",
+            locator: "api-key" as SignerLocator,
+            address: ctx.walletAddress,
+        } as InternalSignerConfig<C>;
+    },
+    canAutoAssemble(): boolean {
+        return true;
+    },
+};

--- a/packages/wallets/src/signers/descriptors/descriptors.test.ts
+++ b/packages/wallets/src/signers/descriptors/descriptors.test.ts
@@ -1,0 +1,164 @@
+import { expect, it, vi } from "vitest";
+import type { Crossmint } from "@crossmint/common-sdk-base";
+import type { EVMChain } from "../../chains/chains";
+import type { DeviceSignerKeyStorage } from "../../utils/device-signers/DeviceSignerKeyStorage";
+import type { ServerSignerResolver } from "../server/resolver";
+import type { ApiSourcedServerSignerConfig, ServerSignerConfig, SignerConfigForChain } from "../types";
+import { getSignerDescriptor } from "./index";
+import type { SignerDescriptorContext } from "./types";
+
+const CHAIN: EVMChain = "base-sepolia";
+const WALLET_ADDRESS = "0xWalletAddress";
+const crossmint = { sentinel: "crossmint" } as unknown as Crossmint;
+const clientTEEConnection = { sentinel: "tee" } as SignerDescriptorContext<EVMChain>["clientTEEConnection"];
+const onAuthRequired = vi.fn() as unknown as SignerDescriptorContext<EVMChain>["onAuthRequired"];
+const SERVER_KEY_MATERIAL = { derivedKeyBytes: new Uint8Array([1, 2, 3]), derivedAddress: "0xDerivedServer" };
+
+type Config = SignerConfigForChain<EVMChain> | ApiSourcedServerSignerConfig;
+const cfg = (c: object) => c as unknown as Config;
+
+function makeCtx(
+    overrides: { deviceSignerKeyStorage?: DeviceSignerKeyStorage; hasRecoveryResolution?: boolean } = {}
+): SignerDescriptorContext<EVMChain> {
+    return {
+        chain: CHAIN,
+        walletAddress: WALLET_ADDRESS,
+        crossmint,
+        clientTEEConnection,
+        onAuthRequired,
+        deviceSignerKeyStorage: overrides.deviceSignerKeyStorage,
+        serverSigners: {
+            keyMaterialForAssembly: vi.fn(() => SERVER_KEY_MATERIAL),
+            hasRecoveryResolution: overrides.hasRecoveryResolution ?? false,
+        } as unknown as ServerSignerResolver,
+    };
+}
+
+it.each<[name: string, type: string, config: Config, message: string]>([
+    ["email missing email", "email", cfg({ type: "email" }), "Email signer requires an email address"],
+    ["phone missing phone", "phone", cfg({ type: "phone" }), "Phone signer requires a phone number"],
+    [
+        "ext missing address",
+        "external-wallet",
+        cfg({ type: "external-wallet", onSign: vi.fn() }),
+        "External wallet signer requires a wallet address",
+    ],
+    [
+        "ext missing onSign",
+        "external-wallet",
+        cfg({ type: "external-wallet", address: "0xabc" }),
+        "External wallet signer requires an onSign callback",
+    ],
+])("validateConfig: %s throws", (_name, type, config, message) => {
+    expect(() => getSignerDescriptor(type as never).validateConfig(config as never)).toThrow(message);
+});
+
+it.each<[type: string, config: Config]>([
+    ["email", cfg({ type: "email", email: "a@b.com" })],
+    ["phone", cfg({ type: "phone", phone: "+15551234" })],
+    ["external-wallet", cfg({ type: "external-wallet", address: "0xabc", onSign: vi.fn() })],
+    ["api-key", cfg({ type: "api-key" })],
+    ["passkey", cfg({ type: "passkey" })],
+    ["device", cfg({ type: "device" })],
+    ["server", cfg({ type: "server", secret: "s" })],
+])("validateConfig: %s valid config is a no-op", (type, config) => {
+    expect(() => getSignerDescriptor(type as never).validateConfig(config as never)).not.toThrow();
+});
+
+it.each<[type: "email" | "phone", field: "email" | "phone", value: string]>([
+    ["email", "email", "a@b.com"],
+    ["phone", "phone", "+15551234"],
+])("buildInternalConfig: %s threads crossmint/clientTEEConnection/onAuthRequired from ctx", (type, field, value) => {
+    const result = getSignerDescriptor(type).buildInternalConfig({ type, [field]: value } as never, makeCtx());
+    expect(result).toEqual({
+        type,
+        [field]: value,
+        locator: `${type}:${value}`,
+        address: WALLET_ADDRESS,
+        crossmint,
+        clientTEEConnection,
+        onAuthRequired,
+    });
+});
+
+it("buildInternalConfig: api-key returns locator and wallet address", () => {
+    const result = getSignerDescriptor("api-key").buildInternalConfig({ type: "api-key" } as never, makeCtx());
+    expect(result).toEqual({ type: "api-key", locator: "api-key", address: WALLET_ADDRESS });
+});
+
+it("buildInternalConfig: external-wallet spreads config and derives locator from address", () => {
+    const onSign = vi.fn();
+    const result = getSignerDescriptor("external-wallet").buildInternalConfig(
+        { type: "external-wallet", address: "0xabc", onSign } as never,
+        makeCtx()
+    );
+    expect(result).toEqual({ type: "external-wallet", address: "0xabc", onSign, locator: "external-wallet:0xabc" });
+});
+
+it("buildInternalConfig: server uses keyMaterialForAssembly result", () => {
+    const ctx = makeCtx();
+    const config = { type: "server", secret: "s" } as ServerSignerConfig;
+    const result = getSignerDescriptor("server").buildInternalConfig(config as never, ctx);
+    expect(ctx.serverSigners.keyMaterialForAssembly).toHaveBeenCalledWith(config);
+    expect(result).toEqual({
+        type: "server",
+        derivedKeyBytes: SERVER_KEY_MATERIAL.derivedKeyBytes,
+        locator: "server:0xDerivedServer",
+        address: "0xDerivedServer",
+    });
+});
+
+it.each<[name: string, locator: string | undefined, expected: string | undefined]>([
+    ["locator set", "device:pubkey", "device:pubkey"],
+    ["locator undefined", undefined, undefined],
+])("buildInternalConfig: device passes through %s", (_name, locator, expected) => {
+    const result = getSignerDescriptor("device").buildInternalConfig({ type: "device", locator } as never, makeCtx());
+    expect(result).toEqual({ type: "device", locator: expected, address: WALLET_ADDRESS });
+});
+
+const publicKey = { x: "1", y: "2" };
+it.each<[name: string, config: Config, expected: object]>([
+    [
+        "missing id falls back to empty string with name/publicKey",
+        cfg({ type: "passkey", name: "my-key", publicKey }),
+        { type: "passkey", id: "", locator: "passkey:", name: "my-key", publicKey },
+    ],
+    [
+        "provided id is kept",
+        cfg({ type: "passkey", id: "cred-1" }),
+        { type: "passkey", id: "cred-1", locator: "passkey:cred-1" },
+    ],
+])("buildInternalConfig: passkey %s", (_name, config, expected) => {
+    expect(getSignerDescriptor("passkey").buildInternalConfig(config as never, makeCtx())).toMatchObject(expected);
+});
+
+it.each<[type: string]>([["email"], ["phone"], ["passkey"], ["api-key"]])(
+    "canAutoAssemble: %s is always true",
+    (type) => {
+        expect(getSignerDescriptor(type as never).canAutoAssemble({ type } as never, makeCtx())).toBe(true);
+    }
+);
+
+it.each<[name: string, storage: DeviceSignerKeyStorage | undefined, expected: boolean]>([
+    ["with storage", {} as DeviceSignerKeyStorage, true],
+    ["without storage", undefined, false],
+])("canAutoAssemble: device %s", (_name, storage, expected) => {
+    const ctx = makeCtx({ deviceSignerKeyStorage: storage });
+    expect(getSignerDescriptor("device").canAutoAssemble({ type: "device" } as never, ctx)).toBe(expected);
+});
+
+it.each<[name: string, config: Config, expected: boolean]>([
+    ["with onSign", cfg({ type: "external-wallet", address: "0xabc", onSign: vi.fn() }), true],
+    ["without onSign", cfg({ type: "external-wallet", address: "0xabc" }), false],
+])("canAutoAssemble: external-wallet %s", (_name, config, expected) => {
+    expect(getSignerDescriptor("external-wallet").canAutoAssemble(config as never, makeCtx())).toBe(expected);
+});
+
+it.each<[name: string, config: Config, hasRecoveryResolution: boolean, expected: boolean]>([
+    ["full config", cfg({ type: "server", secret: "s" }), false, true],
+    ["api-sourced without recovery resolution", cfg({ type: "server", address: "0xabc" }), false, false],
+    ["api-sourced with recovery resolution", cfg({ type: "server", address: "0xabc" }), true, true],
+])("canAutoAssemble: server %s", (_name, config, hasRecoveryResolution, expected) => {
+    const ctx = makeCtx({ hasRecoveryResolution });
+    expect(getSignerDescriptor("server").canAutoAssemble(config as never, ctx)).toBe(expected);
+});

--- a/packages/wallets/src/signers/descriptors/device.ts
+++ b/packages/wallets/src/signers/descriptors/device.ts
@@ -1,0 +1,25 @@
+import type { Chain } from "../../chains/chains";
+import type { ApiSourcedServerSignerConfig, InternalSignerConfig, SignerConfigForChain } from "../types";
+import type { SignerDescriptor, SignerDescriptorContext } from "./types";
+
+export const deviceSignerDescriptor: SignerDescriptor = {
+    type: "device",
+    validateConfig(_config: SignerConfigForChain<Chain>): void {},
+    buildInternalConfig(
+        config: SignerConfigForChain<Chain> | ApiSourcedServerSignerConfig,
+        ctx: SignerDescriptorContext<Chain>
+    ): InternalSignerConfig<Chain> {
+        const locator = "locator" in config && config.locator ? config.locator : undefined;
+        return {
+            type: "device",
+            locator,
+            address: ctx.walletAddress,
+        } as InternalSignerConfig<Chain>;
+    },
+    canAutoAssemble(
+        _config: SignerConfigForChain<Chain> | ApiSourcedServerSignerConfig,
+        ctx: SignerDescriptorContext<Chain>
+    ): boolean {
+        return ctx.deviceSignerKeyStorage != null;
+    },
+};

--- a/packages/wallets/src/signers/descriptors/email.ts
+++ b/packages/wallets/src/signers/descriptors/email.ts
@@ -1,0 +1,30 @@
+import type { Chain } from "../../chains/chains";
+import type { EmailSignerConfig, InternalSignerConfig, SignerConfigForChain, SignerLocator } from "../types";
+import type { SignerDescriptor, SignerDescriptorContext } from "./types";
+
+export const emailSignerDescriptor: SignerDescriptor = {
+    type: "email",
+    validateConfig(config: SignerConfigForChain<Chain>): void {
+        if (!("email" in config) || config.email == null) {
+            throw new Error("Email signer requires an email address");
+        }
+    },
+    buildInternalConfig(
+        config: SignerConfigForChain<Chain>,
+        ctx: SignerDescriptorContext<Chain>
+    ): InternalSignerConfig<Chain> {
+        const emailConfig = config as EmailSignerConfig;
+        return {
+            type: "email",
+            email: emailConfig.email,
+            locator: `email:${emailConfig.email}` as SignerLocator,
+            address: ctx.walletAddress,
+            crossmint: ctx.crossmint,
+            clientTEEConnection: ctx.clientTEEConnection,
+            onAuthRequired: ctx.onAuthRequired,
+        } as InternalSignerConfig<Chain>;
+    },
+    canAutoAssemble(): boolean {
+        return true;
+    },
+};

--- a/packages/wallets/src/signers/descriptors/external-wallet.ts
+++ b/packages/wallets/src/signers/descriptors/external-wallet.ts
@@ -1,0 +1,34 @@
+import type { Chain } from "../../chains/chains";
+import type {
+    ApiSourcedServerSignerConfig,
+    ExternalWalletSignerConfigForChain,
+    InternalSignerConfig,
+    SignerConfigForChain,
+    SignerLocator,
+} from "../types";
+import type { SignerDescriptor } from "./types";
+
+export const externalWalletSignerDescriptor: SignerDescriptor = {
+    type: "external-wallet",
+
+    validateConfig(config: SignerConfigForChain<Chain>): void {
+        if (!("address" in config) || config.address == null) {
+            throw new Error("External wallet signer requires a wallet address");
+        }
+        if (!("onSign" in config) || typeof config.onSign !== "function") {
+            throw new Error("External wallet signer requires an onSign callback");
+        }
+    },
+
+    buildInternalConfig(config: SignerConfigForChain<Chain> | ApiSourcedServerSignerConfig): InternalSignerConfig<Chain> {
+        const externalWalletConfig = config as ExternalWalletSignerConfigForChain<Chain>;
+        return {
+            ...externalWalletConfig,
+            locator: `external-wallet:${externalWalletConfig.address}` as SignerLocator,
+        } as InternalSignerConfig<Chain>;
+    },
+
+    canAutoAssemble(config: SignerConfigForChain<Chain> | ApiSourcedServerSignerConfig): boolean {
+        return "onSign" in config && typeof config.onSign === "function";
+    },
+};

--- a/packages/wallets/src/signers/descriptors/external-wallet.ts
+++ b/packages/wallets/src/signers/descriptors/external-wallet.ts
@@ -20,7 +20,9 @@ export const externalWalletSignerDescriptor: SignerDescriptor = {
         }
     },
 
-    buildInternalConfig(config: SignerConfigForChain<Chain> | ApiSourcedServerSignerConfig): InternalSignerConfig<Chain> {
+    buildInternalConfig(
+        config: SignerConfigForChain<Chain> | ApiSourcedServerSignerConfig
+    ): InternalSignerConfig<Chain> {
         const externalWalletConfig = config as ExternalWalletSignerConfigForChain<Chain>;
         return {
             ...externalWalletConfig,

--- a/packages/wallets/src/signers/descriptors/index.ts
+++ b/packages/wallets/src/signers/descriptors/index.ts
@@ -1,0 +1,33 @@
+import type { Chain } from "../../chains/chains";
+import { UnknownSignerTypeError } from "../../utils/errors";
+import { apiKeySignerDescriptor } from "./api-key";
+import { deviceSignerDescriptor } from "./device";
+import { emailSignerDescriptor } from "./email";
+import { externalWalletSignerDescriptor } from "./external-wallet";
+import { passkeySignerDescriptor } from "./passkey";
+import { phoneSignerDescriptor } from "./phone";
+import { serverSignerDescriptor } from "./server";
+import type { SignerDescriptor } from "./types";
+
+export type { SignerDescriptor, SignerDescriptorContext } from "./types";
+
+export function getSignerDescriptor<C extends Chain>(type: SignerDescriptor["type"]): SignerDescriptor<C> {
+    switch (type) {
+        case "email":
+            return emailSignerDescriptor as SignerDescriptor<C>;
+        case "phone":
+            return phoneSignerDescriptor as SignerDescriptor<C>;
+        case "passkey":
+            return passkeySignerDescriptor as SignerDescriptor<C>;
+        case "device":
+            return deviceSignerDescriptor as SignerDescriptor<C>;
+        case "api-key":
+            return apiKeySignerDescriptor as SignerDescriptor<C>;
+        case "server":
+            return serverSignerDescriptor as SignerDescriptor<C>;
+        case "external-wallet":
+            return externalWalletSignerDescriptor as SignerDescriptor<C>;
+        default:
+            throw new UnknownSignerTypeError(`Unknown signer type: ${type}`);
+    }
+}

--- a/packages/wallets/src/signers/descriptors/passkey.ts
+++ b/packages/wallets/src/signers/descriptors/passkey.ts
@@ -1,0 +1,32 @@
+import type { Chain } from "../../chains/chains";
+import type {
+    ApiSourcedServerSignerConfig,
+    InternalSignerConfig,
+    PasskeySignerConfig,
+    SignerConfigForChain,
+    SignerLocator,
+} from "../types";
+import type { SignerDescriptor } from "./types";
+
+export const passkeySignerDescriptor: SignerDescriptor = {
+    type: "passkey",
+    validateConfig(): void {},
+    buildInternalConfig<C extends Chain>(
+        config: SignerConfigForChain<C> | ApiSourcedServerSignerConfig
+    ): InternalSignerConfig<C> {
+        const passkeyConfig = config as PasskeySignerConfig;
+        const id = "id" in passkeyConfig && passkeyConfig.id ? passkeyConfig.id : "";
+        return {
+            type: "passkey",
+            id,
+            locator: `passkey:${id}` as SignerLocator,
+            name: "name" in passkeyConfig ? passkeyConfig.name : undefined,
+            publicKey: "publicKey" in passkeyConfig ? passkeyConfig.publicKey : undefined,
+            onCreatePasskey: passkeyConfig.onCreatePasskey,
+            onSignWithPasskey: passkeyConfig.onSignWithPasskey,
+        } as InternalSignerConfig<C>;
+    },
+    canAutoAssemble(): boolean {
+        return true;
+    },
+};

--- a/packages/wallets/src/signers/descriptors/phone.ts
+++ b/packages/wallets/src/signers/descriptors/phone.ts
@@ -1,0 +1,30 @@
+import type { Chain } from "../../chains/chains";
+import type { InternalSignerConfig, PhoneSignerConfig, SignerConfigForChain, SignerLocator } from "../types";
+import type { SignerDescriptor, SignerDescriptorContext } from "./types";
+
+export const phoneSignerDescriptor: SignerDescriptor = {
+    type: "phone",
+    validateConfig(config: SignerConfigForChain<Chain>): void {
+        if (!("phone" in config) || config.phone == null) {
+            throw new Error("Phone signer requires a phone number");
+        }
+    },
+    buildInternalConfig(
+        config: SignerConfigForChain<Chain>,
+        ctx: SignerDescriptorContext<Chain>
+    ): InternalSignerConfig<Chain> {
+        const phoneConfig = config as PhoneSignerConfig;
+        return {
+            type: "phone",
+            phone: phoneConfig.phone,
+            locator: `phone:${phoneConfig.phone}` as SignerLocator,
+            address: ctx.walletAddress,
+            crossmint: ctx.crossmint,
+            clientTEEConnection: ctx.clientTEEConnection,
+            onAuthRequired: ctx.onAuthRequired,
+        } as InternalSignerConfig<Chain>;
+    },
+    canAutoAssemble(): boolean {
+        return true;
+    },
+};

--- a/packages/wallets/src/signers/descriptors/server.ts
+++ b/packages/wallets/src/signers/descriptors/server.ts
@@ -1,0 +1,38 @@
+import type { Chain } from "../../chains/chains";
+import {
+    type ApiSourcedServerSignerConfig,
+    type InternalSignerConfig,
+    isApiSourcedServerSignerConfig,
+    type ServerSignerConfig,
+    type ServerSignerLocator,
+    type SignerConfigForChain,
+} from "../types";
+import type { SignerDescriptor, SignerDescriptorContext } from "./types";
+
+export const serverSignerDescriptor: SignerDescriptor = {
+    type: "server",
+
+    validateConfig() {},
+
+    buildInternalConfig<C extends Chain>(
+        config: SignerConfigForChain<C> | ApiSourcedServerSignerConfig,
+        ctx: SignerDescriptorContext<C>
+    ): InternalSignerConfig<C> {
+        const { derivedKeyBytes, derivedAddress } = ctx.serverSigners.keyMaterialForAssembly(
+            config as ServerSignerConfig | ApiSourcedServerSignerConfig
+        );
+        return {
+            type: "server",
+            derivedKeyBytes,
+            locator: `server:${derivedAddress}` as ServerSignerLocator,
+            address: derivedAddress,
+        } as InternalSignerConfig<C>;
+    },
+
+    canAutoAssemble<C extends Chain>(
+        config: SignerConfigForChain<C> | ApiSourcedServerSignerConfig,
+        ctx: SignerDescriptorContext<C>
+    ): boolean {
+        return !isApiSourcedServerSignerConfig(config) || ctx.serverSigners.hasRecoveryResolution;
+    },
+};

--- a/packages/wallets/src/signers/descriptors/types.ts
+++ b/packages/wallets/src/signers/descriptors/types.ts
@@ -1,0 +1,28 @@
+import type { HandshakeParent } from "@crossmint/client-sdk-window";
+import type { signerInboundEvents, signerOutboundEvents } from "@crossmint/client-signers";
+import type { Crossmint } from "@crossmint/common-sdk-base";
+import type { Chain } from "../../chains/chains";
+import type { DeviceSignerKeyStorage } from "../../utils/device-signers/DeviceSignerKeyStorage";
+import type { Callbacks } from "../../wallets/types";
+import type { ServerSignerResolver } from "../server/resolver";
+import type { ApiSourcedServerSignerConfig, InternalSignerConfig, SignerConfigForChain } from "../types";
+
+export interface SignerDescriptorContext<C extends Chain> {
+    chain: C;
+    walletAddress: string;
+    crossmint: Crossmint;
+    clientTEEConnection?: HandshakeParent<typeof signerOutboundEvents, typeof signerInboundEvents>;
+    onAuthRequired?: Callbacks["onAuthRequired"];
+    deviceSignerKeyStorage?: DeviceSignerKeyStorage;
+    serverSigners: ServerSignerResolver;
+}
+
+export interface SignerDescriptor<C extends Chain = Chain> {
+    readonly type: "email" | "phone" | "passkey" | "device" | "api-key" | "server" | "external-wallet";
+    validateConfig(config: SignerConfigForChain<C>): void;
+    buildInternalConfig(
+        config: SignerConfigForChain<C> | ApiSourcedServerSignerConfig,
+        ctx: SignerDescriptorContext<C>
+    ): InternalSignerConfig<C>;
+    canAutoAssemble(config: SignerConfigForChain<C> | ApiSourcedServerSignerConfig, ctx: SignerDescriptorContext<C>): boolean;
+}

--- a/packages/wallets/src/signers/descriptors/types.ts
+++ b/packages/wallets/src/signers/descriptors/types.ts
@@ -24,5 +24,8 @@ export interface SignerDescriptor<C extends Chain = Chain> {
         config: SignerConfigForChain<C> | ApiSourcedServerSignerConfig,
         ctx: SignerDescriptorContext<C>
     ): InternalSignerConfig<C>;
-    canAutoAssemble(config: SignerConfigForChain<C> | ApiSourcedServerSignerConfig, ctx: SignerDescriptorContext<C>): boolean;
+    canAutoAssemble(
+        config: SignerConfigForChain<C> | ApiSourcedServerSignerConfig,
+        ctx: SignerDescriptorContext<C>
+    ): boolean;
 }

--- a/packages/wallets/src/utils/errors.ts
+++ b/packages/wallets/src/utils/errors.ts
@@ -60,6 +60,12 @@ export class InvalidSignerError extends CrossmintSDKError {
     }
 }
 
+export class UnknownSignerTypeError extends CrossmintSDKError {
+    constructor(message: string, details?: string) {
+        super(message, WalletErrorCode.SIGNER_INVALID, details);
+    }
+}
+
 /**
  * Stable error code returned by the wallets API when a Solana smart wallet's underlying
  * provider does not support device signers. The SDK catches this code in `recover()` and
@@ -207,6 +213,7 @@ export type WalletError =
     | WalletTypeMismatchError
     | SignerTypeMismatchError
     | InvalidSignerError
+    | UnknownSignerTypeError
     | DeviceSignerNotSupportedError
     | InvalidMessageFormatError
     | InvalidTypedDataError

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -5,7 +5,6 @@ import type {
     GetSignerResponse,
     WalletLocator,
     RegisterSignerParams,
-    RegisterSignerPasskeyParams,
     GetTransactionSuccessResponse,
     GetTransactionsResponse,
     GetWalletSuccessResponse,
@@ -55,7 +54,6 @@ import type {
     PasskeySignerConfig,
     RecoverySignerConfigForChain,
     ServerSignerConfig,
-    ServerSignerLocator,
     SignerAdapter,
     SignerConfigForChain,
     SignerLocator,
@@ -69,6 +67,7 @@ import {
 import { assembleSigner } from "../signers";
 import { NonCustodialSigner } from "../signers/non-custodial";
 import { ServerSignerResolver } from "../signers/server/resolver";
+import { getSignerDescriptor, type SignerDescriptorContext } from "../signers/descriptors";
 import { walletsLogger } from "../logger";
 
 import { getSignerLocator } from "../utils/signer-locator";
@@ -210,7 +209,10 @@ export class Wallet<C extends Chain> {
         }
 
         // Assemble the device signer with the resolved config
-        const internalConfig = this.buildInternalSignerConfig(deviceConfig as SignerConfigForChain<C>);
+        const internalConfig = getSignerDescriptor<C>(deviceConfig.type).buildInternalConfig(
+            deviceConfig as SignerConfigForChain<C>,
+            this.descriptorContext()
+        );
         this.#signer = await this.assembleFullSigner(internalConfig, deviceSignerKeyStorage);
 
         // If the backend signer isn't approved yet (e.g. a previous recover() was
@@ -264,13 +266,16 @@ export class Wallet<C extends Chain> {
             return;
         }
 
-        if (!this.isAutoAssemblableSignerConfig(signerToAssemble)) {
+        if (!getSignerDescriptor<C>(signerToAssemble.type).canAutoAssemble(signerToAssemble, this.descriptorContext())) {
             return;
         }
 
         const isAdminSigner = signerToAssemble === this.#recovery;
         try {
-            const internalConfig = this.buildInternalSignerConfig(signerToAssemble as SignerConfigForChain<C>);
+            const internalConfig = getSignerDescriptor<C>(signerToAssemble.type).buildInternalConfig(
+                signerToAssemble as SignerConfigForChain<C>,
+                this.descriptorContext()
+            );
             this.#signer = await this.assembleFullSigner(internalConfig, undefined, { isAdminSigner });
         } catch (error) {
             walletsLogger.warn("wallet.initDefaultSigner.autoAssemblyFailed", {
@@ -289,11 +294,14 @@ export class Wallet<C extends Chain> {
      * initDefaultSigner.
      */
     private async assembleRecoverySignerFallback(): Promise<void> {
-        if (!this.isAutoAssemblableSignerConfig(this.#recovery)) {
+        if (!getSignerDescriptor<C>(this.#recovery.type).canAutoAssemble(this.#recovery, this.descriptorContext())) {
             return;
         }
         try {
-            const internalConfig = this.buildInternalSignerConfig(this.#recovery);
+            const internalConfig = getSignerDescriptor<C>(this.#recovery.type).buildInternalConfig(
+                this.#recovery,
+                this.descriptorContext()
+            );
             this.#signer = await this.assembleFullSigner(internalConfig, undefined, { isAdminSigner: true });
         } catch (error) {
             walletsLogger.warn("wallet.recover.device.unsupportedFallback.autoAssemblyFailed", {
@@ -337,6 +345,18 @@ export class Wallet<C extends Chain> {
 
     private get chainAdapter(): ChainAdapter {
         return getChainAdapter(this.chain);
+    }
+
+    private descriptorContext(): SignerDescriptorContext<C> {
+        return {
+            chain: this.chain,
+            walletAddress: this.address,
+            crossmint: this.#apiClient.crossmint,
+            clientTEEConnection: this.#options?.clientTEEConnection,
+            onAuthRequired: this.#options?.callbacks?.onAuthRequired,
+            deviceSignerKeyStorage: this.#options?.deviceSignerKeyStorage,
+            serverSigners: this.#serverSignerResolver,
+        };
     }
 
     /**
@@ -880,7 +900,7 @@ export class Wallet<C extends Chain> {
         if (signer.type === "server") {
             this.#serverSignerResolver.resetDelegatedCache();
         }
-        this.validateSignerInput(signer);
+        getSignerDescriptor<C>(signer.type).validateConfig(signer);
 
         let isAdminSigner = false;
         if (signer.type === "device") {
@@ -889,7 +909,7 @@ export class Wallet<C extends Chain> {
             isAdminSigner = await this.resolveNonDeviceSigner(signer);
         }
 
-        const internalConfig = this.buildInternalSignerConfig(signer);
+        const internalConfig = getSignerDescriptor<C>(signer.type).buildInternalConfig(signer, this.descriptorContext());
         const signerLocator = getSignerLocator(signer);
         this.#signer = await this.assembleFullSigner(internalConfig, undefined, { isAdminSigner });
         walletsLogger.info("wallet.useSigner.success", { signerLocator });
@@ -1033,14 +1053,17 @@ export class Wallet<C extends Chain> {
         if (
             this.#recovery != null &&
             this.#recovery.type === "external-wallet" &&
-            !this.isAutoAssemblableSignerConfig(this.#recovery)
+            !getSignerDescriptor<C>(this.#recovery.type).canAutoAssemble(this.#recovery, this.descriptorContext())
         ) {
             throw new Error(
                 "Cannot assemble external wallet signer: no onSign callback available. " +
                     'Call wallet.useSigner({ type: "external-wallet", address: "0x...", onSign: async (tx) => ... }) first.'
             );
         }
-        const recoveryInternalConfig = this.buildInternalSignerConfig(this.#recovery);
+        const recoveryInternalConfig = getSignerDescriptor<C>(this.#recovery.type).buildInternalConfig(
+            this.#recovery,
+            this.descriptorContext()
+        );
         this.#signer = assembleSigner(this.chain, recoveryInternalConfig, this.#options?.deviceSignerKeyStorage);
 
         try {
@@ -1290,14 +1313,17 @@ export class Wallet<C extends Chain> {
         if (
             this.#recovery != null &&
             this.#recovery.type === "external-wallet" &&
-            !this.isAutoAssemblableSignerConfig(this.#recovery)
+            !getSignerDescriptor<C>(this.#recovery.type).canAutoAssemble(this.#recovery, this.descriptorContext())
         ) {
             throw new Error(
                 "Cannot resume pending approval: no onSign callback available. " +
                     'Call wallet.useSigner({ type: "external-wallet", address: "0x...", onSign: async (tx) => ... }) first.'
             );
         }
-        const recoveryInternalConfig = this.buildInternalSignerConfig(this.#recovery);
+        const recoveryInternalConfig = getSignerDescriptor<C>(this.#recovery.type).buildInternalConfig(
+            this.#recovery,
+            this.descriptorContext()
+        );
         this.#signer = assembleSigner(this.chain, recoveryInternalConfig, this.#options?.deviceSignerKeyStorage);
 
         try {
@@ -1453,7 +1479,10 @@ export class Wallet<C extends Chain> {
                         'Example: wallet.useSigner({ type: "server", secret: process.env.YOUR_SERVER_SECRET })'
                 );
             }
-            if (this.#recovery.type === "external-wallet" || !this.isAutoAssemblableSignerConfig(this.#recovery)) {
+            if (
+                this.#recovery.type === "external-wallet" ||
+                !getSignerDescriptor<C>(this.#recovery.type).canAutoAssemble(this.#recovery, this.descriptorContext())
+            ) {
                 throw new Error(
                     "No signer is set. External wallet signers require calling wallet.useSigner() with the onSign callback before signing operations.\n" +
                         'Example: wallet.useSigner({ type: "external-wallet", address: "0x...", onSign: async (tx) => ... })'
@@ -1535,39 +1564,6 @@ export class Wallet<C extends Chain> {
     }
 
     /**
-     * Validate that the signer input has the required values for its type.
-     */
-    private validateSignerInput(config: SignerConfigForChain<C> | RegisterSignerPasskeyParams): void {
-        switch (config.type) {
-            case "email":
-                if (!("email" in config) || config.email == null) {
-                    throw new Error("Email signer requires an email address");
-                }
-                break;
-            case "phone":
-                if (!("phone" in config) || config.phone == null) {
-                    throw new Error("Phone signer requires a phone number");
-                }
-                break;
-            case "external-wallet":
-                if (!("address" in config) || config.address == null) {
-                    throw new Error("External wallet signer requires a wallet address");
-                }
-                if (!("onSign" in config) || typeof config.onSign !== "function") {
-                    throw new Error("External wallet signer requires an onSign callback");
-                }
-                break;
-            case "passkey":
-            case "device":
-            case "api-key":
-                // These are allowed without id/locator
-                break;
-            default:
-                break;
-        }
-    }
-
-    /**
      * Check if a device signer key is available locally, or flag for recovery.
      * Looks up device key storage by wallet address, then by matching registered device signers.
      * If no key is found, sets needsRecovery so a new device key is generated during the next transaction.
@@ -1643,104 +1639,6 @@ export class Wallet<C extends Chain> {
             signer,
             pendingOperation: getPendingSignerOperation(signerResponse, this.chain),
         };
-    }
-
-    /**
-     * Build an InternalSignerConfig from a SignerConfigForChain.
-     */
-    private buildInternalSignerConfig(
-        config: SignerConfigForChain<C> | ApiSourcedServerSignerConfig
-    ): InternalSignerConfig<C> {
-        switch (config.type) {
-            case "email":
-                return {
-                    type: "email",
-                    email: config.email,
-                    locator: `email:${config.email}` as SignerLocator,
-                    address: this.address,
-                    crossmint: this.#apiClient.crossmint,
-                    clientTEEConnection: this.#options?.clientTEEConnection,
-                    onAuthRequired: this.#options?.callbacks?.onAuthRequired,
-                } as InternalSignerConfig<C>;
-            case "phone":
-                return {
-                    type: "phone",
-                    phone: config.phone,
-                    locator: `phone:${config.phone}` as SignerLocator,
-                    address: this.address,
-                    crossmint: this.#apiClient.crossmint,
-                    clientTEEConnection: this.#options?.clientTEEConnection,
-                    onAuthRequired: this.#options?.callbacks?.onAuthRequired,
-                } as InternalSignerConfig<C>;
-            case "passkey": {
-                const id = "id" in config && config.id ? config.id : "";
-                return {
-                    type: "passkey",
-                    id,
-                    locator: `passkey:${id}` as SignerLocator,
-                    name: "name" in config ? config.name : undefined,
-                    publicKey: "publicKey" in config ? config.publicKey : undefined,
-                    onCreatePasskey: config.onCreatePasskey,
-                    onSignWithPasskey: config.onSignWithPasskey,
-                } as InternalSignerConfig<C>;
-            }
-            case "device": {
-                const locator = "locator" in config && config.locator ? config.locator : undefined;
-                return {
-                    type: "device",
-                    locator,
-                    address: this.address,
-                } as InternalSignerConfig<C>;
-            }
-            case "external-wallet":
-                return {
-                    ...config,
-                    locator: `external-wallet:${config.address}` as SignerLocator,
-                } as InternalSignerConfig<C>;
-            case "api-key":
-                return {
-                    type: "api-key",
-                    locator: "api-key" as SignerLocator,
-                    address: this.address,
-                } as InternalSignerConfig<C>;
-            case "server": {
-                const serverConfig = config as ServerSignerConfig | ApiSourcedServerSignerConfig;
-                const { derivedKeyBytes, derivedAddress } =
-                    this.#serverSignerResolver.keyMaterialForAssembly(serverConfig);
-                return {
-                    type: "server",
-                    derivedKeyBytes,
-                    locator: `server:${derivedAddress}` as ServerSignerLocator,
-                    address: derivedAddress,
-                } as InternalSignerConfig<C>;
-            }
-            default:
-                throw new Error(`Unknown signer type: ${(config as unknown as { type?: string })?.type}`);
-        }
-    }
-
-    /**
-     * Returns true if the signer config can be auto-assembled without user interaction.
-     * Types like external-wallet (stored as evm-keypair/solana-keypair in the API) require
-     * the user to provide a signing callback via useSigner(), so they cannot be auto-assembled.
-     * Server signers also require the secret to be present in the config.
-     */
-    private isAutoAssemblableSignerConfig(config: SignerConfigForChain<C> | ApiSourcedServerSignerConfig): boolean {
-        switch (config.type) {
-            case "email":
-            case "phone":
-            case "passkey":
-            case "api-key":
-                return true;
-            case "device":
-                return this.#options?.deviceSignerKeyStorage != null;
-            case "server":
-                return !isApiSourcedServerSignerConfig(config) || this.#serverSignerResolver.hasRecoveryResolution;
-            case "external-wallet":
-                return "onSign" in config && typeof config.onSign === "function";
-            default:
-                return false;
-        }
     }
 
     protected resolveChainForEnvironment(): C {

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -266,7 +266,9 @@ export class Wallet<C extends Chain> {
             return;
         }
 
-        if (!getSignerDescriptor<C>(signerToAssemble.type).canAutoAssemble(signerToAssemble, this.descriptorContext())) {
+        if (
+            !getSignerDescriptor<C>(signerToAssemble.type).canAutoAssemble(signerToAssemble, this.descriptorContext())
+        ) {
             return;
         }
 
@@ -909,7 +911,10 @@ export class Wallet<C extends Chain> {
             isAdminSigner = await this.resolveNonDeviceSigner(signer);
         }
 
-        const internalConfig = getSignerDescriptor<C>(signer.type).buildInternalConfig(signer, this.descriptorContext());
+        const internalConfig = getSignerDescriptor<C>(signer.type).buildInternalConfig(
+            signer,
+            this.descriptorContext()
+        );
         const signerLocator = getSignerLocator(signer);
         this.#signer = await this.assembleFullSigner(internalConfig, undefined, { isAdminSigner });
         walletsLogger.info("wallet.useSigner.success", { signerLocator });

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -266,18 +266,15 @@ export class Wallet<C extends Chain> {
             return;
         }
 
-        if (
-            !getSignerDescriptor<C>(signerToAssemble.type).canAutoAssemble(signerToAssemble, this.descriptorContext())
-        ) {
+        const descriptor = getSignerDescriptor<C>(signerToAssemble.type);
+        const ctx = this.descriptorContext();
+        if (!descriptor.canAutoAssemble(signerToAssemble, ctx)) {
             return;
         }
 
         const isAdminSigner = signerToAssemble === this.#recovery;
         try {
-            const internalConfig = getSignerDescriptor<C>(signerToAssemble.type).buildInternalConfig(
-                signerToAssemble as SignerConfigForChain<C>,
-                this.descriptorContext()
-            );
+            const internalConfig = descriptor.buildInternalConfig(signerToAssemble as SignerConfigForChain<C>, ctx);
             this.#signer = await this.assembleFullSigner(internalConfig, undefined, { isAdminSigner });
         } catch (error) {
             walletsLogger.warn("wallet.initDefaultSigner.autoAssemblyFailed", {
@@ -296,14 +293,13 @@ export class Wallet<C extends Chain> {
      * initDefaultSigner.
      */
     private async assembleRecoverySignerFallback(): Promise<void> {
-        if (!getSignerDescriptor<C>(this.#recovery.type).canAutoAssemble(this.#recovery, this.descriptorContext())) {
+        const descriptor = getSignerDescriptor<C>(this.#recovery.type);
+        const ctx = this.descriptorContext();
+        if (!descriptor.canAutoAssemble(this.#recovery, ctx)) {
             return;
         }
         try {
-            const internalConfig = getSignerDescriptor<C>(this.#recovery.type).buildInternalConfig(
-                this.#recovery,
-                this.descriptorContext()
-            );
+            const internalConfig = descriptor.buildInternalConfig(this.#recovery, ctx);
             this.#signer = await this.assembleFullSigner(internalConfig, undefined, { isAdminSigner: true });
         } catch (error) {
             walletsLogger.warn("wallet.recover.device.unsupportedFallback.autoAssemblyFailed", {
@@ -1055,20 +1051,19 @@ export class Wallet<C extends Chain> {
                     'Call wallet.useSigner({ type: "server", secret: ... }) first with the recovery server secret.'
             );
         }
+        const descriptor = getSignerDescriptor<C>(this.#recovery.type);
+        const ctx = this.descriptorContext();
         if (
             this.#recovery != null &&
             this.#recovery.type === "external-wallet" &&
-            !getSignerDescriptor<C>(this.#recovery.type).canAutoAssemble(this.#recovery, this.descriptorContext())
+            !descriptor.canAutoAssemble(this.#recovery, ctx)
         ) {
             throw new Error(
                 "Cannot assemble external wallet signer: no onSign callback available. " +
                     'Call wallet.useSigner({ type: "external-wallet", address: "0x...", onSign: async (tx) => ... }) first.'
             );
         }
-        const recoveryInternalConfig = getSignerDescriptor<C>(this.#recovery.type).buildInternalConfig(
-            this.#recovery,
-            this.descriptorContext()
-        );
+        const recoveryInternalConfig = descriptor.buildInternalConfig(this.#recovery, ctx);
         this.#signer = assembleSigner(this.chain, recoveryInternalConfig, this.#options?.deviceSignerKeyStorage);
 
         try {
@@ -1315,20 +1310,19 @@ export class Wallet<C extends Chain> {
                     'Call wallet.useSigner({ type: "server", secret: ... }) first with the recovery server secret.'
             );
         }
+        const descriptor = getSignerDescriptor<C>(this.#recovery.type);
+        const ctx = this.descriptorContext();
         if (
             this.#recovery != null &&
             this.#recovery.type === "external-wallet" &&
-            !getSignerDescriptor<C>(this.#recovery.type).canAutoAssemble(this.#recovery, this.descriptorContext())
+            !descriptor.canAutoAssemble(this.#recovery, ctx)
         ) {
             throw new Error(
                 "Cannot resume pending approval: no onSign callback available. " +
                     'Call wallet.useSigner({ type: "external-wallet", address: "0x...", onSign: async (tx) => ... }) first.'
             );
         }
-        const recoveryInternalConfig = getSignerDescriptor<C>(this.#recovery.type).buildInternalConfig(
-            this.#recovery,
-            this.descriptorContext()
-        );
+        const recoveryInternalConfig = descriptor.buildInternalConfig(this.#recovery, ctx);
         this.#signer = assembleSigner(this.chain, recoveryInternalConfig, this.#options?.deviceSignerKeyStorage);
 
         try {


### PR DESCRIPTION
## What

Phase 4 (first of two) of the `wallet.ts` decomposition. Moves the synchronous per-signer-type `switch` logic into a `SignerDescriptor` per type (`signers/descriptors/`). **Pure refactor, no behavior change.** wallet.ts: 1952 → 1850.

This PR extracts the **three config-shaping methods** for all 7 types:
- `validateConfig` ← `Wallet.validateSignerInput`
- `buildInternalConfig` ← `Wallet.buildInternalSignerConfig`
- `canAutoAssemble` ← `Wallet.isAutoAssemblableSignerConfig`

`wallet.ts` dispatches via `getSignerDescriptor(type)` through a `descriptorContext()` helper; the `server` descriptor delegates to the merged `ServerSignerResolver` via `ctx.serverSigners`. Adds `UnknownSignerTypeError` for the unknown-type path.

The remaining per-type switches (`addSigner` payload ternary, `isRecoverySigner`, `requireSigner` messages) stay in wallet.ts for **PR 2/2** — kept this PR under the size budget.

## Review surface

7 small descriptor files + a lean consolidated test; the wallet.ts diff is +43/−145. Each descriptor's three methods are ported verbatim from the matching switch arm (exact error strings, object shapes, and casts preserved). An adversarial parity review passed.

## Two intentional, behavior-preserving notes

- **Unknown-type path**: `getSignerDescriptor(unknownType)` now throws `UnknownSignerTypeError` uniformly. Previously `buildInternalSignerConfig` threw on unknown but `validateSignerInput`/`isAutoAssemblableSignerConfig` were no-op/false. This only differs for a malformed config whose `.type` is outside the closed `SignerType` union — unreachable in practice, and fail-fast is the better behavior.
- `validateConfig` narrows its param to `SignerConfigForChain<C>` (the original also accepted a vestigial `RegisterSignerPasskeyParams` arm); the sole caller already passes `SignerConfigForChain<C>`.

## Test plan

- `pnpm --filter @crossmint/wallets-sdk test:vitest` → **671 passed / 0 failed / 68 skipped**
- `tsc --noEmit` clean; build green; biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/crossmint-sdk/pull/1932" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->