### PR TITLE
fix(wallets): harden wallet reads + addSigner scope handling (WAL-10671/10672/10674)

### DIFF
--- a/.changeset/wallet-read-and-scopes.md
+++ b/.changeset/wallet-read-and-scopes.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+Fix wallet read + scope handling: nfts() now resolves the chain for the environment and throws on API errors (WAL-10671), transaction() serializes response.message instead of response.error (WAL-10672), and addSigner() fails loudly instead of silently dropping scopes when resuming a pending registration (WAL-10674).

--- a/packages/wallets/src/wallets/__tests__/setup.ts
+++ b/packages/wallets/src/wallets/__tests__/setup.ts
@@ -6,6 +6,7 @@ const mockWalletsLogger = {
     info: vi.fn(),
     error: vi.fn(),
     warn: vi.fn(),
+    debug: vi.fn(),
 };
 
 vi.mock("../../logger/init", () => ({

--- a/packages/wallets/src/wallets/wallet.test.ts
+++ b/packages/wallets/src/wallets/wallet.test.ts
@@ -14,6 +14,7 @@ import {
     SignatureNotAvailableError,
 } from "../utils/errors";
 import { createMockWallet, createMockApiClient, type MockedApiClient } from "./__tests__/test-helpers";
+import { walletsLogger } from "../logger";
 
 vi.mock("@/signers/server", async (importOriginal) => {
     const actual = await importOriginal<typeof import("@/signers/server")>();
@@ -310,6 +311,54 @@ describe("Wallet - balances()", () => {
 
             await expect(wallet.balances()).rejects.toThrow("Network error");
         });
+    });
+});
+
+describe("Wallet - nfts()", () => {
+    let mockApiClient: MockedApiClient & { getNfts: ReturnType<typeof vi.fn> };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockApiClient = Object.assign(createMockApiClient(), { getNfts: vi.fn() });
+    });
+
+    it("resolves the chain for the environment before fetching (polygon -> polygon-amoy in staging)", async () => {
+        const wallet = await createMockWallet("polygon", mockApiClient);
+        mockApiClient.getNfts.mockResolvedValue([]);
+
+        await wallet.nfts({ perPage: 10, page: 1 });
+
+        expect(mockApiClient.getNfts).toHaveBeenCalledWith(
+            expect.objectContaining({ chain: "polygon-amoy", perPage: 10, page: 1 })
+        );
+    });
+
+    it("throws when the API returns an error response", async () => {
+        const wallet = await createMockWallet("base-sepolia", mockApiClient);
+        mockApiClient.getNfts.mockResolvedValue({ error: true, message: "Failed to fetch nfts" });
+
+        await expect(wallet.nfts({ perPage: 10, page: 1 })).rejects.toThrow("Failed to get nfts");
+    });
+});
+
+describe("Wallet - transaction()", () => {
+    let mockApiClient: MockedApiClient;
+    let wallet: Wallet<"base-sepolia">;
+
+    beforeEach(async () => {
+        vi.clearAllMocks();
+        mockApiClient = createMockApiClient();
+        wallet = await createMockWallet("base-sepolia", mockApiClient);
+    });
+
+    it("serializes response.message (not response.error) in the thrown error", async () => {
+        mockApiClient.getTransaction.mockResolvedValue({
+            error: { internal: "opaque-error-object" },
+            message: "Transaction not found",
+        } as any);
+
+        await expect(wallet.transaction("txn-missing")).rejects.toThrow("Transaction not found");
+        await expect(wallet.transaction("txn-missing")).rejects.not.toThrow("opaque-error-object");
     });
 });
 
