### PR TITLE
fix(wallets): transaction-failure message + signature polling timeout (WAL-10670, WAL-10675)

### DIFF
--- a/.changeset/wal-10670-10675-operation-poller-fixes.md
+++ b/.changeset/wal-10670-10675-operation-poller-fixes.md
@@ -1,0 +1,8 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+fix(wallets): transaction-failure message + signature polling timeout (WAL-10670, WAL-10675)
+
+- `waitForTransactionCompletion`: the `failed` branch interpolated `transactionResponse.error`, which is always falsy there (any truthy error already threw earlier in the loop), so consumers always saw `Transaction sending failed: undefined`. It now serializes the full failed transaction response.
+- `waitForSignatureCompletion`: previously polled a perpetually-pending signature forever. It now honors a `timeoutMs` (default 60s, matching `waitForTransactionCompletion`) and throws the new `SignatureConfirmationTimeoutError` on timeout.

--- a/packages/wallets/src/utils/errors.ts
+++ b/packages/wallets/src/utils/errors.ts
@@ -141,6 +141,12 @@ export class SignatureFailedError extends CrossmintSDKError {
     }
 }
 
+export class SignatureConfirmationTimeoutError extends CrossmintSDKError {
+    constructor(message: string, details?: string) {
+        super(message, WalletErrorCode.SIGNING_FAILED, details);
+    }
+}
+
 export class InvalidTransferAmountError extends CrossmintSDKError {
     constructor(message: string, details?: string) {
         super(message, WalletErrorCode.NO_TRANSACTION, details);

--- a/packages/wallets/src/wallets/services/operation-poller.test.ts
+++ b/packages/wallets/src/wallets/services/operation-poller.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ApiClient, WalletLocator } from "../../api";
 import {
+    SignatureConfirmationTimeoutError,
     SignatureNotAvailableError,
     SigningFailedError,
     TransactionAwaitingApprovalError,
@@ -89,10 +90,10 @@ describe("operation-poller", () => {
 
         it.each([
             {
-                title: "throws TransactionSendingFailedError with message 'Transaction sending failed: undefined' when status is failed (WAL-10670)",
+                title: "throws TransactionSendingFailedError including the failed response payload when status is failed",
                 response: { id: "txn-fail", status: "failed" } as any,
                 errorClass: TransactionSendingFailedError,
-                message: "Transaction sending failed: undefined",
+                message: 'Transaction sending failed: {"id":"txn-fail","status":"failed"}',
             },
             {
                 title: "throws TransactionAwaitingApprovalError when transaction is awaiting-approval",
@@ -262,23 +263,11 @@ describe("operation-poller", () => {
             expect(mockApiClient.getSignature).toHaveBeenCalledWith("me:evm:smart", "sig-loop");
         });
 
-        it("polls indefinitely with no timeout while the signature stays pending (WAL-10675)", async () => {
-            let response: any = { id: "sig-forever", status: "pending" };
-            mockApiClient.getSignature.mockImplementation(async () => response);
-            const calls = () => mockApiClient.getSignature.mock.calls.length;
-            let settled = false;
-            const promise = pollSig("sig-forever").finally(() => {
-                settled = true;
-            });
-
-            await vi.advanceTimersByTimeAsync(600_000);
-            expect(settled).toBe(false);
-            expect(calls()).toBe(1_200);
-
-            response = { id: "sig-forever", status: "success", outputSignature: "0xeventualsig" };
-            await vi.runAllTimersAsync();
-            expect(await promise).toEqual({ signature: "0xeventualsig", signatureId: "sig-forever" });
-            expect(settled).toBe(true);
+        it("times out after the default 60s when the signature stays pending", async () => {
+            mockApiClient.getSignature.mockResolvedValue({ id: "sig-forever", status: "pending" } as any);
+            const error = await settleError(pollSig("sig-forever"));
+            expect(error).toBeInstanceOf(SignatureConfirmationTimeoutError);
+            expect(error.message).toBe("Signature confirmation timeout");
         });
 
         it("throws SignatureNotAvailableError when getSignature returns an error during polling", async () => {

--- a/packages/wallets/src/wallets/services/operation-poller.ts
+++ b/packages/wallets/src/wallets/services/operation-poller.ts
@@ -1,6 +1,7 @@
 import type { ApiClient, GetSignatureResponse, WalletLocator } from "../../api";
 import type { Signature, Transaction } from "../types";
 import {
+    SignatureConfirmationTimeoutError,
     SignatureNotAvailableError,
     SigningFailedError,
     TransactionAwaitingApprovalError,
@@ -48,7 +49,7 @@ export async function waitForTransactionCompletion(
 
     if (transactionResponse.status === "failed") {
         const error = new TransactionSendingFailedError(
-            `Transaction sending failed: ${JSON.stringify(transactionResponse.error)}`
+            `Transaction sending failed: ${JSON.stringify(transactionResponse)}`
         );
         throw error;
     }
@@ -80,11 +81,17 @@ export async function waitForTransactionCompletion(
 export async function waitForSignatureCompletion(
     apiClient: ApiClient,
     walletLocator: WalletLocator,
-    signatureId: string
+    signatureId: string,
+    options?: PollingOptions
 ): Promise<Signature<false>> {
+    const { timeoutMs = 60_000 } = options ?? {};
+    const startTime = Date.now();
     let signatureResponse: GetSignatureResponse | null = null;
 
     do {
+        if (Date.now() - startTime > timeoutMs) {
+            throw new SignatureConfirmationTimeoutError("Signature confirmation timeout");
+        }
         await new Promise((resolve) => setTimeout(resolve, STATUS_POLLING_INTERVAL_MS));
         signatureResponse = await apiClient.getSignature(walletLocator, signatureId);
         if ("error" in signatureResponse) {


### PR DESCRIPTION
Two reliability fixes in `operation-poller.ts`. Fixes [WAL-10670](https://linear.app/crossmint/issue/WAL-10670) and [WAL-10675](https://linear.app/crossmint/issue/WAL-10675) (both Low). Off `main`, unstacked.

## WAL-10670 — `"Transaction sending failed: undefined"`
`waitForTransactionCompletion`'s `failed` branch interpolated `transactionResponse.error`, but any truthy `.error` already threw `TransactionNotAvailableError` earlier in the loop — so on this path `.error` is always falsy and consumers always saw the literal `Transaction sending failed: undefined`. Now serializes the full failed response (mirrors the sibling `TransactionNotAvailableError`), surfacing the real failure payload.

## WAL-10675 — `waitForSignature` polled forever
`waitForSignatureCompletion` had no timeout — a perpetually-pending signature was polled indefinitely, unlike `waitForTransactionCompletion`'s 60s cap. It now takes `options?: PollingOptions`, defaults `timeoutMs` to 60s, and throws a new `SignatureConfirmationTimeoutError` on timeout. (Decision per the ticket: make it consistent with transactions.)

## Tests
- `operation-poller.test.ts`: WAL-10670 case updated to assert the serialized payload; WAL-10675 case rewritten to assert the 60s timeout throws `SignatureConfirmationTimeoutError`.
- Relevant suites green; `tsc` clean; `biome` error-gate exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/crossmint-sdk/pull/1939" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->