### PR TITLE
refactor(wallets): extract DeviceRecoveryService + DeviceSignerState union

### DIFF
--- a/.changeset/extract-device-recovery-service.md
+++ b/.changeset/extract-device-recovery-service.md
@@ -1,0 +1,11 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+refactor: extract DeviceRecoveryService from wallet.ts
+
+- `wallets/services/device-recovery-service.ts`: a `DeviceRecoveryService` owning device-signer initialization and recovery (`initDeviceSigner`, `recover`, `resolveAvailability`, pending-approval resumption, local-key matching, unsupported-provider fallback)
+- the three device flags (`#needsRecovery` / `#deviceSignerApproved` / `#deviceSignerUnsupported`) are replaced by an explicit `DeviceSignerState` lifecycle (`"unknown" | "needs-recovery" | "resolved"`) plus an orthogonal provider-rejection latch
+- `wallet.ts` delegates `recover()` / `needsRecovery()` and the device branch of `useSigner`; the signer-session → device-recovery coupling collapses to one `onSignerSelected()` notification
+
+Internal refactor — no behavior or public API changes.

--- a/packages/wallets/src/wallets/services/device-recovery-service.test.ts
+++ b/packages/wallets/src/wallets/services/device-recovery-service.test.ts
@@ -1,0 +1,304 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Chain } from "../../chains/chains";
+import { walletsLogger } from "../../logger";
+import { assembleSigner } from "../../signers";
+import { AuthRejectedError, OtpValidationError, type SignerAdapter } from "../../signers/types";
+import { createDeviceSigner } from "@/utils/device-signers";
+import { DeviceSignerNotSupportedError } from "../../utils/errors";
+import { DeviceRecoveryService, type DeviceRecoveryServiceParams } from "./device-recovery-service";
+
+vi.mock("../../signers", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("../../signers")>();
+    return { ...actual, assembleSigner: vi.fn() };
+});
+vi.mock("@/utils/device-signers", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@/utils/device-signers")>();
+    return { ...actual, createDeviceSigner: vi.fn() };
+});
+
+const mockedAssembleSigner = vi.mocked(assembleSigner);
+const mockedCreateDeviceSigner = vi.mocked(createDeviceSigner);
+
+const WALLET_ADDRESS = "0x1234567890123456789012345678901234567890";
+const NULL_STATE = { response: null, signer: null, pendingOperation: null };
+
+function makeSigner(type: string, locatorValue: string, status?: string): SignerAdapter {
+    return { type, status, locator: () => locatorValue } as unknown as SignerAdapter;
+}
+
+function pendingState(operationType: "signature" | "transaction", id: string) {
+    return { response: {}, signer: { status: "awaiting-approval" }, pendingOperation: { type: operationType, id } };
+}
+
+function makeSignerManager(overrides: Record<string, unknown> = {}) {
+    let active = overrides.activeSigner as SignerAdapter | undefined;
+    return {
+        get activeSigner() {
+            return active;
+        },
+        setActiveSigner: vi.fn((signer: SignerAdapter | undefined) => {
+            active = signer;
+        }),
+        recovery: overrides.recovery ?? { type: "api-key" },
+        descriptorContext: vi.fn(() => ({ walletAddress: WALLET_ADDRESS })),
+        isApprovedSignerStatus: (status: unknown) => status === "success" || status === "active",
+        getSignerState: overrides.getSignerState ?? vi.fn().mockResolvedValue(NULL_STATE),
+        assemble: overrides.assemble ?? vi.fn().mockResolvedValue(makeSigner("device", "device:assembled", "success")),
+    };
+}
+
+function makeStorage(overrides: Record<string, unknown> = {}) {
+    return {
+        getKey: vi.fn().mockResolvedValue(null),
+        hasKey: vi.fn().mockResolvedValue(false),
+        mapAddressToKey: vi.fn().mockResolvedValue(undefined),
+        deleteKey: vi.fn().mockResolvedValue(undefined),
+        ...overrides,
+    };
+}
+
+type SetupOverrides = {
+    storage?: ReturnType<typeof makeStorage> | null;
+    signerManager?: Record<string, unknown>;
+    hasRecoveryResolution?: boolean;
+    signers?: ReturnType<typeof vi.fn>;
+    addSigner?: ReturnType<typeof vi.fn>;
+    approveSignature?: ReturnType<typeof vi.fn>;
+    approveTransaction?: ReturnType<typeof vi.fn>;
+};
+
+function setup(overrides: SetupOverrides = {}) {
+    const storage = overrides.storage === null ? undefined : overrides.storage ?? makeStorage();
+    const options = storage == null ? undefined : ({ deviceSignerKeyStorage: storage } as Record<string, unknown>);
+    const signerManager = makeSignerManager(overrides.signerManager);
+    const serverSignerResolver = { hasRecoveryResolution: overrides.hasRecoveryResolution ?? false };
+    const signers = overrides.signers ?? vi.fn().mockResolvedValue([]);
+    const addSigner = overrides.addSigner ?? vi.fn().mockResolvedValue(undefined);
+    const approveSignature = overrides.approveSignature ?? vi.fn().mockResolvedValue(undefined);
+    const approveTransaction = overrides.approveTransaction ?? vi.fn().mockResolvedValue(undefined);
+    const service = new DeviceRecoveryService({
+        chain: "base-sepolia",
+        walletAddress: WALLET_ADDRESS,
+        options,
+        signerManager,
+        serverSignerResolver,
+        signers,
+        addSigner,
+        approveSignature,
+        approveTransaction,
+    } as unknown as DeviceRecoveryServiceParams<Chain>);
+    return { service, storage, options, signerManager, signers, addSigner, approveSignature, approveTransaction };
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mockedCreateDeviceSigner.mockResolvedValue({
+        type: "device",
+        locator: "device:newkey",
+        publicKey: { x: "0x01", y: "0x02" },
+        name: "Test Device",
+    } as never);
+    mockedAssembleSigner.mockReturnValue(makeSigner("device", "device:recovery"));
+});
+
+describe("DeviceRecoveryService", () => {
+    describe("recovery-need state", () => {
+        it("needsRecovery is false before anything resolves", () => {
+            expect(setup().service.needsRecovery).toBe(false);
+        });
+
+        it("resolveAvailability flags recovery when no local key matches any registered device signer", async () => {
+            const { service } = setup();
+            await service.resolveAvailability({ type: "device" } as never);
+            expect(service.needsRecovery).toBe(true);
+        });
+
+        it("onSignerSelected clears a pending recovery need", async () => {
+            const { service } = setup();
+            await service.resolveAvailability({ type: "device" } as never);
+            expect(service.needsRecovery).toBe(true);
+            service.onSignerSelected();
+            expect(service.needsRecovery).toBe(false);
+        });
+
+        it("onSignerSelected does not re-trigger recovery on an already-resolved wallet", async () => {
+            const { service } = setup();
+            await service.recover();
+            service.onSignerSelected();
+            await service.recover();
+            expect(mockedCreateDeviceSigner).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("resolveAvailability", () => {
+        it("throws when device key storage is missing", async () => {
+            const { service } = setup({ storage: null });
+            await expect(service.resolveAvailability({ type: "device" } as never)).rejects.toThrow(
+                /key storage is required for device signers/
+            );
+        });
+
+        it("uses an existing local key without flagging recovery", async () => {
+            const storage = makeStorage({ getKey: vi.fn().mockResolvedValue("existingKey") });
+            const { service } = setup({ storage });
+            const config = { type: "device" } as { type: "device"; locator?: string };
+            await service.resolveAvailability(config as never);
+            expect(config.locator).toBe("device:existingKey");
+            expect(service.needsRecovery).toBe(false);
+        });
+
+        it("maps a registered device signer whose key is present locally", async () => {
+            const storage = makeStorage({ hasKey: vi.fn().mockResolvedValue(true) });
+            const signers = vi.fn().mockResolvedValue([{ locator: "device:registeredKey" }]);
+            const { service } = setup({ storage, signers });
+            const config = { type: "device" } as { type: "device"; locator?: string };
+            await service.resolveAvailability(config as never);
+            expect(storage.mapAddressToKey).toHaveBeenCalledWith(WALLET_ADDRESS, "registeredKey");
+            expect(config.locator).toBe("device:registeredKey");
+            expect(service.needsRecovery).toBe(false);
+        });
+    });
+
+    describe("recover() guards", () => {
+        it("fast-paths without touching the backend once already resolved", async () => {
+            const { service, addSigner } = setup();
+            await service.recover();
+            await service.recover();
+            expect(addSigner).toHaveBeenCalledTimes(1);
+            expect(mockedCreateDeviceSigner).toHaveBeenCalledTimes(1);
+        });
+
+        it("skips recovery and clears the need when a non-device signer is active", async () => {
+            const { service, addSigner } = setup({ signerManager: { activeSigner: makeSigner("api-key", "api-key") } });
+            await service.resolveAvailability({ type: "device" } as never);
+            await service.recover();
+            expect(service.needsRecovery).toBe(false);
+            expect(addSigner).not.toHaveBeenCalled();
+        });
+
+        it("returns silently when storage is missing and recovery is not needed", async () => {
+            const { service, signers } = setup({ storage: null });
+            await expect(service.recover()).resolves.toBeUndefined();
+            expect(signers).not.toHaveBeenCalled();
+        });
+
+        it("throws when recovery is needed but storage has gone missing", async () => {
+            const { service, options } = setup();
+            await service.resolveAvailability({ type: "device" } as never);
+            expect(service.needsRecovery).toBe(true);
+            (options as Record<string, unknown>).deviceSignerKeyStorage = undefined;
+            await expect(service.recover()).rejects.toThrow(/key storage is required to recover/);
+        });
+    });
+
+    describe("recover() new-device registration", () => {
+        it("falls back to the recovery signer when the provider rejects device signers", async () => {
+            const addSigner = vi.fn().mockRejectedValue(new DeviceSignerNotSupportedError("unsupported"));
+            const { service, storage, signerManager } = setup({ addSigner });
+            await service.recover();
+            expect(storage?.deleteKey).toHaveBeenCalledWith(WALLET_ADDRESS);
+            expect(signerManager.setActiveSigner).toHaveBeenCalled();
+            expect(service.needsRecovery).toBe(false);
+            await service.recover();
+            expect(addSigner).toHaveBeenCalledTimes(1);
+        });
+
+        it("swallows an already-approved error and reassembles the device signer", async () => {
+            const addSigner = vi.fn().mockRejectedValue(new Error("Delegated signer is already approved"));
+            const { service, storage, signerManager } = setup({ addSigner });
+            await expect(service.recover()).resolves.toBeUndefined();
+            expect(storage?.deleteKey).not.toHaveBeenCalled();
+            expect(signerManager.assemble).toHaveBeenCalled();
+            expect(signerManager.setActiveSigner).toHaveBeenCalled();
+        });
+
+        it("deletes the key and rethrows on an unrecognized registration error", async () => {
+            const addSigner = vi.fn().mockRejectedValue(new Error("boom"));
+            const { service, storage } = setup({ addSigner });
+            await expect(service.recover()).rejects.toThrow(/boom/);
+            expect(storage?.deleteKey).toHaveBeenCalledWith(WALLET_ADDRESS);
+        });
+
+        it.each([
+            ["AuthRejectedError instance", new AuthRejectedError("auth")],
+            ["a plain Error named AuthRejectedError", Object.assign(new Error("auth"), { name: "AuthRejectedError" })],
+            ["OtpValidationError instance", new OtpValidationError("otp", "INVALID_OTP" as never)],
+            ["a plain Error named OtpValidationError", Object.assign(new Error("otp"), { name: "OtpValidationError" })],
+        ])("keeps the local key and rethrows for %s", async (_name, error) => {
+            const addSigner = vi.fn().mockRejectedValue(error);
+            const { service, storage } = setup({ addSigner });
+            await expect(service.recover()).rejects.toBe(error);
+            expect(storage?.deleteKey).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("recover() resume guards", () => {
+        it.each([
+            ["server recovery with no resolved secret", { type: "server", address: "0xServer" }, /no secret available/],
+            [
+                "external-wallet recovery without an onSign callback",
+                { type: "external-wallet", address: "0xExt" },
+                /no onSign callback available/,
+            ],
+        ])("throws before swapping the signer for %s", async (_name, recovery, expected) => {
+            const activeSigner = makeSigner("device", "device:active");
+            const { service, signerManager } = setup({
+                signerManager: {
+                    activeSigner,
+                    recovery,
+                    getSignerState: vi.fn().mockResolvedValue(pendingState("signature", "sig-1")),
+                },
+            });
+            await expect(service.recover()).rejects.toThrow(expected);
+            expect(signerManager.setActiveSigner).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("initDeviceSigner", () => {
+        it("is a no-op when no device key storage is configured", async () => {
+            const { service, signers } = setup({ storage: null });
+            await service.initDeviceSigner();
+            expect(service.needsRecovery).toBe(false);
+            expect(signers).not.toHaveBeenCalled();
+        });
+
+        it("does not retry once the provider is known to reject device signers", async () => {
+            const addSigner = vi.fn().mockRejectedValue(new DeviceSignerNotSupportedError("unsupported"));
+            const { service, storage } = setup({ addSigner });
+            await service.recover();
+            storage?.getKey.mockClear();
+            await service.initDeviceSigner();
+            expect(storage?.getKey).not.toHaveBeenCalled();
+        });
+
+        it("flags recovery and logs when availability resolution throws", async () => {
+            const storage = makeStorage({ getKey: vi.fn().mockRejectedValue(new Error("storage blocked")) });
+            const { service } = setup({ storage });
+            await service.initDeviceSigner();
+            expect(service.needsRecovery).toBe(true);
+            expect(walletsLogger.error).toHaveBeenCalledWith(
+                "wallet.initDeviceSigner.error",
+                expect.objectContaining({ error: expect.any(Error) })
+            );
+        });
+
+        it("flags recovery when the assembled device signer is not yet approved", async () => {
+            const storage = makeStorage({ getKey: vi.fn().mockResolvedValue("localKey") });
+            const signerManager = { assemble: vi.fn().mockResolvedValue(makeSigner("device", "device:localKey")) };
+            const { service } = setup({ storage, signerManager });
+            await service.initDeviceSigner();
+            expect(service.needsRecovery).toBe(true);
+        });
+
+        it("assembles and activates an approved device signer without flagging recovery", async () => {
+            const storage = makeStorage({ getKey: vi.fn().mockResolvedValue("localKey") });
+            const signerManager = {
+                assemble: vi.fn().mockResolvedValue(makeSigner("device", "device:localKey", "success")),
+            };
+            const { service, signerManager: sm } = setup({ storage, signerManager });
+            await service.initDeviceSigner();
+            expect(sm.setActiveSigner).toHaveBeenCalled();
+            expect(service.needsRecovery).toBe(false);
+        });
+    });
+});

--- a/packages/wallets/src/wallets/services/device-recovery-service.ts
+++ b/packages/wallets/src/wallets/services/device-recovery-service.ts
@@ -1,0 +1,379 @@
+import type { Chain } from "../../chains/chains";
+import { assembleSigner } from "../../signers";
+import { getSignerDescriptor } from "../../signers/descriptors";
+import type { ServerSignerResolver } from "../../signers/server/resolver";
+import {
+    AuthRejectedError,
+    type DeviceSignerConfig,
+    type InternalSignerConfig,
+    isApiSourcedServerSignerConfig,
+    OtpValidationError,
+    type SignerAdapter,
+    type SignerConfigForChain,
+    type SignerLocator,
+} from "../../signers/types";
+import { DeviceSignerNotSupportedError } from "../../utils/errors";
+import { createDeviceSigner } from "@/utils/device-signers";
+import type { DeviceSignerKeyStorage } from "@/utils/device-signers/DeviceSignerKeyStorage";
+import { walletsLogger } from "../../logger";
+import type { PendingSignerOperation, Signer as WalletSigner, WalletOptions } from "../types";
+import type { SignerManager } from "./signer-manager";
+
+export type DeviceSignerState = "unknown" | "needs-recovery" | "resolved";
+
+export type DeviceRecoveryServiceParams<C extends Chain> = {
+    chain: C;
+    walletAddress: string;
+    options: WalletOptions | undefined;
+    signerManager: SignerManager<C>;
+    serverSignerResolver: ServerSignerResolver;
+    signers: () => Promise<WalletSigner[]>;
+    addSigner: (signer: SignerConfigForChain<C>) => Promise<unknown>;
+    approveSignature: (signatureId: string) => Promise<unknown>;
+    approveTransaction: (transactionId: string) => Promise<unknown>;
+};
+
+export class DeviceRecoveryService<C extends Chain> {
+    #status: DeviceSignerState = "unknown";
+    // Sticky latch: a previous recover() learned from the backend (DEVICE_SIGNER_NOT_SUPPORTED)
+    // that this wallet's provider does not support device signers. Orthogonal to #status — it can
+    // coexist with both "needs-recovery" and "resolved", so it is not a #status kind.
+    #providerRejectedDeviceSigners = false;
+
+    #chain: C;
+    #walletAddress: string;
+    #options: WalletOptions | undefined;
+    #signerManager: SignerManager<C>;
+    #serverSignerResolver: ServerSignerResolver;
+    #signers: () => Promise<WalletSigner[]>;
+    #addSigner: (signer: SignerConfigForChain<C>) => Promise<unknown>;
+    #approveSignature: (signatureId: string) => Promise<unknown>;
+    #approveTransaction: (transactionId: string) => Promise<unknown>;
+
+    constructor(params: DeviceRecoveryServiceParams<C>) {
+        this.#chain = params.chain;
+        this.#walletAddress = params.walletAddress;
+        this.#options = params.options;
+        this.#signerManager = params.signerManager;
+        this.#serverSignerResolver = params.serverSignerResolver;
+        this.#signers = params.signers;
+        this.#addSigner = params.addSigner;
+        this.#approveSignature = params.approveSignature;
+        this.#approveTransaction = params.approveTransaction;
+    }
+
+    get needsRecovery(): boolean {
+        return this.#status === "needs-recovery";
+    }
+
+    onSignerSelected(): void {
+        if (this.#status === "needs-recovery") {
+            this.#status = "unknown";
+        }
+    }
+
+    async initDeviceSigner(): Promise<void> {
+        const deviceSignerKeyStorage = this.#options?.deviceSignerKeyStorage;
+        if (deviceSignerKeyStorage == null) {
+            return;
+        }
+        if (this.#providerRejectedDeviceSigners) {
+            return;
+        }
+
+        const deviceConfig: DeviceSignerConfig = { type: "device" };
+        try {
+            await this.resolveAvailability(deviceConfig);
+        } catch (error) {
+            walletsLogger.error("wallet.initDeviceSigner.error", { error });
+            this.#status = "needs-recovery";
+            return;
+        }
+
+        if (this.#status === "needs-recovery") {
+            return;
+        }
+
+        const internalConfig = getSignerDescriptor<C>(deviceConfig.type).buildInternalConfig(
+            deviceConfig as SignerConfigForChain<C>,
+            this.#signerManager.descriptorContext()
+        );
+        const deviceSigner = await this.#signerManager.assemble(internalConfig);
+        this.#signerManager.setActiveSigner(deviceSigner);
+
+        if (!this.#signerManager.isApprovedSignerStatus(deviceSigner.status)) {
+            walletsLogger.info("wallet.initDeviceSigner.pendingApproval", {
+                signerLocator: deviceSigner.locator(),
+                status: deviceSigner.status,
+            });
+            this.#status = "needs-recovery";
+        }
+    }
+
+    async recover(): Promise<void> {
+        walletsLogger.info("wallet.recover.start");
+
+        if (this.#status === "resolved") {
+            walletsLogger.info("wallet.recover.skipped", { reason: "Device signer already approved (cached)" });
+            return;
+        }
+
+        if (this.#providerRejectedDeviceSigners) {
+            walletsLogger.info("wallet.recover.skipped", { reason: "device signer not supported (cached)" });
+            this.#status = "resolved";
+            return;
+        }
+
+        const activeSigner = this.#signerManager.activeSigner;
+        if (activeSigner?.type === "device") {
+            if (await this.#checkAndResumeDeviceSigner(activeSigner)) {
+                this.#status = "resolved";
+                return;
+            }
+        }
+
+        if (activeSigner != null && activeSigner.type !== "device") {
+            walletsLogger.warn("wallet.recover.skipped", { reason: "Recovery is only supported for device signers" });
+            this.#status = "unknown";
+            return;
+        }
+
+        const deviceSignerKeyStorage = this.#options?.deviceSignerKeyStorage;
+        if (deviceSignerKeyStorage == null) {
+            if (this.#status !== "needs-recovery") {
+                return;
+            }
+            throw new Error("Device signer key storage is required to recover a device signer");
+        }
+
+        const matchedSigner = await this.#findLocalDeviceSigner(deviceSignerKeyStorage);
+        if (matchedSigner != null) {
+            if (await this.#checkAndResumeDeviceSigner(matchedSigner)) {
+                this.#signerManager.setActiveSigner(matchedSigner);
+                this.#status = "resolved";
+                const publicKeyBase64 = matchedSigner.locator().replace("device:", "");
+                try {
+                    await deviceSignerKeyStorage.mapAddressToKey(this.#walletAddress, publicKeyBase64);
+                } catch (error) {
+                    walletsLogger.warn("wallet.recover.mapAddressToKey.error", { error });
+                }
+                return;
+            }
+        }
+
+        const newDeviceSigner = await createDeviceSigner(deviceSignerKeyStorage, this.#walletAddress);
+
+        try {
+            await this.#addSigner(newDeviceSigner as SignerConfigForChain<C>);
+        } catch (error) {
+            if (error instanceof DeviceSignerNotSupportedError) {
+                walletsLogger.info("wallet.recover.device.unsupportedFallback", {
+                    signerLocator: newDeviceSigner.locator,
+                });
+                await deviceSignerKeyStorage.deleteKey(this.#walletAddress);
+                this.#providerRejectedDeviceSigners = true;
+                this.#status = "resolved";
+                await this.#assembleRecoverySignerFallback();
+                return;
+            } else if (isAlreadyApprovedSignerError(error)) {
+                walletsLogger.info("wallet.recover.skipped", {
+                    reason: "Device signer already approved",
+                    signerLocator: newDeviceSigner.locator,
+                });
+            } else if (
+                error instanceof AuthRejectedError ||
+                (error instanceof Error && error.name === "AuthRejectedError")
+            ) {
+                walletsLogger.info("wallet.recover.device.authRejected", { signerLocator: newDeviceSigner.locator });
+                throw error;
+            } else if (
+                error instanceof OtpValidationError ||
+                (error instanceof Error && error.name === "OtpValidationError")
+            ) {
+                walletsLogger.warn("wallet.recover.device.otpValidationFailed", {
+                    signerLocator: newDeviceSigner.locator,
+                    code: error instanceof OtpValidationError ? error.code : undefined,
+                });
+                throw error;
+            } else {
+                walletsLogger.error("wallet.recover.device.error", { error });
+                await deviceSignerKeyStorage.deleteKey(this.#walletAddress);
+                throw error;
+            }
+        }
+
+        const reassembledSigner = await this.#signerManager.assemble({
+            type: "device",
+            locator: newDeviceSigner.locator as SignerLocator,
+            address: this.#walletAddress,
+        } as InternalSignerConfig<C>);
+        this.#signerManager.setActiveSigner(reassembledSigner);
+        if (reassembledSigner.type === "device") {
+            reassembledSigner.status = "success";
+        }
+        walletsLogger.info("wallet.recover.device.success", { signerLocator: newDeviceSigner.locator });
+
+        this.#status = "resolved";
+    }
+
+    async resolveAvailability(config: DeviceSignerConfig): Promise<void> {
+        const deviceSignerKeyStorage = this.#options?.deviceSignerKeyStorage;
+        if (deviceSignerKeyStorage == null) {
+            throw new Error("Device signer key storage is required for device signers");
+        }
+
+        const existingKey = await deviceSignerKeyStorage.getKey(this.#walletAddress);
+        if (existingKey != null) {
+            config.locator = `device:${existingKey}`;
+            return;
+        }
+
+        const existingSigners = await this.#signers();
+        const deviceSigners = existingSigners.filter((s) => s.locator.startsWith("device:"));
+        for (const walletSigner of deviceSigners) {
+            const publicKeyBase64 = walletSigner.locator.replace("device:", "");
+            const hasKey = await deviceSignerKeyStorage.hasKey(publicKeyBase64);
+            if (hasKey) {
+                await deviceSignerKeyStorage.mapAddressToKey(this.#walletAddress, publicKeyBase64);
+                config.locator = walletSigner.locator;
+                return;
+            }
+        }
+
+        this.#status = "needs-recovery";
+    }
+
+    async #checkAndResumeDeviceSigner(deviceSigner: SignerAdapter): Promise<boolean> {
+        if (this.#signerManager.isApprovedSignerStatus(deviceSigner.status)) {
+            walletsLogger.info("wallet.recover.skipped", { reason: "Device signer already approved" });
+            return true;
+        }
+
+        const signerState = await this.#signerManager.getSignerState(deviceSigner.locator());
+        deviceSigner.status = signerState.signer?.status;
+
+        if (signerState.pendingOperation != null) {
+            await this.#resumePendingDeviceSignerApproval(deviceSigner, signerState.pendingOperation);
+            return true;
+        }
+
+        if (this.#signerManager.isApprovedSignerStatus(deviceSigner.status)) {
+            walletsLogger.info("wallet.recover.skipped", { reason: "Device signer already approved" });
+            return true;
+        }
+
+        return false;
+    }
+
+    async #resumePendingDeviceSignerApproval(
+        deviceSigner: SignerAdapter,
+        pendingOperation: PendingSignerOperation
+    ): Promise<void> {
+        const originalSigner = this.#signerManager.activeSigner;
+        const recovery = this.#signerManager.recovery;
+        if (isApiSourcedServerSignerConfig(recovery) && !this.#serverSignerResolver.hasRecoveryResolution) {
+            throw new Error(
+                "Cannot resume pending approval: no secret available. " +
+                    'Call wallet.useSigner({ type: "server", secret: ... }) first with the recovery server secret.'
+            );
+        }
+        const signerDescriptor = getSignerDescriptor<C>(recovery.type);
+        const signerDescriptorContext = this.#signerManager.descriptorContext();
+        if (
+            recovery != null &&
+            recovery.type === "external-wallet" &&
+            !signerDescriptor.canAutoAssemble(recovery, signerDescriptorContext)
+        ) {
+            throw new Error(
+                "Cannot resume pending approval: no onSign callback available. " +
+                    'Call wallet.useSigner({ type: "external-wallet", address: "0x...", onSign: async (tx) => ... }) first.'
+            );
+        }
+        const recoveryInternalConfig = signerDescriptor.buildInternalConfig(recovery, signerDescriptorContext);
+        this.#signerManager.setActiveSigner(
+            assembleSigner(this.#chain, recoveryInternalConfig, this.#options?.deviceSignerKeyStorage)
+        );
+
+        try {
+            if (pendingOperation.type === "signature") {
+                await this.#approveSignature(pendingOperation.id);
+            } else {
+                await this.#approveTransaction(pendingOperation.id);
+            }
+        } catch (error) {
+            this.#signerManager.setActiveSigner(deviceSigner);
+            throw error;
+        } finally {
+            if (this.#signerManager.activeSigner !== deviceSigner) {
+                this.#signerManager.setActiveSigner(originalSigner);
+            }
+        }
+        deviceSigner.status = "success";
+        walletsLogger.info("wallet.recover.device.success", {
+            signerLocator: deviceSigner.locator(),
+            resumed: true,
+        });
+    }
+
+    async #findLocalDeviceSigner(deviceSignerKeyStorage: DeviceSignerKeyStorage): Promise<SignerAdapter | null> {
+        const existingSigners = await this.#signers();
+        const deviceSigners = existingSigners.filter((s) => s.locator.startsWith("device:"));
+
+        for (const walletSigner of deviceSigners) {
+            const publicKeyBase64 = walletSigner.locator.replace("device:", "");
+            try {
+                const hasKey = await deviceSignerKeyStorage.hasKey(publicKeyBase64);
+                if (hasKey) {
+                    const signer = assembleSigner(
+                        this.#chain,
+                        {
+                            type: "device",
+                            locator: walletSigner.locator as SignerLocator,
+                            address: this.#walletAddress,
+                        } as InternalSignerConfig<C>,
+                        deviceSignerKeyStorage
+                    );
+                    walletsLogger.info("wallet.recover.foundLocalDeviceSigner", {
+                        signerLocator: walletSigner.locator,
+                    });
+                    return signer;
+                }
+            } catch (error) {
+                walletsLogger.warn("wallet.recover.findLocalDeviceSigner.keyCheckError", {
+                    signerLocator: walletSigner.locator,
+                    error,
+                });
+            }
+        }
+        return null;
+    }
+
+    async #assembleRecoverySignerFallback(): Promise<void> {
+        const recovery = this.#signerManager.recovery;
+        const signerDescriptor = getSignerDescriptor<C>(recovery.type);
+        const signerDescriptorContext = this.#signerManager.descriptorContext();
+        if (!signerDescriptor.canAutoAssemble(recovery, signerDescriptorContext)) {
+            return;
+        }
+        try {
+            const internalConfig = signerDescriptor.buildInternalConfig(recovery, signerDescriptorContext);
+            this.#signerManager.setActiveSigner(
+                await this.#signerManager.assemble(internalConfig, { isAdminSigner: true })
+            );
+        } catch (error) {
+            walletsLogger.warn("wallet.recover.device.unsupportedFallback.autoAssemblyFailed", {
+                recoveryType: recovery.type,
+                error,
+            });
+        }
+    }
+}
+
+// TODO: replace with a stable backend error code instead of message string matching.
+function isAlreadyApprovedSignerError(error: unknown): boolean {
+    if (!(error instanceof Error)) {
+        return false;
+    }
+    const message = error.message.toLowerCase();
+    return message.includes("delegated signer") && message.includes("already") && message.includes("approved");
+}

--- a/packages/wallets/src/wallets/services/device-recovery-service.ts
+++ b/packages/wallets/src/wallets/services/device-recovery-service.ts
@@ -280,7 +280,6 @@ export class DeviceRecoveryService<C extends Chain> {
         const signerDescriptor = getSignerDescriptor<C>(recovery.type);
         const signerDescriptorContext = this.#signerManager.descriptorContext();
         if (
-            recovery != null &&
             recovery.type === "external-wallet" &&
             !signerDescriptor.canAutoAssemble(recovery, signerDescriptorContext)
         ) {

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -45,9 +45,7 @@ import { STATUS_POLLING_INTERVAL_MS } from "../utils/constants";
 import { validateChainForEnvironment, type Chain } from "../chains/chains";
 import { type ChainAdapter, type ChainType, getChainAdapter, isSupportedChainType } from "../chains/chain-adapter";
 import type {
-    DeviceSignerConfig,
     ExternalWalletRegistrationConfig,
-    InternalSignerConfig,
     PasskeySignerConfig,
     RecoverySignerConfigForChain,
     ServerSignerConfig,
@@ -55,13 +53,7 @@ import type {
     SignerConfigForChain,
     SignerLocator,
 } from "../signers/types";
-import {
-    type ApiSourcedServerSignerConfig,
-    isApiSourcedServerSignerConfig,
-    AuthRejectedError,
-    OtpValidationError,
-} from "../signers/types";
-import { assembleSigner } from "../signers";
+import { type ApiSourcedServerSignerConfig, isApiSourcedServerSignerConfig } from "../signers/types";
 import { NonCustodialSigner } from "../signers/non-custodial";
 import { ServerSignerResolver } from "../signers/server/resolver";
 import { getSignerDescriptor } from "../signers/descriptors";
@@ -71,9 +63,8 @@ import { getSignerLocator } from "../utils/signer-locator";
 import { toRecipientLocator, toTokenLocator } from "../utils/locators";
 import { formatBalanceResponse } from "./services/balance-formatter";
 import { SignerManager } from "./services/signer-manager";
+import { DeviceRecoveryService } from "./services/device-recovery-service";
 import { waitForSignatureCompletion, waitForTransactionCompletion } from "./services/operation-poller";
-import { createDeviceSigner } from "@/utils/device-signers";
-import type { DeviceSignerKeyStorage } from "@/utils/device-signers/DeviceSignerKeyStorage";
 
 type WalletContructorType<C extends Chain> = {
     chain: C;
@@ -96,19 +87,12 @@ export class Wallet<C extends Chain> {
     #options?: WalletOptions;
     #apiClient: ApiClient;
     #initialSigners: SignerConfigForChain<C>[];
-    #needsRecovery = false;
-    #deviceSignerApproved = false;
     #serverSignerResolver: ServerSignerResolver;
     #signerManager: SignerManager<C>;
+    #deviceRecovery: DeviceRecoveryService<C>;
     #apiDelegatedServerSignerAddresses: string[] = [];
     #signerInitialization: Promise<void>;
     #recovering: Promise<void> | null = null;
-    /**
-     * Cached once `recover()` learns from the backend that this wallet's Solana provider does
-     * not support device signers (via the stable `DEVICE_SIGNER_NOT_SUPPORTED` error code).
-     * Used to short-circuit subsequent recover() calls without retrying registration.
-     */
-    #deviceSignerUnsupported = false;
 
     constructor(args: WalletContructorType<C>, apiClient: ApiClient) {
         const {
@@ -165,6 +149,17 @@ export class Wallet<C extends Chain> {
             signers: () => this.signers(),
             signer,
         });
+        this.#deviceRecovery = new DeviceRecoveryService({
+            chain,
+            walletAddress: this.address,
+            options,
+            signerManager: this.#signerManager,
+            serverSignerResolver: this.#serverSignerResolver,
+            signers: () => this.signers(),
+            addSigner: (deviceSigner) => this.addSigner(deviceSigner),
+            approveSignature: (signatureId) => this.approveSignatureAndWait(signatureId),
+            approveTransaction: (transactionId) => this.approveTransactionAndWait(transactionId),
+        });
         this.#signerInitialization = this.initDefaultSigner();
     }
 
@@ -178,64 +173,6 @@ export class Wallet<C extends Chain> {
      */
     public async waitForInit(): Promise<void> {
         await this.#signerInitialization;
-    }
-
-    /**
-     * Initialize the device signer by resolving key availability.
-     * If a device key is found locally, assembles the signer immediately.
-     * If not, flags the wallet for recovery so a key is generated during the next transaction.
-     * Device signer support depends on the wallet provider; validation is handled server-side.
-     */
-    private async initDeviceSigner(): Promise<void> {
-        const deviceSignerKeyStorage = this.#options?.deviceSignerKeyStorage;
-        if (deviceSignerKeyStorage == null) {
-            return;
-        }
-
-        // If a previous recover() learned the backend doesn't support device signers for this
-        // wallet (DEVICE_SIGNER_NOT_SUPPORTED), short-circuit without setting needsRecovery so
-        // initDefaultSigner falls back to the recovery signer instead of retrying registration.
-        if (this.#deviceSignerUnsupported) {
-            return;
-        }
-
-        const deviceConfig: DeviceSignerConfig = { type: "device" };
-        try {
-            await this.resolveDeviceSignerAvailability(deviceConfig);
-        } catch (error) {
-            walletsLogger.error("wallet.initDeviceSigner.error", {
-                error,
-            });
-            this.#needsRecovery = true;
-            return;
-        }
-
-        // If no local key was found, skip signer assembly — recovery will handle it
-        if (this.#needsRecovery) {
-            return;
-        }
-
-        // Assemble the device signer with the resolved config
-        const internalConfig = getSignerDescriptor<C>(deviceConfig.type).buildInternalConfig(
-            deviceConfig as SignerConfigForChain<C>,
-            this.#signerManager.descriptorContext()
-        );
-        const deviceSigner = await this.#signerManager.assemble(internalConfig);
-        this.#signerManager.setActiveSigner(deviceSigner);
-
-        // If the backend signer isn't approved yet (e.g. a previous recover() was
-        // interrupted mid-approval), flag for recovery so the next recover() call
-        // resumes the pending operation via checkAndResumeDeviceSigner. The signer
-        // is kept assigned so recover() takes the device fast-path and resumes
-        // rather than creating a new device signer.
-        if (!this.#signerManager.isApprovedSignerStatus(deviceSigner.status)) {
-            walletsLogger.info("wallet.initDeviceSigner.pendingApproval", {
-                signerLocator: deviceSigner.locator(),
-                status: deviceSigner.status,
-            });
-            this.#needsRecovery = true;
-            this.#deviceSignerApproved = false;
-        }
     }
 
     /**
@@ -256,10 +193,10 @@ export class Wallet<C extends Chain> {
             return;
         }
         // Step 1: Try device signer (existing behavior)
-        await this.initDeviceSigner();
+        await this.#deviceRecovery.initDeviceSigner();
 
         // If device signer was found or recovery is pending, we're done
-        if (this.#signerManager.activeSigner != null || this.#needsRecovery) {
+        if (this.#signerManager.activeSigner != null || this.#deviceRecovery.needsRecovery) {
             return;
         }
 
@@ -294,32 +231,6 @@ export class Wallet<C extends Chain> {
                 error,
             });
             // #signer remains undefined — user will need to call useSigner() explicitly
-        }
-    }
-
-    /**
-     * Attempt to auto-assemble the recovery signer onto the wallet. Used as the fallback
-     * when device-signer registration is rejected by the backend with `DEVICE_SIGNER_NOT_SUPPORTED`
-     * so the consumer's next transaction has a usable signer without re-routing through
-     * initDefaultSigner.
-     */
-    private async assembleRecoverySignerFallback(): Promise<void> {
-        const recovery = this.#signerManager.recovery;
-        const signerDescriptor = getSignerDescriptor<C>(recovery.type);
-        const signerDescriptorContext = this.#signerManager.descriptorContext();
-        if (!signerDescriptor.canAutoAssemble(recovery, signerDescriptorContext)) {
-            return;
-        }
-        try {
-            const internalConfig = signerDescriptor.buildInternalConfig(recovery, signerDescriptorContext);
-            this.#signerManager.setActiveSigner(
-                await this.#signerManager.assemble(internalConfig, { isAdminSigner: true })
-            );
-        } catch (error) {
-            walletsLogger.warn("wallet.recover.device.unsupportedFallback.autoAssemblyFailed", {
-                recoveryType: recovery.type,
-                error,
-            });
         }
     }
 
@@ -893,7 +804,7 @@ export class Wallet<C extends Chain> {
 
         let isAdminSigner = false;
         if (signer.type === "device") {
-            await this.resolveDeviceSignerAvailability(signer);
+            await this.#deviceRecovery.resolveAvailability(signer);
         } else {
             isAdminSigner = await this.resolveNonDeviceSigner(signer);
         }
@@ -921,7 +832,7 @@ export class Wallet<C extends Chain> {
         // Server signers are excluded so they always flow through the server signer block below,
         // which resolves the correct (primary or legacy) derivation.
         if (signer.type !== "passkey" && signer.type !== "server" && this.isRecoverySigner(signer)) {
-            this.#needsRecovery = false;
+            this.#deviceRecovery.onSignerSelected();
             return true;
         }
 
@@ -931,7 +842,7 @@ export class Wallet<C extends Chain> {
             if (!selected) {
                 // No registered passkeys — use recovery if this is the recovery signer
                 if (this.isRecoverySigner(signer)) {
-                    this.#needsRecovery = false;
+                    this.#deviceRecovery.onSignerSelected();
                     return true;
                 }
                 throw new Error("No passkey signer is registered on this wallet.");
@@ -945,13 +856,13 @@ export class Wallet<C extends Chain> {
         // Check if this is a registered signer
         const locator = this.resolveSignerLocator(signer);
         if (await this.signerIsRegistered(locator)) {
-            this.#needsRecovery = false;
+            this.#deviceRecovery.onSignerSelected();
             return false;
         }
 
         // Not a registered signer — fall back to recovery
         if (this.isRecoverySigner(signer)) {
-            this.#needsRecovery = false;
+            this.#deviceRecovery.onSignerSelected();
             return true;
         }
 
@@ -970,11 +881,11 @@ export class Wallet<C extends Chain> {
         );
         switch (resolution.kind) {
             case "delegated":
-                this.#needsRecovery = false;
+                this.#deviceRecovery.onSignerSelected();
                 return false;
             case "recovery":
                 this.#signerManager.stripSecretFromRecovery();
-                this.#needsRecovery = false;
+                this.#deviceRecovery.onSignerSelected();
                 return true;
             case "unregistered":
                 throw new Error(resolution.message);
@@ -1041,7 +952,7 @@ export class Wallet<C extends Chain> {
      * @returns true if recovery is needed
      */
     public needsRecovery(): boolean {
-        return this.#needsRecovery;
+        return this.#deviceRecovery.needsRecovery;
     }
 
     /**
@@ -1057,280 +968,7 @@ export class Wallet<C extends Chain> {
         },
     })
     public async recover(): Promise<void> {
-        walletsLogger.info("wallet.recover.start");
-
-        // Fast-path: skip the API call if we've already verified the device signer is approved
-        if (this.#deviceSignerApproved) {
-            walletsLogger.info("wallet.recover.skipped", { reason: "Device signer already approved (cached)" });
-            return;
-        }
-
-        // Wallets whose provider does not support device signers have nothing to recover —
-        // signing relies on the recovery signer instead. We learn this from the backend by
-        // catching DEVICE_SIGNER_NOT_SUPPORTED on a previous addSigner attempt and caching
-        // the result on the wallet instance.
-        if (this.#deviceSignerUnsupported) {
-            walletsLogger.info("wallet.recover.skipped", {
-                reason: "device signer not supported (cached)",
-            });
-            this.#needsRecovery = false;
-            this.#deviceSignerApproved = true;
-            return;
-        }
-
-        const markDeviceSignerApproved = () => {
-            this.#needsRecovery = false;
-            this.#deviceSignerApproved = true;
-        };
-
-        // If we already have a valid device signer assembled, check its status
-        const activeSigner = this.#signerManager.activeSigner;
-        if (activeSigner?.type === "device") {
-            if (await this.checkAndResumeDeviceSigner(activeSigner)) {
-                markDeviceSignerApproved();
-                return;
-            }
-        }
-
-        // If the current signer is a non-device type (e.g., user explicitly called useSigner
-        // with email/passkey/server), skip device recovery to avoid overwriting their choice.
-        if (activeSigner != null && activeSigner.type !== "device") {
-            walletsLogger.warn("wallet.recover.skipped", { reason: "Recovery is only supported for device signers" });
-            this.#needsRecovery = false;
-            return;
-        }
-
-        // No usable device signer assembled yet. Search all registered device signers
-        // to find one whose private key exists on this device, or generate a new one.
-        const deviceSignerKeyStorage = this.#options?.deviceSignerKeyStorage;
-        if (deviceSignerKeyStorage == null) {
-            if (!this.#needsRecovery) {
-                return; // No device signer was configured — nothing to recover
-            }
-            throw new Error("Device signer key storage is required to recover a device signer");
-        }
-
-        const matchedSigner = await this.findLocalDeviceSigner(deviceSignerKeyStorage);
-        if (matchedSigner != null) {
-            if (await this.checkAndResumeDeviceSigner(matchedSigner)) {
-                // Assign signer and mark approved before the non-critical mapAddressToKey call,
-                // so a storage I/O error doesn't leave the wallet without a usable signer.
-                this.#signerManager.setActiveSigner(matchedSigner);
-                markDeviceSignerApproved();
-                const publicKeyBase64 = matchedSigner.locator().replace("device:", "");
-                try {
-                    await deviceSignerKeyStorage.mapAddressToKey(this.address, publicKeyBase64);
-                } catch (error) {
-                    walletsLogger.warn("wallet.recover.mapAddressToKey.error", { error });
-                }
-                return;
-            }
-        }
-
-        // No existing device signer matches this device — generate a new key and register it
-        const newDeviceSigner = await createDeviceSigner(deviceSignerKeyStorage, this.address);
-
-        try {
-            await this.addSigner(newDeviceSigner as SignerConfigForChain<C>);
-        } catch (error) {
-            const isAlreadyApproved =
-                error instanceof Error &&
-                error.message.toLowerCase().includes("delegated signer") &&
-                error.message.toLowerCase().includes("already") &&
-                error.message.toLowerCase().includes("approved");
-
-            if (error instanceof DeviceSignerNotSupportedError) {
-                // Backend says this wallet's provider doesn't support device signers.
-                // Swallow the error and fall back to the recovery signer so the consumer's
-                // first transaction works seamlessly without needing to know about providers.
-                walletsLogger.info("wallet.recover.device.unsupportedFallback", {
-                    signerLocator: newDeviceSigner.locator,
-                });
-                await deviceSignerKeyStorage.deleteKey(this.address);
-                this.#deviceSignerUnsupported = true;
-                this.#needsRecovery = false;
-                this.#deviceSignerApproved = true;
-                await this.assembleRecoverySignerFallback();
-                return;
-            } else if (isAlreadyApproved) {
-                walletsLogger.info("wallet.recover.skipped", {
-                    reason: "Device signer already approved",
-                    signerLocator: newDeviceSigner.locator,
-                });
-            } else if (
-                error instanceof AuthRejectedError ||
-                (error instanceof Error && error.name === "AuthRejectedError")
-            ) {
-                // User canceled OTP — keep the local key so findLocalDeviceSigner()
-                // can match the server-side pending signer on the next recover() attempt.
-                walletsLogger.info("wallet.recover.device.authRejected", {
-                    signerLocator: newDeviceSigner.locator,
-                });
-                throw error;
-            } else if (
-                error instanceof OtpValidationError ||
-                (error instanceof Error && error.name === "OtpValidationError")
-            ) {
-                // OTP verification failed (wrong code, expired, server-side rejection).
-                // Keep the local key so the user can retry the OTP flow on the next
-                // recover() attempt without re-registering the device signer.
-                walletsLogger.warn("wallet.recover.device.otpValidationFailed", {
-                    signerLocator: newDeviceSigner.locator,
-                    code: error instanceof OtpValidationError ? error.code : undefined,
-                });
-                throw error;
-            } else {
-                walletsLogger.error("wallet.recover.device.error", { error });
-                await deviceSignerKeyStorage.deleteKey(this.address);
-                throw error;
-            }
-        }
-
-        // Reassemble device signer with the resolved locator. This also covers the
-        // idempotent case where the backend reports the signer is already approved.
-        const reassembledSigner = await this.#signerManager.assemble({
-            type: "device",
-            locator: newDeviceSigner.locator as SignerLocator,
-            address: this.address,
-        } as InternalSignerConfig<C>);
-        this.#signerManager.setActiveSigner(reassembledSigner);
-        if (reassembledSigner.type === "device") {
-            reassembledSigner.status = "success";
-        }
-        walletsLogger.info("wallet.recover.device.success", { signerLocator: newDeviceSigner.locator });
-
-        markDeviceSignerApproved();
-    }
-
-    /**
-     * Check if a device signer is already approved or has a pending operation that can be resumed.
-     * Returns true if the signer is now approved (either already was, or pending op was completed).
-     */
-    private async checkAndResumeDeviceSigner(deviceSigner: SignerAdapter): Promise<boolean> {
-        if (this.#signerManager.isApprovedSignerStatus(deviceSigner.status)) {
-            walletsLogger.info("wallet.recover.skipped", { reason: "Device signer already approved" });
-            return true;
-        }
-
-        const signerState = await this.#signerManager.getSignerState(deviceSigner.locator());
-        deviceSigner.status = signerState.signer?.status;
-
-        if (signerState.pendingOperation != null) {
-            await this.resumePendingDeviceSignerApproval(deviceSigner, signerState.pendingOperation);
-            return true;
-        }
-
-        if (this.#signerManager.isApprovedSignerStatus(deviceSigner.status)) {
-            walletsLogger.info("wallet.recover.skipped", { reason: "Device signer already approved" });
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * Resume a pending approval operation for a device signer.
-     * Temporarily swaps to the recovery signer, approves the pending operation,
-     * then restores the device signer.
-     */
-    private async resumePendingDeviceSignerApproval(
-        deviceSigner: SignerAdapter,
-        pendingOperation: { type: "signature" | "transaction"; id: string }
-    ): Promise<void> {
-        const originalSigner = this.#signerManager.activeSigner;
-        const recovery = this.#signerManager.recovery;
-        if (isApiSourcedServerSignerConfig(recovery) && !this.#serverSignerResolver.hasRecoveryResolution) {
-            throw new Error(
-                "Cannot resume pending approval: no secret available. " +
-                    'Call wallet.useSigner({ type: "server", secret: ... }) first with the recovery server secret.'
-            );
-        }
-        const signerDescriptor = getSignerDescriptor<C>(recovery.type);
-        const signerDescriptorContext = this.#signerManager.descriptorContext();
-        if (
-            recovery != null &&
-            recovery.type === "external-wallet" &&
-            !signerDescriptor.canAutoAssemble(recovery, signerDescriptorContext)
-        ) {
-            throw new Error(
-                "Cannot resume pending approval: no onSign callback available. " +
-                    'Call wallet.useSigner({ type: "external-wallet", address: "0x...", onSign: async (tx) => ... }) first.'
-            );
-        }
-        const recoveryInternalConfig = signerDescriptor.buildInternalConfig(recovery, signerDescriptorContext);
-        this.#signerManager.setActiveSigner(
-            assembleSigner(this.chain, recoveryInternalConfig, this.#options?.deviceSignerKeyStorage)
-        );
-
-        try {
-            if (pendingOperation.type === "signature") {
-                await this.approveSignatureAndWait(pendingOperation.id);
-            } else {
-                await this.approveTransactionAndWait(pendingOperation.id);
-            }
-        } catch (error) {
-            // Restore the device signer (not null) so the caller has a reference to the
-            // signer that was being recovered, rather than masking the failure behind a
-            // generic "read-only wallet" error from signerManager.require().
-            this.#signerManager.setActiveSigner(deviceSigner);
-            throw error;
-        } finally {
-            // On the success path, restore the original signer — the caller (recover)
-            // will reassign the active signer to the device signer after mapAddressToKey.
-            if (this.#signerManager.activeSigner !== deviceSigner) {
-                this.#signerManager.setActiveSigner(originalSigner);
-            }
-        }
-        deviceSigner.status = "success";
-        walletsLogger.info("wallet.recover.device.success", {
-            signerLocator: deviceSigner.locator(),
-            resumed: true,
-        });
-    }
-
-    /**
-     * Search registered device signers to find one whose private key exists locally.
-     * Returns an assembled SignerAdapter (without pre-fetched status) if found, or null.
-     * The caller is responsible for checking status via checkAndResumeDeviceSigner.
-     */
-    private async findLocalDeviceSigner(deviceSignerKeyStorage: DeviceSignerKeyStorage): Promise<SignerAdapter | null> {
-        // Fetch registered signers — let network errors propagate so we don't
-        // accidentally generate a new key when an existing one is on the device.
-        const existingSigners = await this.signers();
-        const deviceSigners = existingSigners.filter((s) => s.locator.startsWith("device:"));
-
-        for (const walletSigner of deviceSigners) {
-            const publicKeyBase64 = walletSigner.locator.replace("device:", "");
-            try {
-                const hasKey = await deviceSignerKeyStorage.hasKey(publicKeyBase64);
-                if (hasKey) {
-                    // Don't call mapAddressToKey here — the caller (recover) will do it
-                    // only after confirming the signer is usable, to avoid poisoning
-                    // the key mapping if we fall through to new-key generation.
-                    const signer = assembleSigner(
-                        this.chain,
-                        {
-                            type: "device",
-                            locator: walletSigner.locator as SignerLocator,
-                            address: this.address,
-                        } as InternalSignerConfig<C>,
-                        deviceSignerKeyStorage
-                    );
-                    walletsLogger.info("wallet.recover.foundLocalDeviceSigner", {
-                        signerLocator: walletSigner.locator,
-                    });
-                    return signer;
-                }
-            } catch (error) {
-                // hasKey / assembleSigner failures for individual keys are non-fatal;
-                // continue checking other device signers.
-                walletsLogger.warn("wallet.recover.findLocalDeviceSigner.keyCheckError", {
-                    signerLocator: walletSigner.locator,
-                    error,
-                });
-            }
-        }
-        return null;
+        await this.#deviceRecovery.recover();
     }
 
     /**
@@ -1434,43 +1072,6 @@ export class Wallet<C extends Chain> {
             this.#signerManager.adoptRecoveryConfig(signerConfig);
         }
         return true;
-    }
-
-    /**
-     * Check if a device signer key is available locally, or flag for recovery.
-     * Looks up device key storage by wallet address, then by matching registered device signers.
-     * If no key is found, sets needsRecovery so a new device key is generated during the next transaction.
-     */
-    private async resolveDeviceSignerAvailability(config: DeviceSignerConfig): Promise<void> {
-        const deviceSignerKeyStorage = this.#options?.deviceSignerKeyStorage;
-
-        if (deviceSignerKeyStorage == null) {
-            throw new Error("Device signer key storage is required for device signers");
-        }
-
-        // Check if device signer key exists for this wallet address
-        const existingKey = await deviceSignerKeyStorage.getKey(this.address);
-        if (existingKey != null) {
-            config.locator = `device:${existingKey}`;
-            return;
-        }
-
-        const existingSigners = await this.signers();
-        const deviceSigners = existingSigners.filter((s) => s.locator.startsWith("device:"));
-
-        for (const walletSigner of deviceSigners) {
-            const publicKeyBase64 = walletSigner.locator.replace("device:", "");
-            const hasKey = await deviceSignerKeyStorage.hasKey(publicKeyBase64);
-            if (hasKey) {
-                await deviceSignerKeyStorage.mapAddressToKey(this.address, publicKeyBase64);
-                config.locator = walletSigner.locator;
-                return;
-            }
-        }
-
-        // No device signer available — will be created during next transaction
-        this.#needsRecovery = true;
-        this.#deviceSignerApproved = false;
     }
 
     protected resolveChainForEnvironment(): C {


### PR DESCRIPTION
**Phase 5 PR2 — the finale of the `wallet.ts` decomposition.** Extracts device-signer init + recovery into a `DeviceRecoveryService` and replaces the three device flags with an explicit state machine. No behavior or public API changes.

> ⚠️ **Stacked on #1934** (`wallets/signer-manager`) — `DeviceRecoveryService` depends on `SignerManager`'s API (`assemble`/`setActiveSigner`/`activeSigner`/`recovery`/`descriptorContext`/…). Will rebase onto `main` + retarget the base to `main` once #1934 merges. Review the [3-file diff against the #1934 branch](https://github.com/Crossmint/crossmint-sdk/compare/wallets/signer-manager...wallets/device-recovery-service).

## What moved
`wallets/services/device-recovery-service.ts` (new) absorbs, verbatim, from `wallet.ts`:
- `initDeviceSigner`, `recover`, `resolveAvailability` (was `resolveDeviceSignerAvailability`)
- `checkAndResumeDeviceSigner`, `resumePendingDeviceSignerApproval`, `findLocalDeviceSigner`, `assembleRecoverySignerFallback` (now private)
- the inline "already approved" string-match → a named `isAlreadyApprovedSignerError(error)` (with the one allowed `TODO: backend error code` comment)

`wallet.ts` now: constructs the service, delegates `recover()` (keeps its `@WithLoggerContext`) + `needsRecovery()` + the `useSigner` device branch, and the 6 `#needsRecovery = false` clear-sites become one `onSignerSelected()` notification. **+25 / −424.**

## State model (the union)
The 3 booleans (`#needsRecovery`, `#deviceSignerApproved`, `#deviceSignerUnsupported`) → `#status: "unknown" | "needs-recovery" | "resolved"` **+ an orthogonal `#providerRejectedDeviceSigners` latch.**

**Deviation from the plan's sketch (5-kind object union):** I traced every flag read/write first. `#needsRecovery`/`#deviceSignerApproved` are mutually exclusive → they collapse cleanly into the 3-state lifecycle. But `#deviceSignerUnsupported` is **orthogonal** — it co-occurs with *both* `needs-recovery` and `resolved` (the `(needsRecovery=true, unsupported=true)` transient is reachable via `useSigner({type:"device"})` after an unsupported fallback). A single union kind can't represent that faithfully, so it stays a sticky latch. The object-payload kinds (`signer`/`operation`) were dropped because that data lives in `SignerManager.activeSigner`, not in the device state — folding it in would have changed behavior. `onSignerSelected()` only clears `needs-recovery → unknown` (leaves `resolved` untouched), matching the original `#needsRecovery = false` semantics exactly.

**Location:** placed in `wallets/services/` next to its sibling/dependency `signer-manager.ts` (plan said `signers/device/`).

## Verification
- **Full suite: 741 passed / 0 failed / 68 skipped** — incl. the local characterization suite's `device-init-and-recovery` (17) + `signer-wiring-and-device-usesigner` (6) tests, which pin exact error strings, logger event keys, API call counts, the `mapAddressToKey`-after-confirmation deferral, `deleteKey` timing, and `AuthRejectedError`/`OtpValidationError` by-name matching.
- **25 new colocated unit tests** for the service in isolation (state machine, `onSignerSelected`, `resolveAvailability`, `recover` guards + registration error matrix + resume guards, `initDeviceSigner`).
- `tsc` clean (our source); `biome` error-gate exits 0.
- **Adversarial drift review** (4 independent lenses — union-faithfulness, error/logger strings, control-flow/ordering, seam/wiring — + an independent synthesis re-verification): **no drift, 0 findings.**

## Size
+719 / −424 — over the usual ≤500-additions cap. The service is one cohesive class (379-line faithful move) + its test (304); it can't be cleanly split. Landed as one PR by maintainer decision — most of it is moved code that diffs against the 424 deleted `wallet.ts` lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/crossmint-sdk/pull/1936" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->