### PR TITLE
fix(wallets): wipe server-signer key bytes on locator-only resolution (WAL-10667)

### DIFF
--- a/.changeset/wal-10667-server-signer-locator-wipe.md
+++ b/.changeset/wal-10667-server-signer-locator-wipe.md
@@ -1,0 +1,7 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+fix(wallets): wipe server-signer key bytes on locator-only resolution (WAL-10667)
+
+`ServerSignerResolver.apiLocator()` resolves a server signer to its on-chain locator (used by `addSigner` and by `send` with a server `options.signer`), which needs only the derived address. The selected candidate's `derivedKeyBytes` were left live in memory until GC — only the losing candidate was wiped. They are now `secureWipe`d unless the resolution is a cached slot, consistent with the existing secure-wipe hardening.

--- a/packages/wallets/src/signers/server/resolver.test.ts
+++ b/packages/wallets/src/signers/server/resolver.test.ts
@@ -111,9 +111,20 @@ describe("ServerSignerResolver", () => {
             expectWipedAndKept(recorded[0], "legacy", "primary", 7);
         });
     });
-    it("apiLocator formats the resolved derived address as a server locator", () => {
-        installCandidates({ s: { primary: { address: "0xPrimary", fill: 7 }, legacy: null } });
-        expect(makeResolver().apiLocator(fullConfig("s"))).toBe("server:0xPrimary");
+    describe("apiLocator", () => {
+        it("formats the resolved derived address as a server locator and wipes the locator-only key bytes (WAL-10667)", () => {
+            const recorded = installCandidates({ s: { primary: { address: "0xPrimary", fill: 7 }, legacy: null } });
+            expect(makeResolver().apiLocator(fullConfig("s"))).toBe("server:0xPrimary");
+            expect(isZeroed(recorded[0].primary.derivedKeyBytes)).toBe(true);
+        });
+        it("does not wipe a cached resolution's key bytes", () => {
+            const recorded = installCandidates({ s: { primary: { address: "0xPrimary", fill: 7 }, legacy: null } });
+            const resolver = makeResolver();
+            const cached = cacheDelegated(resolver, recorded, "s", "server:0xPrimary").primary;
+            installCandidates({ s: { primary: { address: "0xPrimary", fill: 7 }, legacy: null } });
+            expect(resolver.apiLocator(fullConfig("s"))).toBe("server:0xPrimary");
+            expect(everyByteIs(cached.derivedKeyBytes, 7)).toBe(true);
+        });
     });
     describe("resolveForUseSigner", () => {
         it.each([

--- a/packages/wallets/src/signers/server/resolver.ts
+++ b/packages/wallets/src/signers/server/resolver.ts
@@ -76,7 +76,12 @@ export class ServerSignerResolver {
     }
 
     apiLocator(config: ServerSignerConfig | ApiSourcedServerSignerConfig): ServerSignerLocator {
-        return `server:${this.resolveDerivation(config).derivedAddress}`;
+        const resolved = this.resolveDerivation(config);
+        // Only the address is needed here — wipe the selected candidate's key bytes (never the cached slots).
+        if (resolved !== this.#resolvedServerSigner && resolved !== this.#resolvedRecoveryServerSigner) {
+            secureWipe(resolved.derivedKeyBytes);
+        }
+        return `server:${resolved.derivedAddress}`;
     }
 
     /**


### PR DESCRIPTION
Fixes [WAL-10667](https://linear.app/crossmint/issue/WAL-10667) (High). First of the post-decomposition reliability fixes.

## Bug
`ServerSignerResolver.apiLocator()` → `resolveDerivation()` returns the **selected** server-signer candidate with its `derivedKeyBytes` still live. Locator resolution only needs `derivedAddress`, and only the *losing* candidate was wiped — so the selected candidate's private key material lingered in memory until GC. Reached from `addSigner()` and from `send()` with a server `options.signer`. Inconsistent with the secure-wipe hardening (#1911).

## Fix
In `apiLocator()`, after resolving, `secureWipe()` the selected candidate's key bytes **unless** the resolution is one of the cached slots (`#resolvedServerSigner` / `#resolvedRecoveryServerSigner`, which are only wiped on reset). This mirrors the exact guard already used by `keyMaterialForAssembly()`.

```ts
const resolved = this.resolveDerivation(config);
if (resolved !== this.#resolvedServerSigner && resolved !== this.#resolvedRecoveryServerSigner) {
    secureWipe(resolved.derivedKeyBytes);
}
return `server:${resolved.derivedAddress}`;
```

`resolveDerivation()` is unchanged — it still returns live bytes for `keyMaterialForAssembly()`, which needs them (it copies, then wipes).

## Tests
- `resolver.test.ts`: new `apiLocator` block — proves the locator-only path wipes the selected candidate's key bytes (WAL-10667), and that a cached resolution's bytes are **not** wiped.
- Full suite **742 passed / 0 failed**; `tsc` clean; `biome` error-gate exits 0.

## Note on the ticket
WAL-10667 currently shows `Done` in Linear — that's a stale auto-status from the refactor PRs referencing the WAL id; the bug was still present in code (the characterization pins asserted the unwiped behavior). This is the actual fix. (Several `WAL-*` tickets are similarly mis-stated — happy to reconcile them.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/crossmint-sdk/pull/1938" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->