### PR TITLE
Check the live keychain for device signer presence

### DIFF
--- a/.changeset/fuzzy-dots-judge.md
+++ b/.changeset/fuzzy-dots-judge.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-native-ui": patch
+---
+
+Fix device signers failing with `keyNotFound` after restoring a wallet onto a new phone. `hasKey` now checks the live keychain instead of a backup-eligible record, so a key that did not transfer to the new device is detected as missing and the device re-registers a fresh signer.

--- a/packages/client/ui/react-native/ios/CrossmintReactNativeUI.podspec
+++ b/packages/client/ui/react-native/ios/CrossmintReactNativeUI.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.swift_version  = '6.0'
 
   s.dependency 'ExpoModulesCore'
-  s.dependency 'CrossmintDeviceSigner', '~> 0.11'
+  s.dependency 'CrossmintDeviceSigner', '~> 0.12'
 end

--- a/packages/client/ui/react-native/ios/DeviceSignerModule.swift
+++ b/packages/client/ui/react-native/ios/DeviceSignerModule.swift
@@ -3,28 +3,15 @@ import CrossmintDeviceSigner
 import ExpoModulesCore
 import Security
 
-/// Expo native module that exposes device signer key storage to React Native.
-///
-/// On physical iOS devices the module delegates to ``SecureEnclaveKeyStorage`` so all
-/// key material lives in the Secure Enclave. On simulators it always uses
-/// ``KeychainKeyStorage`` (Secure Enclave is not available on simulators).
-///
-/// The module is registered as `"CrossmintDeviceSigner"` and consumed on the JS side by
-/// `NativeDeviceSignerKeyStorage` from `@crossmint/client-sdk-react-native-ui`.
 public class DeviceSignerModule: Module {
-
-    // MARK: - Module definition
 
     public func definition() -> ModuleDefinition {
         Name("CrossmintDeviceSigner")
 
-        // Returns true — the module always has a storage backend available (hardware
-        // on real devices, software fallback on simulators).
         AsyncFunction("isAvailable") { () -> Bool in
             true
         }
 
-        // Generates a new P-256 key and persists it.
         AsyncFunction("generateKey") { (address: String?) async throws -> String in
             do {
                 return try await self.defaultStorage().generateKey(address: address)
@@ -36,7 +23,6 @@ public class DeviceSignerModule: Module {
             }
         }
 
-        // Renames the pending Keychain entry to a wallet-address entry.
         AsyncFunction("mapAddressToKey") { (address: String, publicKeyBase64: String) async throws in
             do {
                 try await self.defaultStorage().mapAddressToKey(address: address, publicKeyBase64: publicKeyBase64)
@@ -45,22 +31,14 @@ public class DeviceSignerModule: Module {
             }
         }
 
-        // Returns the stored public key for a wallet address, or nil.
         AsyncFunction("getKey") { (address: String) async -> String? in
             await self.defaultStorage().getKey(address: address)
         }
 
-        // Returns true only if the private key for the given public key is actually
-        // present on this device. Delegates to the storage backend, which inspects the
-        // real Keychain / Secure Enclave item — not a record of past key generation.
-        // A device-bound key does not survive a restore onto new hardware, so reporting
-        // presence from anything other than the live item would send the SDK into a
-        // rename/sign loop that can never succeed (WAL-10734).
         AsyncFunction("hasKey") { (publicKeyBase64: String) -> Bool in
             self.defaultStorage().hasKey(publicKeyBase64: publicKeyBase64)
         }
 
-        // Signs a base64-encoded message; returns { r, s } hex strings.
         AsyncFunction("signMessage") { (address: String, message: String) async throws -> [String: String] in
             do {
                 let sig = try await self.defaultStorage().signMessage(address: address, message: message)
@@ -70,18 +48,14 @@ public class DeviceSignerModule: Module {
             }
         }
 
-        // Deletes the key for a wallet address.
         AsyncFunction("deleteKey") { (address: String) async throws in
             try await self.defaultStorage().deleteKey(address: address)
         }
 
-        // Deletes a pending key that was never promoted to a wallet-address key.
         AsyncFunction("deletePendingKey") { (publicKeyBase64: String) async throws in
             try await self.defaultStorage().deletePendingKey(publicKeyBase64: publicKeyBase64)
         }
     }
-
-    // MARK: - Private helpers
 
     private func defaultStorage() -> any DeviceSignerKeyStorage {
         #if targetEnvironment(simulator)

--- a/packages/client/ui/react-native/ios/DeviceSignerModule.swift
+++ b/packages/client/ui/react-native/ios/DeviceSignerModule.swift
@@ -3,15 +3,28 @@ import CrossmintDeviceSigner
 import ExpoModulesCore
 import Security
 
+/// Expo native module that exposes device signer key storage to React Native.
+///
+/// On physical iOS devices the module delegates to ``SecureEnclaveKeyStorage`` so all
+/// key material lives in the Secure Enclave. On simulators it always uses
+/// ``KeychainKeyStorage`` (Secure Enclave is not available on simulators).
+///
+/// The module is registered as `"CrossmintDeviceSigner"` and consumed on the JS side by
+/// `NativeDeviceSignerKeyStorage` from `@crossmint/client-sdk-react-native-ui`.
 public class DeviceSignerModule: Module {
+
+    // MARK: - Module definition
 
     public func definition() -> ModuleDefinition {
         Name("CrossmintDeviceSigner")
 
+        // Returns true — the module always has a storage backend available (hardware
+        // on real devices, software fallback on simulators).
         AsyncFunction("isAvailable") { () -> Bool in
             true
         }
 
+        // Generates a new P-256 key and persists it.
         AsyncFunction("generateKey") { (address: String?) async throws -> String in
             do {
                 return try await self.defaultStorage().generateKey(address: address)
@@ -23,6 +36,7 @@ public class DeviceSignerModule: Module {
             }
         }
 
+        // Renames the pending Keychain entry to a wallet-address entry.
         AsyncFunction("mapAddressToKey") { (address: String, publicKeyBase64: String) async throws in
             do {
                 try await self.defaultStorage().mapAddressToKey(address: address, publicKeyBase64: publicKeyBase64)
@@ -31,14 +45,17 @@ public class DeviceSignerModule: Module {
             }
         }
 
+        // Returns the stored public key for a wallet address, or nil.
         AsyncFunction("getKey") { (address: String) async -> String? in
             await self.defaultStorage().getKey(address: address)
         }
 
+        // Returns true if the private key for the given public key is present on this device.
         AsyncFunction("hasKey") { (publicKeyBase64: String) -> Bool in
             self.defaultStorage().hasKey(publicKeyBase64: publicKeyBase64)
         }
 
+        // Signs a base64-encoded message; returns { r, s } hex strings.
         AsyncFunction("signMessage") { (address: String, message: String) async throws -> [String: String] in
             do {
                 let sig = try await self.defaultStorage().signMessage(address: address, message: message)
@@ -48,14 +65,18 @@ public class DeviceSignerModule: Module {
             }
         }
 
+        // Deletes the key for a wallet address.
         AsyncFunction("deleteKey") { (address: String) async throws in
             try await self.defaultStorage().deleteKey(address: address)
         }
 
+        // Deletes a pending key that was never promoted to a wallet-address key.
         AsyncFunction("deletePendingKey") { (publicKeyBase64: String) async throws in
             try await self.defaultStorage().deletePendingKey(publicKeyBase64: publicKeyBase64)
         }
     }
+
+    // MARK: - Private helpers
 
     private func defaultStorage() -> any DeviceSignerKeyStorage {
         #if targetEnvironment(simulator)

--- a/packages/client/ui/react-native/ios/DeviceSignerModule.swift
+++ b/packages/client/ui/react-native/ios/DeviceSignerModule.swift
@@ -27,9 +27,7 @@ public class DeviceSignerModule: Module {
         // Generates a new P-256 key and persists it.
         AsyncFunction("generateKey") { (address: String?) async throws -> String in
             do {
-                let pubKey = try await self.defaultStorage().generateKey(address: address)
-                self.trackPublicKey(pubKey)
-                return pubKey
+                return try await self.defaultStorage().generateKey(address: address)
             } catch {
                 throw Exception(
                     name: "GenerateKeyFailed",
@@ -52,9 +50,14 @@ public class DeviceSignerModule: Module {
             await self.defaultStorage().getKey(address: address)
         }
 
-        // Returns true if a key with the given public key was generated on this device.
+        // Returns true only if the private key for the given public key is actually
+        // present on this device. Delegates to the storage backend, which inspects the
+        // real Keychain / Secure Enclave item — not a record of past key generation.
+        // A device-bound key does not survive a restore onto new hardware, so reporting
+        // presence from anything other than the live item would send the SDK into a
+        // rename/sign loop that can never succeed (WAL-10734).
         AsyncFunction("hasKey") { (publicKeyBase64: String) -> Bool in
-            self.trackedPublicKeys().contains(publicKeyBase64)
+            self.defaultStorage().hasKey(publicKeyBase64: publicKeyBase64)
         }
 
         // Signs a base64-encoded message; returns { r, s } hex strings.
@@ -69,78 +72,25 @@ public class DeviceSignerModule: Module {
 
         // Deletes the key for a wallet address.
         AsyncFunction("deleteKey") { (address: String) async throws in
-            let pubKey = await self.defaultStorage().getKey(address: address)
             try await self.defaultStorage().deleteKey(address: address)
-            if let pubKey = pubKey {
-                self.untrackPublicKey(pubKey)
-            }
         }
 
         // Deletes a pending key that was never promoted to a wallet-address key.
         AsyncFunction("deletePendingKey") { (publicKeyBase64: String) async throws in
             try await self.defaultStorage().deletePendingKey(publicKeyBase64: publicKeyBase64)
-            self.untrackPublicKey(publicKeyBase64)
         }
-    }
-
-    // MARK: - Public key index (Keychain-backed)
-
-    private static let indexService = "com.crossmint.device-signer"
-    private static let indexAccount = "public_key_index"
-
-    private func trackedPublicKeys() -> Set<String> {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: Self.indexService,
-            kSecAttrAccount as String: Self.indexAccount,
-            kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne,
-        ]
-        var result: AnyObject?
-        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
-              let data = result as? Data,
-              let keys = try? JSONDecoder().decode([String].self, from: data)
-        else { return [] }
-        return Set(keys)
-    }
-
-    private func saveTrackedPublicKeys(_ keys: Set<String>) {
-        guard let data = try? JSONEncoder().encode(Array(keys)) else { return }
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: Self.indexService,
-            kSecAttrAccount as String: Self.indexAccount,
-        ]
-        let status = SecItemUpdate(query as CFDictionary, [kSecValueData as String: data] as CFDictionary)
-        if status == errSecItemNotFound {
-            var addQuery = query
-            addQuery[kSecValueData as String] = data
-            SecItemAdd(addQuery as CFDictionary, nil)
-        }
-    }
-
-    private func trackPublicKey(_ pubKey: String) {
-        var keys = trackedPublicKeys()
-        keys.insert(pubKey)
-        saveTrackedPublicKeys(keys)
-    }
-
-    private func untrackPublicKey(_ pubKey: String) {
-        var keys = trackedPublicKeys()
-        keys.remove(pubKey)
-        saveTrackedPublicKeys(keys)
     }
 
     // MARK: - Private helpers
 
     private func defaultStorage() -> any DeviceSignerKeyStorage {
         #if targetEnvironment(simulator)
-        return SoftwareDeviceSignerKeyStorage()
+        return KeychainKeyStorage()
         #else
         if SecureEnclave.isAvailable {
             return SecureEnclaveKeyStorage()
         } else {
-            return SoftwareDeviceSignerKeyStorage()
+            return KeychainKeyStorage()
         }
         #endif
     }

--- a/packages/wallets/src/wallets/wallet.device-key-loss.test.ts
+++ b/packages/wallets/src/wallets/wallet.device-key-loss.test.ts
@@ -3,24 +3,6 @@ import { Wallet } from "./wallet";
 import type { ApiClient } from "../api";
 import { createMockApiClient, type MockedApiClient } from "./__tests__/test-helpers";
 
-/**
- * WAL-10734: a wallet has a device signer registered server-side, but the private
- * key is no longer on the device (for example after a restore onto new hardware,
- * where the `ThisDeviceOnly` Secure Enclave key does not survive).
- *
- * The device signer is registered, so `resolveDeviceSignerAvailability` finds a
- * `device:` signer and asks the key storage `hasKey`. The production bug is that the
- * React Native module answered `hasKey` from a backup-eligible index of
- * once-generated keys rather than from the live key material, so it returned `true`
- * for a key that was gone and the SDK then looped on a `mapAddressToKey` that could
- * never succeed.
- *
- * These tests exercise the orchestration with a key storage mock:
- *  - an honest `hasKey` (false when the key is gone) routes straight to recovery and
- *    never attempts the doomed mapping;
- *  - even with a lying `hasKey` plus a failing map, resolution no longer throws and
- *    the wallet ends up flagged for recovery rather than surfacing a hard error.
- */
 const WALLET_ADDRESS = "0x1234567890123456789012345678901234567890";
 const LOST_SIGNER_LOCATOR = "device:LOSTKEY";
 
@@ -60,7 +42,6 @@ describe("Wallet - device signer key loss (WAL-10734)", () => {
             },
             mockApiClient as unknown as ApiClient
         );
-        // A device signer is registered server-side, but its key is gone locally.
         vi.spyOn(wallet, "signers").mockResolvedValue([
             { type: "device", address: WALLET_ADDRESS, locator: LOST_SIGNER_LOCATOR, status: "success" } as never,
         ]);
@@ -97,8 +78,6 @@ describe("Wallet - device signer key loss (WAL-10734)", () => {
         await wallet.waitForInit();
 
         const config: { type: "device"; locator?: string } = { type: "device" };
-        // Direct call to the resolution step (the unguarded useSigner path reaches it):
-        // with the fix this resolves; before the fix the rejected map propagated out.
         await expect(
             (wallet as unknown as { resolveDeviceSignerAvailability(c: unknown): Promise<void> }).resolveDeviceSignerAvailability(
                 config

--- a/packages/wallets/src/wallets/wallet.device-key-loss.test.ts
+++ b/packages/wallets/src/wallets/wallet.device-key-loss.test.ts
@@ -70,19 +70,4 @@ describe("Wallet - device signer key loss (WAL-10734)", () => {
         expect(wallet.signer).toBeUndefined();
         expect(wallet.needsRecovery()).toBe(true);
     });
-
-    it("resolveDeviceSignerAvailability swallows a failing map instead of throwing", async () => {
-        const mapAddressToKey = vi.fn().mockRejectedValue(new Error("mapAddressToKey failed: storageError(-25300)"));
-        const storage = makeStorage({ hasKey: vi.fn().mockResolvedValue(true), mapAddressToKey });
-        const wallet = buildWallet(storage);
-        await wallet.waitForInit();
-
-        const config: { type: "device"; locator?: string } = { type: "device" };
-        await expect(
-            (wallet as unknown as { resolveDeviceSignerAvailability(c: unknown): Promise<void> }).resolveDeviceSignerAvailability(
-                config
-            )
-        ).resolves.toBeUndefined();
-        expect(config.locator).toBeUndefined();
-    });
 });

--- a/packages/wallets/src/wallets/wallet.device-key-loss.test.ts
+++ b/packages/wallets/src/wallets/wallet.device-key-loss.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Wallet } from "./wallet";
+import type { ApiClient } from "../api";
+import { createMockApiClient, type MockedApiClient } from "./__tests__/test-helpers";
+
+/**
+ * WAL-10734: a wallet has a device signer registered server-side, but the private
+ * key is no longer on the device (for example after a restore onto new hardware,
+ * where the `ThisDeviceOnly` Secure Enclave key does not survive).
+ *
+ * The device signer is registered, so `resolveDeviceSignerAvailability` finds a
+ * `device:` signer and asks the key storage `hasKey`. The production bug is that the
+ * React Native module answered `hasKey` from a backup-eligible index of
+ * once-generated keys rather than from the live key material, so it returned `true`
+ * for a key that was gone and the SDK then looped on a `mapAddressToKey` that could
+ * never succeed.
+ *
+ * These tests exercise the orchestration with a key storage mock:
+ *  - an honest `hasKey` (false when the key is gone) routes straight to recovery and
+ *    never attempts the doomed mapping;
+ *  - even with a lying `hasKey` plus a failing map, resolution no longer throws and
+ *    the wallet ends up flagged for recovery rather than surfacing a hard error.
+ */
+const WALLET_ADDRESS = "0x1234567890123456789012345678901234567890";
+const LOST_SIGNER_LOCATOR = "device:LOSTKEY";
+
+type StorageOverrides = {
+    getKey?: ReturnType<typeof vi.fn>;
+    hasKey?: ReturnType<typeof vi.fn>;
+    mapAddressToKey?: ReturnType<typeof vi.fn>;
+};
+
+function makeStorage(overrides: StorageOverrides = {}) {
+    return {
+        generateKey: vi.fn().mockResolvedValue("freshPublicKeyBase64"),
+        getKey: overrides.getKey ?? vi.fn().mockResolvedValue(null),
+        hasKey: overrides.hasKey ?? vi.fn().mockResolvedValue(false),
+        mapAddressToKey: overrides.mapAddressToKey ?? vi.fn().mockResolvedValue(undefined),
+        deleteKey: vi.fn().mockResolvedValue(undefined),
+        signMessage: vi.fn(),
+        getDeviceName: vi.fn().mockReturnValue("Test Device"),
+    };
+}
+
+describe("Wallet - device signer key loss (WAL-10734)", () => {
+    let mockApiClient: MockedApiClient;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockApiClient = createMockApiClient();
+    });
+
+    function buildWallet(storage: ReturnType<typeof makeStorage>): Wallet<"base-sepolia"> {
+        const wallet = new Wallet(
+            {
+                chain: "base-sepolia",
+                address: WALLET_ADDRESS,
+                recovery: { type: "api-key" } as never,
+                options: { deviceSignerKeyStorage: storage as never },
+            },
+            mockApiClient as unknown as ApiClient
+        );
+        // A device signer is registered server-side, but its key is gone locally.
+        vi.spyOn(wallet, "signers").mockResolvedValue([
+            { type: "device", address: WALLET_ADDRESS, locator: LOST_SIGNER_LOCATOR, status: "success" } as never,
+        ]);
+        return wallet;
+    }
+
+    it("honest hasKey (false) routes to recovery without attempting a mapping", async () => {
+        const storage = makeStorage({ hasKey: vi.fn().mockResolvedValue(false) });
+        const wallet = buildWallet(storage);
+
+        await wallet.waitForInit();
+
+        expect(storage.mapAddressToKey).not.toHaveBeenCalled();
+        expect(wallet.needsRecovery()).toBe(true);
+        expect(wallet.signer).toBeUndefined();
+    });
+
+    it("does not bind the dead device signer and flags recovery when the key is gone but hasKey lies", async () => {
+        const mapAddressToKey = vi.fn().mockRejectedValue(new Error("mapAddressToKey failed: storageError(-25300)"));
+        const storage = makeStorage({ hasKey: vi.fn().mockResolvedValue(true), mapAddressToKey });
+        const wallet = buildWallet(storage);
+
+        await expect(wallet.waitForInit()).resolves.toBeUndefined();
+
+        expect(mapAddressToKey).toHaveBeenCalledWith(WALLET_ADDRESS, "LOSTKEY");
+        expect(wallet.signer).toBeUndefined();
+        expect(wallet.needsRecovery()).toBe(true);
+    });
+
+    it("resolveDeviceSignerAvailability swallows a failing map instead of throwing", async () => {
+        const mapAddressToKey = vi.fn().mockRejectedValue(new Error("mapAddressToKey failed: storageError(-25300)"));
+        const storage = makeStorage({ hasKey: vi.fn().mockResolvedValue(true), mapAddressToKey });
+        const wallet = buildWallet(storage);
+        await wallet.waitForInit();
+
+        const config: { type: "device"; locator?: string } = { type: "device" };
+        // Direct call to the resolution step (the unguarded useSigner path reaches it):
+        // with the fix this resolves; before the fix the rejected map propagated out.
+        await expect(
+            (wallet as unknown as { resolveDeviceSignerAvailability(c: unknown): Promise<void> }).resolveDeviceSignerAvailability(
+                config
+            )
+        ).resolves.toBeUndefined();
+        expect(config.locator).toBeUndefined();
+    });
+});

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -1547,7 +1547,19 @@ export class Wallet<C extends Chain> {
             const publicKeyBase64 = walletSigner.locator.replace("device:", "");
             const hasKey = await deviceSignerKeyStorage.hasKey(publicKeyBase64);
             if (hasKey) {
-                await deviceSignerKeyStorage.mapAddressToKey(this.address, publicKeyBase64);
+                try {
+                    await deviceSignerKeyStorage.mapAddressToKey(this.address, publicKeyBase64);
+                } catch (error) {
+                    // hasKey reported the key as present but the mapping failed, so the
+                    // local key material is not actually usable (e.g. it did not survive a
+                    // restore onto new hardware). Skip this signer and fall through to
+                    // recovery instead of surfacing a hard failure (WAL-10734).
+                    walletsLogger.warn("wallet.resolveDeviceSigner.mapAddressToKey.error", {
+                        signerLocator: walletSigner.locator,
+                        error,
+                    });
+                    continue;
+                }
                 config.locator = walletSigner.locator;
                 return;
             }

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -1547,15 +1547,7 @@ export class Wallet<C extends Chain> {
             const publicKeyBase64 = walletSigner.locator.replace("device:", "");
             const hasKey = await deviceSignerKeyStorage.hasKey(publicKeyBase64);
             if (hasKey) {
-                try {
-                    await deviceSignerKeyStorage.mapAddressToKey(this.address, publicKeyBase64);
-                } catch (error) {
-                    walletsLogger.warn("wallet.resolveDeviceSigner.mapAddressToKey.error", {
-                        signerLocator: walletSigner.locator,
-                        error,
-                    });
-                    continue;
-                }
+                await deviceSignerKeyStorage.mapAddressToKey(this.address, publicKeyBase64);
                 config.locator = walletSigner.locator;
                 return;
             }

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -1550,10 +1550,6 @@ export class Wallet<C extends Chain> {
                 try {
                     await deviceSignerKeyStorage.mapAddressToKey(this.address, publicKeyBase64);
                 } catch (error) {
-                    // hasKey reported the key as present but the mapping failed, so the
-                    // local key material is not actually usable (e.g. it did not survive a
-                    // restore onto new hardware). Skip this signer and fall through to
-                    // recovery instead of surfacing a hard failure (WAL-10734).
                     walletsLogger.warn("wallet.resolveDeviceSigner.mapAddressToKey.error", {
                         signerLocator: walletSigner.locator,
                         error,


### PR DESCRIPTION
Device signers could stop working after someone restored their wallet onto a new phone, failing with `keyNotFound` and retrying in a loop. The iOS module decided a key was present by reading a record of keys generated on the device, and that record is backup eligible, so it survives a restore even though the device-bound key does not.

This makes `hasKey` answer from the live Keychain, so a key that is gone reads as absent. The wallet then registers a fresh device signer on the new phone, or falls back to the recovery signer, instead of looping.

## Changes
- `DeviceSignerModule.hasKey` now delegates to the storage backend, which checks the actual Keychain or Secure Enclave item, instead of a separate `public_key_index`. Removed that index and its bookkeeping in `generateKey`, `deleteKey`, and `deletePendingKey`.
- Bumped the `CrossmintDeviceSigner` pod to `~> 0.12`, which exposes the presence check and uses the `KeychainKeyStorage` name, and updated the simulator path to match.
- Added wallet tests for the key-loss path.

Depends on the `CrossmintDeviceSigner` 0.12.1 release from https://github.com/Crossmint/crossmint-swift-sdk/pull/108.
