### PR TITLE
fix(wallets): clear stale needs-recovery when device key is adopted (WAL-10668)

### DIFF
--- a/.changeset/clear-stale-needsrecovery-on-device-adopt.md
+++ b/.changeset/clear-stale-needsrecovery-on-device-adopt.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+WAL-10668: clear a stale needs-recovery status when resolveAvailability adopts a local device key

--- a/packages/wallets/src/wallets/services/device-recovery-service.test.ts
+++ b/packages/wallets/src/wallets/services/device-recovery-service.test.ts
@@ -157,6 +157,17 @@ describe("DeviceRecoveryService", () => {
             expect(config.locator).toBe("device:registeredKey");
             expect(service.needsRecovery).toBe(false);
         });
+
+        it("clears a stale recovery need once a local key is adopted (WAL-10668)", async () => {
+            const storage = makeStorage();
+            const { service } = setup({ storage });
+            await service.resolveAvailability({ type: "device" } as never);
+            expect(service.needsRecovery).toBe(true);
+
+            storage.getKey.mockResolvedValue("adoptedKey");
+            await service.resolveAvailability({ type: "device" } as never);
+            expect(service.needsRecovery).toBe(false);
+        });
     });
 
     describe("recover() guards", () => {

--- a/packages/wallets/src/wallets/services/device-recovery-service.ts
+++ b/packages/wallets/src/wallets/services/device-recovery-service.ts
@@ -225,6 +225,7 @@ export class DeviceRecoveryService<C extends Chain> {
         const existingKey = await deviceSignerKeyStorage.getKey(this.#walletAddress);
         if (existingKey != null) {
             config.locator = `device:${existingKey}`;
+            this.#status = "unknown";
             return;
         }
 
@@ -236,6 +237,7 @@ export class DeviceRecoveryService<C extends Chain> {
             if (hasKey) {
                 await deviceSignerKeyStorage.mapAddressToKey(this.#walletAddress, publicKeyBase64);
                 config.locator = walletSigner.locator;
+                this.#status = "unknown";
                 return;
             }
         }


### PR DESCRIPTION
## WAL-10668

In `DeviceRecoveryService.resolveAvailability(config)`, the two success branches returned **without** touching `#status`:

1. an existing local key found via `storage.getKey`
2. a registered device signer whose key is present locally via `storage.hasKey`

The no-key branch correctly sets `#status = "needs-recovery"`. So once a prior step had set `needs-recovery`, a later successful device-key adoption (e.g. `useSigner({ type: "device" })`) left it stale — `wallet.needsRecovery()` kept returning `true` even though a key had just been adopted.

## Fix

Both success branches now set `this.#status = "unknown"` before returning. `"unknown"` is the honest state since signer approval is confirmed later — this only changes behavior when the prior status was `needs-recovery`.

`initDeviceSigner` is unaffected: after `resolveAvailability` finds a key, it still assembles the signer and re-sets `needs-recovery` when the signer is unapproved.

## Test

Added a committed test in `device-recovery-service.test.ts` (matching the existing `setup()` harness): drive the service to `needs-recovery` (resolveAvailability with no key), then call `resolveAvailability` again with `storage.getKey` resolving a key → `service.needsRecovery` becomes `false`. All existing tests still pass (570 passed / 68 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/crossmint-sdk/pull/1940" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->