@@ -988,6 +1037,49 @@ describe("Wallet - addSigner()", () => {
 
             expect(mockApiClient.registerSigner).not.toHaveBeenCalled();
             expect(result.signatureId).toBe("sig-pending");
+        });
+
+        it("throws and does not re-register when scopes are passed while resuming a pending registration", async () => {
+            mockApiClient.getSigner.mockResolvedValueOnce({
+                type: "external-wallet",
+                address: "0x456",
+                locator: "external-wallet:0x456",
+                chains: {
+                    "base-sepolia": { id: "sig-pending", status: "awaiting-approval" },
+                },
+            } as any);
+
+            await expect(
+                evmWallet.addSigner(
+                    { type: "external-wallet", address: "0x456" },
+                    { scopes: [{ type: "transfer", tokenLocator: "base-sepolia:usdc" }] }
+                )
+            ).rejects.toThrow("Cannot apply scopes when resuming a pending signer registration");
+
+            expect(mockApiClient.registerSigner).not.toHaveBeenCalled();
+        });
+
+        it("warns but does not throw when scopes are passed for an already-approved signer", async () => {
+            mockApiClient.getSigner.mockResolvedValueOnce({
+                type: "external-wallet",
+                address: "0x456",
+                locator: "external-wallet:0x456",
+                chains: {
+                    "base-sepolia": { id: "sig-done", status: "success" },
+                },
+            } as any);
+
+            const result = await evmWallet.addSigner(
+                { type: "external-wallet", address: "0x456" },
+                { scopes: [{ type: "transfer", tokenLocator: "base-sepolia:usdc" }] }
+            );
+
+            expect(result.status).toBe("success");
+            expect(mockApiClient.registerSigner).not.toHaveBeenCalled();
+            expect(walletsLogger.warn).toHaveBeenCalledWith(
+                "wallet.addSigner.scopesIgnored",
+                expect.objectContaining({ reason: "signer already approved" })
+            );
         });
 
         it("falls through to fresh registration when signer is in failed state", async () => {

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -369,11 +369,17 @@ export class Wallet<C extends Chain> {
      * @returns The NFTs
      */
     public async nfts(params: { perPage: number; page: number }) {
-        return await this.#apiClient.getNfts({
+        const resolvedChain = this.resolveChainForEnvironment();
+        const response = await this.#apiClient.getNfts({
             ...params,
-            chain: this.chain,
+            chain: resolvedChain,
             address: this.address,
         });
+        if (response != null && typeof response === "object" && "error" in response) {
+            walletsLogger.error("wallet.nfts.error", { error: response });
+            throw new Error(`Failed to get nfts: ${JSON.stringify((response as { message?: unknown }).message)}`);
+        }
+        return response;
     }
 
     /**
@@ -397,7 +403,9 @@ export class Wallet<C extends Chain> {
     public async transaction(transactionId: string): Promise<GetTransactionSuccessResponse> {
         const response = await this.#apiClient.getTransaction(this.walletLocator, transactionId);
         if ("error" in response) {
-            throw new Error(`Failed to get transaction: ${JSON.stringify(response.error)}`);
+            throw new Error(
+                `Failed to get transaction: ${JSON.stringify((response as { message?: unknown }).message)}`
+            );
         }
         return response;
     }
@@ -610,12 +618,23 @@ export class Wallet<C extends Chain> {
             if (existingState.signer != null) {
                 // Signer already fully approved — return immediately (idempotent)
                 if (this.#signerManager.isApprovedSignerStatus(existingState.signer.status)) {
+                    if (options?.scopes != null) {
+                        walletsLogger.warn("wallet.addSigner.scopesIgnored", {
+                            reason: "signer already approved",
+                            signerLocator,
+                        });
+                    }
                     walletsLogger.info("wallet.addSigner.alreadyApproved");
                     return this.completeSignerRegistration(existingState.signer, null, options);
                 }
 
                 // Pending operation from a previous attempt — resume instead of re-registering
                 if (existingState.pendingOperation != null) {
+                    if (options?.scopes != null) {
+                        throw new Error(
+                            "Cannot apply scopes when resuming a pending signer registration. Remove the pending signer and register it again with the desired scopes."
+                        );
+                    }
                     walletsLogger.info("wallet.addSigner.resuming", {
                         operationType: existingState.pendingOperation.type,
                         operationId: existingState.pendingOperation.id,


### PR DESCRIPTION
## Summary

Fixes three reliability bugs in `packages/wallets/src/wallets/wallet.ts`, bringing the affected methods in line with their siblings.

- **WAL-10671 — `nfts()`**: Now calls `this.resolveChainForEnvironment()` and passes the resolved chain to `getNfts` (previously used `this.chain` directly, so a mainnet chain like `polygon` was never converted to its testnet equivalent in staging). Adds an error guard that throws a plain `Error` (`Failed to get nfts: ...`) on an error-shaped API response instead of returning it, matching the `transfers()`/`balances()` pattern and logging `wallet.nfts.error`.
- **WAL-10672 — `transaction()`**: The error branch now serializes `response.message` instead of `response.error`, matching every sibling read method so the thrown message is the human-readable server message rather than the opaque error object.
- **WAL-10674 — `addSigner()` resume path**: When an existing pending registration is found and resumed (no `registerSigner` call), `options.scopes` was silently dropped. It now throws a clear error before resuming if scopes are supplied: _"Cannot apply scopes when resuming a pending signer registration. Remove the pending signer and register it again with the desired scopes."_ The fresh-registration path is unchanged (it already forwards scopes).

## Tests

Added committed cases to `wallet.test.ts` matching the existing harness:

- `nfts()` resolves `polygon` → `polygon-amoy` in staging and passes it to `getNfts`; throws `Failed to get nfts` on an error response.
- `transaction()` throws a message containing `response.message` text and not the `response.error` object.
- `addSigner({...}, { scopes })` against a pending registration throws the scopes error and does NOT call `registerSigner`.

All 108 `wallet.test.ts` cases pass; `tsc` is clean (ignoring the pre-existing `ncs-signer.ts:384` error) and biome error-level check exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/crossmint-sdk/pull/1941" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->