### PR TITLE
test(wallets): focused Wallet integration suite (src/tests/e2e)

### DIFF
--- a/packages/wallets/src/tests/e2e/wallet.factory-rewrap.test.ts
+++ b/packages/wallets/src/tests/e2e/wallet.factory-rewrap.test.ts
@@ -1,0 +1,371 @@
+/**
+ * Characterization (contract) tests for the chain subclass <-> base Wallet handoff.
+ *
+ * These tests pin CURRENT behavior of EVMWallet / SolanaWallet / StellarWallet and the
+ * protected-state rewrap performed by their constructors (via Wallet.getOptions /
+ * getRecovery / getInitialSigners / getApiRecoveryServerSignerAddress /
+ * getApiDelegatedServerSignerAddresses / getApiClient) before wallet.ts is decomposed
+ * into services. Exact error classes, exact message strings, exact API call arguments,
+ * and locator formats are all part of the contract — do not "fix" them here.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Wallet } from "../../wallets/wallet";
+import { EVMWallet } from "../../wallets/evm";
+import { SolanaWallet } from "../../wallets/solana";
+import { StellarWallet } from "../../wallets/stellar";
+import { deriveServerSignerCandidates } from "../../signers/server";
+import type { ApiClient } from "../../api";
+import type { Chain } from "../../chains/chains";
+import {
+    createMockApiClient,
+    createMockWallet,
+    createMockSolanaSerializedTransaction,
+    type MockedApiClient,
+} from "../../wallets/__tests__/test-helpers";
+
+const EVM_ADDRESS = "0x1234567890123456789012345678901234567890";
+const SOLANA_ADDRESS = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
+const STELLAR_ADDRESS = "GCKFBEIYTKP6RCZX6LRQW2JVAVLMGGVSNESWKN7L2YGQNI2DCOHVHJVY";
+const STELLAR_CONTRACT_ID = "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC";
+
+/**
+ * Construct a base Wallet directly (mirroring test-helpers.createMockWallet) but with
+ * extra constructor fields (alias, owner, options, signers, recovery overrides, ...)
+ * that the shared helper does not expose. By default activates the api-key signer,
+ * which matches the api-key recovery (admin path) and therefore performs no API calls.
+ */
+async function createConfiguredWallet<C extends Chain>(
+    chain: C,
+    address: string,
+    mockApiClient: MockedApiClient,
+    constructorOverrides: Record<string, unknown> = {},
+    { useApiKeySigner = true }: { useApiKeySigner?: boolean } = {}
+): Promise<Wallet<C>> {
+    const wallet = new Wallet<C>(
+        {
+            chain,
+            address,
+            recovery: { type: "api-key" },
+            ...constructorOverrides,
+            // biome-ignore lint/suspicious/noExplicitAny: test constructs raw wallet state
+        } as any,
+        mockApiClient as unknown as ApiClient
+    );
+    if (useApiKeySigner) {
+        // biome-ignore lint/suspicious/noExplicitAny: api-key config is valid on every chain
+        await wallet.useSigner({ type: "api-key" } as any);
+    }
+    return wallet;
+}
+
+function pendingTransactionResponse(id: string, chainType: string) {
+    return {
+        id,
+        status: "pending",
+        chainType,
+        walletType: "smart" as const,
+        createdAt: Date.now(),
+        // biome-ignore lint/suspicious/noExplicitAny: partial API response shape
+    } as any;
+}
+
+function successTransactionResponse(id: string, chainType: string, txId: string) {
+    return {
+        id,
+        status: "success",
+        chainType,
+        walletType: "smart" as const,
+        onChain: { txId, explorerLink: `https://explorer.example.com/tx/${txId}` },
+        createdAt: Date.now(),
+        // biome-ignore lint/suspicious/noExplicitAny: partial API response shape
+    } as any;
+}
+
+describe("Wallet integration — from() chain-subclass rewrap state carryover", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    describe("from() rewrap state carryover", () => {
+        it("from() preserves wallet options so onTransactionStart callback fires during rewrapped sendTransaction", async () => {
+            vi.useFakeTimers();
+            const mockApiClient = createMockApiClient();
+            const onTransactionStart = vi.fn().mockResolvedValue(undefined);
+            const wallet = await createConfiguredWallet("base-sepolia", EVM_ADDRESS, mockApiClient, {
+                options: { callbacks: { onTransactionStart } },
+            });
+            const evmWallet = EVMWallet.from(wallet);
+
+            mockApiClient.createTransaction.mockResolvedValue(pendingTransactionResponse("txn-callbacks", "evm"));
+            mockApiClient.getTransaction.mockResolvedValue(
+                successTransactionResponse("txn-callbacks", "evm", "0xcallbackhash")
+            );
+
+            const sendPromise = evmWallet.sendTransaction({ transaction: "0xdeadbeef" });
+            await vi.runAllTimersAsync();
+            const result = await sendPromise;
+
+            expect(result.hash).toBe("0xcallbackhash");
+            expect(onTransactionStart).toHaveBeenCalledTimes(1);
+        });
+
+        it("from() preserves alias so rewrapped wallet API calls use me:<chain>:smart:alias:<alias> locator", async () => {
+            // EVM
+            const evmApi = createMockApiClient();
+            const evmBase = await createConfiguredWallet("base-sepolia", EVM_ADDRESS, evmApi, { alias: "my-alias" });
+            const evmWallet = EVMWallet.from(evmBase);
+            evmApi.createTransaction.mockResolvedValue(pendingTransactionResponse("txn-alias-evm", "evm"));
+            await evmWallet.sendTransaction({ transaction: "0xdeadbeef", options: { prepareOnly: true } });
+            expect(evmApi.createTransaction).toHaveBeenCalledWith("me:evm:smart:alias:my-alias", expect.anything());
+
+            // Solana
+            const solApi = createMockApiClient();
+            const solBase = await createConfiguredWallet("solana", SOLANA_ADDRESS, solApi, { alias: "my-alias" });
+            const solWallet = SolanaWallet.from(solBase);
+            solApi.createTransaction.mockResolvedValue(pendingTransactionResponse("txn-alias-sol", "solana"));
+            await solWallet.sendTransaction({
+                serializedTransaction: createMockSolanaSerializedTransaction(),
+                options: { prepareOnly: true },
+            });
+            expect(solApi.createTransaction).toHaveBeenCalledWith("me:solana:smart:alias:my-alias", expect.anything());
+
+            // Stellar
+            const xlmApi = createMockApiClient();
+            const xlmBase = await createConfiguredWallet("stellar", STELLAR_ADDRESS, xlmApi, { alias: "my-alias" });
+            const xlmWallet = StellarWallet.from(xlmBase);
+            xlmApi.createTransaction.mockResolvedValue(pendingTransactionResponse("txn-alias-xlm", "stellar"));
+            await xlmWallet.sendTransaction({
+                transaction: "AAAA-serialized-xdr",
+                contractId: STELLAR_CONTRACT_ID,
+                options: { prepareOnly: true },
+            });
+            expect(xlmApi.createTransaction).toHaveBeenCalledWith("me:stellar:smart:alias:my-alias", expect.anything());
+        });
+
+        it("from() carries over the active signer so sendTransaction works without re-calling useSigner", async () => {
+            // EVM — no useSigner call after from()
+            const evmApi = createMockApiClient();
+            const evmWallet = EVMWallet.from(await createMockWallet("base-sepolia", evmApi, "api-key"));
+            evmApi.createTransaction.mockResolvedValue(pendingTransactionResponse("txn-carry-evm", "evm"));
+            const evmResult = await evmWallet.sendTransaction({
+                to: "0x00000000000000000000000000000000000000aa",
+                options: { prepareOnly: true },
+            });
+            expect(evmResult.transactionId).toBe("txn-carry-evm");
+            expect(evmApi.createTransaction).toHaveBeenCalledWith("me:evm:smart", {
+                params: {
+                    signer: "api-key",
+                    chain: "base-sepolia",
+                    calls: [{ to: "0x00000000000000000000000000000000000000aa", value: "0", data: "0x" }],
+                },
+            });
+
+            // Solana — no useSigner call after from()
+            const solApi = createMockApiClient();
+            const solWallet = SolanaWallet.from(await createMockWallet("solana", solApi, "api-key"));
+            solApi.createTransaction.mockResolvedValue(pendingTransactionResponse("txn-carry-sol", "solana"));
+            const serializedTx = createMockSolanaSerializedTransaction();
+            const solResult = await solWallet.sendTransaction({
+                serializedTransaction: serializedTx,
+                options: { prepareOnly: true },
+            });
+            expect(solResult.transactionId).toBe("txn-carry-sol");
+            expect(solApi.createTransaction).toHaveBeenCalledWith("me:solana:smart", {
+                params: { transaction: serializedTx, signer: "api-key" },
+            });
+
+            // Stellar — no useSigner call after from()
+            const xlmApi = createMockApiClient();
+            const xlmWallet = StellarWallet.from(await createMockWallet("stellar", xlmApi, "api-key"));
+            xlmApi.createTransaction.mockResolvedValue(pendingTransactionResponse("txn-carry-xlm", "stellar"));
+            const xlmResult = await xlmWallet.sendTransaction({
+                transaction: "AAAA-serialized-xdr",
+                contractId: STELLAR_CONTRACT_ID,
+                options: { prepareOnly: true },
+            });
+            expect(xlmResult.transactionId).toBe("txn-carry-xlm");
+            expect(xlmApi.createTransaction).toHaveBeenCalledWith("me:stellar:smart", {
+                params: {
+                    transaction: {
+                        type: "serialized-transaction",
+                        serializedTransaction: "AAAA-serialized-xdr",
+                        contractId: STELLAR_CONTRACT_ID,
+                    },
+                    signer: "api-key",
+                },
+            });
+        });
+
+        it("from() preserves initial signers so multi-signer requireSigner error survives rewrap", async () => {
+            const mockApiClient = createMockApiClient();
+            const wallet = await createConfiguredWallet(
+                "base-sepolia",
+                EVM_ADDRESS,
+                mockApiClient,
+                {
+                    signers: [
+                        { type: "external-wallet", address: "0x00000000000000000000000000000000000000a1" },
+                        { type: "external-wallet", address: "0x00000000000000000000000000000000000000a2" },
+                    ],
+                },
+                { useApiKeySigner: false }
+            );
+            const evmWallet = EVMWallet.from(wallet);
+
+            await expect(evmWallet.signMessage({ message: "hello" })).rejects.toThrow(
+                /This wallet has multiple signers configured/
+            );
+            // Thrown before any API call is made
+            expect(mockApiClient.createSignature).not.toHaveBeenCalled();
+        });
+
+        it("from() preserves recovery config so server-wallet requireSigner guidance error survives rewrap", async () => {
+            const mockApiClient = createMockApiClient();
+            const wallet = await createConfiguredWallet(
+                "base-sepolia",
+                EVM_ADDRESS,
+                mockApiClient,
+                { recovery: { type: "server", address: "0x00000000000000000000000000000000000000f1" } },
+                { useApiKeySigner: false }
+            );
+            const evmWallet = EVMWallet.from(wallet);
+
+            await expect(evmWallet.signMessage({ message: "hello" })).rejects.toThrow(/server secret/);
+            expect(mockApiClient.createSignature).not.toHaveBeenCalled();
+        });
+
+        it("from() preserves API server-signer addresses so legacy server signer derivation resolves identically after rewrap", async () => {
+            const SECRET = "a".repeat(64);
+            const PROJECT_ID = "test-project";
+            const env = createMockApiClient().environment;
+            const { primary, legacy } = deriveServerSignerCandidates(
+                { type: "server", secret: SECRET },
+                "base-sepolia",
+                PROJECT_ID,
+                env
+            );
+            expect(legacy).not.toBeNull();
+            const legacyAddress = legacy!.derivedAddress;
+            const primaryAddress = primary.derivedAddress;
+            expect(legacyAddress).not.toBe(primaryAddress);
+
+            // Path 1: legacy derivation matches the API-sourced recovery server signer address.
+            const apiA = createMockApiClient();
+            // biome-ignore lint/suspicious/noExplicitAny: projectId lives on the real ApiClient
+            (apiA as any).projectId = PROJECT_ID;
+            const walletA = await createConfiguredWallet(
+                "base-sepolia",
+                EVM_ADDRESS,
+                apiA,
+                { recovery: { type: "server", address: legacyAddress } },
+                { useApiKeySigner: false }
+            );
+            vi.spyOn(walletA, "signers").mockResolvedValue([
+                // biome-ignore lint/suspicious/noExplicitAny: partial signer shape
+                { type: "api-key", locator: "api-key", status: "success" } as any,
+            ]);
+            // biome-ignore lint/suspicious/noExplicitAny: api-key config is valid on every chain
+            await walletA.useSigner({ type: "api-key" } as any);
+            const evmA = EVMWallet.from(walletA);
+            apiA.createTransaction.mockResolvedValue(pendingTransactionResponse("txn-server-a", "evm"));
+            await evmA.sendTransaction({
+                transaction: "0xdeadbeef",
+                options: { prepareOnly: true, signer: { type: "server", secret: SECRET } },
+            });
+            expect(apiA.createTransaction).toHaveBeenCalledWith(
+                "me:evm:smart",
+                expect.objectContaining({
+                    params: expect.objectContaining({ signer: `server:${legacyAddress}` }),
+                })
+            );
+
+            // Path 2: legacy derivation matches a delegated server signer address.
+            const apiB = createMockApiClient();
+            // biome-ignore lint/suspicious/noExplicitAny: projectId lives on the real ApiClient
+            (apiB as any).projectId = PROJECT_ID;
+            const walletB = await createConfiguredWallet("base-sepolia", EVM_ADDRESS, apiB, {
+                apiDelegatedServerSignerAddresses: [legacyAddress],
+            });
+            const evmB = EVMWallet.from(walletB);
+            apiB.createTransaction.mockResolvedValue(pendingTransactionResponse("txn-server-b", "evm"));
+            await evmB.sendTransaction({
+                transaction: "0xdeadbeef",
+                options: { prepareOnly: true, signer: { type: "server", secret: SECRET } },
+            });
+            expect(apiB.createTransaction).toHaveBeenCalledWith(
+                "me:evm:smart",
+                expect.objectContaining({
+                    params: expect.objectContaining({ signer: `server:${legacyAddress}` }),
+                })
+            );
+        });
+
+        it("from() preserves address and owner on the rewrapped wallet", async () => {
+            const owner = "email:owner@example.com";
+
+            const evmApi = createMockApiClient();
+            const evmWallet = EVMWallet.from(
+                await createConfiguredWallet("base-sepolia", EVM_ADDRESS, evmApi, { owner })
+            );
+            expect(evmWallet.address).toBe(EVM_ADDRESS);
+            expect(evmWallet.owner).toBe(owner);
+
+            const solApi = createMockApiClient();
+            const solWallet = SolanaWallet.from(
+                await createConfiguredWallet("solana", SOLANA_ADDRESS, solApi, { owner })
+            );
+            expect(solWallet.address).toBe(SOLANA_ADDRESS);
+            expect(solWallet.owner).toBe(owner);
+
+            const xlmApi = createMockApiClient();
+            const xlmWallet = StellarWallet.from(
+                await createConfiguredWallet("stellar", STELLAR_ADDRESS, xlmApi, { owner })
+            );
+            expect(xlmWallet.address).toBe(STELLAR_ADDRESS);
+            expect(xlmWallet.owner).toBe(owner);
+        });
+
+        it("from() rewrap does not re-trigger device signer initialization when a signer is already set", async () => {
+            const mockApiClient = createMockApiClient();
+            const storage = {
+                getKey: vi.fn().mockResolvedValue(null),
+                hasKey: vi.fn().mockResolvedValue(false),
+                mapAddressToKey: vi.fn(),
+                deleteKey: vi.fn(),
+            };
+
+            // Donor wallet provides an already-assembled SignerAdapter (api-key admin path, no API calls).
+            const donor = await createMockWallet("base-sepolia", mockApiClient, "api-key");
+            const wallet = await createConfiguredWallet(
+                "base-sepolia",
+                EVM_ADDRESS,
+                mockApiClient,
+                {
+                    // biome-ignore lint/suspicious/noExplicitAny: minimal DeviceSignerKeyStorage stub
+                    options: { deviceSignerKeyStorage: storage as any },
+                    signer: donor.signer,
+                },
+                { useApiKeySigner: false }
+            );
+            await wallet.waitForInit();
+            storage.getKey.mockClear();
+            storage.hasKey.mockClear();
+            mockApiClient.registerSigner.mockClear();
+            mockApiClient.getSigner.mockClear();
+
+            const evmWallet = EVMWallet.from(wallet);
+            await evmWallet.waitForInit();
+
+            // Carried-over signer short-circuits initDefaultSigner: no storage access, no registration.
+            expect(evmWallet.signer).toBe(wallet.signer);
+            expect(storage.getKey).not.toHaveBeenCalled();
+            expect(storage.hasKey).not.toHaveBeenCalled();
+            expect(mockApiClient.registerSigner).not.toHaveBeenCalled();
+            expect(mockApiClient.getSigner).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/wallets/src/tests/e2e/wallet.initialization.test.ts
+++ b/packages/wallets/src/tests/e2e/wallet.initialization.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Wallet } from "../../wallets/wallet";
+import type { ApiClient } from "../../api";
+import { walletsLogger } from "../../logger";
+import { createMockApiClient, type MockedApiClient } from "../../wallets/__tests__/test-helpers";
+
+const EVM_ADDRESS = "0x1234567890123456789012345678901234567890";
+
+describe("Wallet integration — initDefaultSigner auto-assembly ladder", () => {
+    let mockApiClient: MockedApiClient;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockApiClient = createMockApiClient();
+    });
+
+    it("auto-assembles the recovery signer as admin (status active, no getSigner) when there are zero delegated signers", async () => {
+        const wallet = new Wallet(
+            { chain: "base-sepolia", address: EVM_ADDRESS, recovery: { type: "api-key" } as any },
+            mockApiClient as unknown as ApiClient
+        );
+
+        await wallet.waitForInit();
+
+        expect(wallet.signer?.type).toBe("api-key");
+        expect(wallet.signer?.locator()).toBe("api-key");
+        // Admin signers get status "active" hardcoded — the getSigner API call is skipped
+        expect(wallet.signer?.status).toBe("active");
+        expect(mockApiClient.getSigner).not.toHaveBeenCalled();
+    });
+
+    it("auto-assembles the single delegated signer with status fetched via getSigner", async () => {
+        mockApiClient.getSigner.mockResolvedValue({
+            type: "email",
+            email: "user@example.com",
+            address: "0xSignerAddress00000000000000000000000000",
+            locator: "email:user@example.com",
+            chains: { "base-sepolia": { status: "success" } },
+        } as any);
+
+        const wallet = new Wallet(
+            {
+                chain: "base-sepolia",
+                address: EVM_ADDRESS,
+                recovery: { type: "api-key" } as any,
+                signers: [{ type: "email", email: "user@example.com" }] as any,
+            },
+            mockApiClient as unknown as ApiClient
+        );
+
+        await wallet.waitForInit();
+
+        expect(wallet.signer?.type).toBe("email");
+        // Delegated (non-admin) signer: status comes from the API, not hardcoded "active"
+        expect(wallet.signer?.status).toBe("success");
+        expect(mockApiClient.getSigner).toHaveBeenCalledWith("me:evm:smart", "email:user@example.com");
+    });
+
+    it("leaves the signer undefined when the wallet has more than one delegated signer", async () => {
+        const wallet = new Wallet(
+            {
+                chain: "base-sepolia",
+                address: EVM_ADDRESS,
+                recovery: { type: "api-key" } as any,
+                signers: [
+                    { type: "email", email: "a@example.com" },
+                    { type: "phone", phone: "+15551234567" },
+                ] as any,
+            },
+            mockApiClient as unknown as ApiClient
+        );
+
+        await wallet.waitForInit();
+
+        // User must call useSigner(); no auto-assembly (and no recovery fallback) happens
+        expect(wallet.signer).toBeUndefined();
+        expect(mockApiClient.getSigner).not.toHaveBeenCalled();
+    });
+
+    it("leaves the signer undefined and resolves waitForInit (no throw) when ladder auto-assembly fails", async () => {
+        // A malformed success response makes assembly throw; initDefaultSigner must swallow it —
+        // a rejection here would poison every later preAuthIfNeeded().
+        mockApiClient.getSigner.mockResolvedValue({ type: "mystery-unknown-type" } as any);
+
+        const wallet = new Wallet(
+            {
+                chain: "base-sepolia",
+                address: EVM_ADDRESS,
+                recovery: { type: "api-key" } as any,
+                signers: [{ type: "email", email: "user@example.com" }] as any,
+            },
+            mockApiClient as unknown as ApiClient
+        );
+
+        await expect(wallet.waitForInit()).resolves.toBeUndefined();
+
+        expect(wallet.signer).toBeUndefined();
+        expect(walletsLogger.warn).toHaveBeenCalledWith(
+            "wallet.initDefaultSigner.autoAssemblyFailed",
+            expect.objectContaining({ recoveryType: "api-key", signerCount: 1, error: expect.any(Error) })
+        );
+    });
+});

--- a/packages/wallets/src/tests/e2e/wallet.recovery.test.ts
+++ b/packages/wallets/src/tests/e2e/wallet.recovery.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Wallet } from "../../wallets/wallet";
+import type { ApiClient } from "../../api";
+import { NonCustodialSigner } from "../../signers/non-custodial";
+import { createMockApiClient, type MockedApiClient } from "../../wallets/__tests__/test-helpers";
+
+vi.mock("@/utils/device-signers", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@/utils/device-signers")>();
+    return {
+        ...actual,
+        createDeviceSigner: vi.fn().mockResolvedValue({
+            type: "device",
+            publicKey: { x: "0x01", y: "0x02" },
+            locator: "device:mockNewKey",
+            name: "Test Device",
+        }),
+    };
+});
+
+const EVM_ADDRESS = "0x1234567890123456789012345678901234567890";
+
+const createMockDeviceKeyStorage = () => ({
+    generateKey: vi.fn().mockResolvedValue("mockPublicKeyBase64"),
+    getKey: vi.fn().mockResolvedValue(null),
+    hasKey: vi.fn().mockResolvedValue(false),
+    mapAddressToKey: vi.fn().mockResolvedValue(undefined),
+    deleteKey: vi.fn().mockResolvedValue(undefined),
+    signMessage: vi.fn().mockResolvedValue({ r: "0x1", s: "0x2" }),
+    getDeviceName: vi.fn().mockReturnValue("Test Device"),
+    apiKey: "test-api-key",
+});
+
+describe("Wallet integration — preAuthIfNeeded (pre-operation recover + auth)", () => {
+    let mockApiClient: MockedApiClient;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockApiClient = createMockApiClient();
+    });
+
+    it("shares a single recover() invocation across concurrent operations, then re-enters on a later operation", async () => {
+        const mockStorage = createMockDeviceKeyStorage();
+        const wallet = new Wallet(
+            {
+                chain: "base-sepolia",
+                address: EVM_ADDRESS,
+                recovery: { type: "api-key" } as any,
+                options: { deviceSignerKeyStorage: mockStorage as any },
+            },
+            mockApiClient as unknown as ApiClient
+        );
+        vi.spyOn(wallet, "signers").mockResolvedValue([] as any);
+        await wallet.waitForInit();
+        expect(wallet.needsRecovery()).toBe(true);
+
+        const recoverSpy = vi.spyOn(wallet, "recover");
+
+        // addSigner's upfront getSignerState check — signer not yet registered
+        mockApiClient.getSigner.mockResolvedValueOnce({ error: { message: "not found" } } as any);
+        // assembleFullSigner after registration — signer approved
+        mockApiClient.getSigner.mockResolvedValue({
+            type: "device",
+            locator: "device:mockNewKey",
+            publicKey: { x: "1", y: "2" },
+            chains: { "base-sepolia": { status: "success" } },
+        } as any);
+        mockApiClient.registerSigner.mockResolvedValue({
+            type: "device",
+            locator: "device:mockNewKey",
+            publicKey: { x: "0x01", y: "0x02" },
+            chains: { "base-sepolia": { status: "success" } },
+        } as any);
+        mockApiClient.send.mockResolvedValue({ id: "tx-prep-1" } as any);
+
+        const [tx1, tx2] = await Promise.all([
+            wallet.send(EVM_ADDRESS, "usdc", "1.0", { prepareOnly: true }),
+            wallet.send(EVM_ADDRESS, "usdc", "1.0", { prepareOnly: true }),
+        ]);
+
+        // Exactly ONE recover() (and one device-key registration) for both concurrent operations
+        expect(recoverSpy).toHaveBeenCalledTimes(1);
+        expect(mockApiClient.registerSigner).toHaveBeenCalledTimes(1);
+        expect(tx1.transactionId).toBe("tx-prep-1");
+        expect(tx2.transactionId).toBe("tx-prep-1");
+        expect(wallet.signer?.type).toBe("device");
+
+        // #recovering is reset in finally — a later operation re-enters recover(), but the cached
+        // approval fast-path prevents a second registration
+        await wallet.send(EVM_ADDRESS, "usdc", "1.0", { prepareOnly: true });
+        expect(recoverSpy).toHaveBeenCalledTimes(2);
+        expect(mockApiClient.registerSigner).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls ensureAuthenticated on a NonCustodialSigner before the operation", async () => {
+        const ensureAuthSpy = vi
+            .spyOn(NonCustodialSigner.prototype, "ensureAuthenticated")
+            .mockResolvedValue(undefined);
+        try {
+            // Email recovery + zero delegated signers → ladder assembles an EVMNonCustodialSigner as admin.
+            const wallet = new Wallet(
+                {
+                    chain: "base-sepolia",
+                    address: EVM_ADDRESS,
+                    recovery: { type: "email", email: "rec@example.com" } as any,
+                },
+                mockApiClient as unknown as ApiClient
+            );
+            await wallet.waitForInit();
+            expect(wallet.signer).toBeInstanceOf(NonCustodialSigner);
+
+            mockApiClient.send.mockResolvedValue({ id: "tx-prep-ncs" } as any);
+
+            await wallet.send(EVM_ADDRESS, "usdc", "1.0", { prepareOnly: true });
+
+            expect(ensureAuthSpy).toHaveBeenCalledTimes(1);
+            expect(ensureAuthSpy.mock.invocationCallOrder[0]).toBeLessThan(
+                mockApiClient.send.mock.invocationCallOrder[0]
+            );
+        } finally {
+            ensureAuthSpy.mockRestore();
+        }
+    });
+});

--- a/packages/wallets/src/tests/e2e/wallet.transactions.test.ts
+++ b/packages/wallets/src/tests/e2e/wallet.transactions.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Wallet } from "../../wallets/wallet";
+import type { ApiClient } from "../../api";
+import type { SignerAdapter, SignerConfigForChain } from "../../signers/types";
+import { createMockApiClient, createMockWallet, type MockedApiClient } from "../../wallets/__tests__/test-helpers";
+
+const EVM_EXTERNAL_SIGNER_LOCATOR = "external-wallet:0x123";
+const STELLAR_EXTERNAL_SIGNER_LOCATOR = "external-wallet:GABC123";
+
+function makeFakeSigner(type: string, locator: string, signature: string) {
+    return {
+        type,
+        locator: () => locator,
+        signMessage: vi.fn().mockResolvedValue({ signature }),
+        signTransaction: vi.fn().mockResolvedValue({ signature }),
+    };
+}
+const asAdapter = (fake: ReturnType<typeof makeFakeSigner>): SignerAdapter => fake as unknown as SignerAdapter;
+
+const evmPendingTx = (id: string, pending: Array<{ message: string; signer: { locator: string } }>) => ({
+    id,
+    status: "awaiting-approval",
+    chainType: "evm",
+    walletType: "smart",
+    onChain: {},
+    approvals: { pending, submitted: [] },
+});
+const successTx = (id: string) => ({
+    id,
+    status: "success",
+    onChain: { txId: "0xabcdef", explorerLink: "https://explorer.test/tx/0xabcdef" },
+});
+
+describe("Wallet integration — transaction approval orchestration", () => {
+    let mockApiClient: MockedApiClient;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.useFakeTimers();
+        mockApiClient = createMockApiClient();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    describe("approval payload selection (keyed off the API response shape)", () => {
+        it("solana: signs the serialized onChain.transaction for ed25519 signers but pendingApproval.message for device signers", async () => {
+            const solanaWallet = await createMockWallet("solana", mockApiClient, "external-wallet");
+            const ed25519Signer = makeFakeSigner("external-wallet", "external-wallet:EdSignerLocator", "ed-sig");
+            const deviceSigner = makeFakeSigner("device", "device:DeviceSignerLocator", "device-sig");
+
+            mockApiClient.getTransaction
+                .mockResolvedValueOnce({
+                    id: "sol-txn",
+                    status: "awaiting-approval",
+                    chainType: "solana",
+                    walletType: "smart",
+                    onChain: { transaction: "SERIALIZED_SOLANA_TX" },
+                    approvals: {
+                        pending: [
+                            { message: "msg-for-ed25519", signer: { locator: "external-wallet:EdSignerLocator" } },
+                            { message: "msg-for-device", signer: { locator: "device:DeviceSignerLocator" } },
+                        ],
+                        submitted: [],
+                    },
+                } as any)
+                .mockResolvedValue({
+                    id: "sol-txn",
+                    status: "success",
+                    onChain: { txId: "sol-tx-hash", explorerLink: "https://explorer.solana.com/tx/sol-tx-hash" },
+                } as any);
+            mockApiClient.approveTransaction.mockResolvedValue({ id: "sol-txn", status: "pending" } as any);
+
+            const approvePromise = solanaWallet.approve({
+                transactionId: "sol-txn",
+                options: { additionalSigners: [asAdapter(ed25519Signer), asAdapter(deviceSigner)] },
+            });
+            await vi.runAllTimersAsync();
+            await approvePromise;
+
+            // ed25519 (non-device) signer receives the full serialized transaction
+            expect(ed25519Signer.signTransaction).toHaveBeenCalledWith("SERIALIZED_SOLANA_TX");
+            // device signer receives the pendingApproval.message (keccak256 hash for the SWIG precompile)
+            expect(deviceSigner.signTransaction).toHaveBeenCalledWith("msg-for-device");
+            expect(mockApiClient.approveTransaction).toHaveBeenCalledWith("me:solana:smart", "sol-txn", {
+                approvals: [
+                    { signature: "ed-sig", signer: "external-wallet:EdSignerLocator" },
+                    { signature: "device-sig", signer: "device:DeviceSignerLocator" },
+                ],
+            });
+        });
+
+        it("stellar wallet signs onChain.transaction when the response claims chainType 'solana' with onChain.transaction", async () => {
+            const stellarWallet = await createMockWallet("stellar", mockApiClient, "external-wallet");
+            // biome-ignore lint/style/noNonNullAssertion: signer is set by createMockWallet
+            const signSpy = vi.spyOn(stellarWallet.signer!, "signTransaction");
+
+            mockApiClient.getTransaction
+                .mockResolvedValueOnce({
+                    id: "stellar-txn",
+                    status: "awaiting-approval",
+                    chainType: "solana",
+                    walletType: "smart",
+                    onChain: { transaction: "SERIALIZED_STELLAR_AS_SOLANA_TX" },
+                    approvals: {
+                        pending: [
+                            {
+                                message: "pending-message-not-to-be-signed",
+                                signer: { locator: STELLAR_EXTERNAL_SIGNER_LOCATOR },
+                            },
+                        ],
+                        submitted: [],
+                    },
+                } as any)
+                .mockResolvedValue({
+                    id: "stellar-txn",
+                    status: "success",
+                    chainType: "stellar",
+                    onChain: {
+                        txEnvelope: "envelope-xdr",
+                        txHash: "stellar-hash",
+                        explorerLink: "https://stellar.explorer/stellar-txn",
+                    },
+                } as any);
+            mockApiClient.approveTransaction.mockResolvedValue({ id: "stellar-txn", status: "pending" } as any);
+
+            const approvePromise = stellarWallet.approve({ transactionId: "stellar-txn" });
+            await vi.runAllTimersAsync();
+            const result = await approvePromise;
+
+            expect(signSpy).toHaveBeenCalledWith("SERIALIZED_STELLAR_AS_SOLANA_TX");
+            expect(signSpy).not.toHaveBeenCalledWith("pending-message-not-to-be-signed");
+            // stellar terminal success resolves the hash from onChain.txHash (txId is absent)
+            expect(result.hash).toBe("stellar-hash");
+        });
+
+        it("evm wallet signs onChain.transaction when the response claims chainType 'solana' with onChain.transaction", async () => {
+            const evmWallet = await createMockWallet("base-sepolia", mockApiClient, "external-wallet");
+            // biome-ignore lint/style/noNonNullAssertion: signer is set by createMockWallet
+            const signSpy = vi.spyOn(evmWallet.signer!, "signTransaction");
+
+            mockApiClient.getTransaction
+                .mockResolvedValueOnce({
+                    id: "evm-txn",
+                    status: "awaiting-approval",
+                    chainType: "solana",
+                    walletType: "smart",
+                    onChain: { transaction: "SOLANA_SHAPED_TX_ON_EVM_WALLET" },
+                    approvals: {
+                        pending: [
+                            { message: "0xevm-pending-message", signer: { locator: EVM_EXTERNAL_SIGNER_LOCATOR } },
+                        ],
+                        submitted: [],
+                    },
+                } as any)
+                .mockResolvedValue({
+                    id: "evm-txn",
+                    status: "success",
+                    onChain: { txId: "0xevmhash", explorerLink: "https://explorer.test/tx/0xevmhash" },
+                } as any);
+            mockApiClient.approveTransaction.mockResolvedValue({ id: "evm-txn", status: "pending" } as any);
+
+            const approvePromise = evmWallet.approve({ transactionId: "evm-txn" });
+            await vi.runAllTimersAsync();
+            await approvePromise;
+
+            expect(signSpy).toHaveBeenCalledWith("SOLANA_SHAPED_TX_ON_EVM_WALLET");
+            expect(signSpy).not.toHaveBeenCalledWith("0xevm-pending-message");
+        });
+    });
+
+    describe("onTransactionStart callback", () => {
+        it("invokes callbacks.onTransactionStart after fetching the transaction and before signing", async () => {
+            const callOrder: string[] = [];
+            const onTransactionStart = vi.fn(async () => {
+                callOrder.push("onTransactionStart");
+            });
+            const onSign = vi.fn(async (_message: string) => {
+                callOrder.push("sign");
+                return "0xsigned";
+            });
+
+            const wallet = new Wallet(
+                {
+                    chain: "base-sepolia" as const,
+                    address: "0x1234567890123456789012345678901234567890",
+                    recovery: { type: "api-key" } as SignerConfigForChain<"base-sepolia">,
+                    options: { callbacks: { onTransactionStart } },
+                },
+                mockApiClient as unknown as ApiClient
+            );
+            vi.spyOn(wallet, "signers").mockResolvedValue([
+                {
+                    type: "external-wallet",
+                    address: "0x123",
+                    locator: EVM_EXTERNAL_SIGNER_LOCATOR,
+                    status: "success",
+                } as any,
+            ]);
+            await wallet.useSigner({
+                type: "external-wallet",
+                address: "0x123",
+                onSign,
+            } as unknown as SignerConfigForChain<"base-sepolia">);
+
+            let fetchCount = 0;
+            mockApiClient.getTransaction.mockImplementation(async () => {
+                fetchCount++;
+                if (fetchCount === 1) {
+                    callOrder.push("getTransaction");
+                    return evmPendingTx("txn-cb", [
+                        { message: "0xcbmsg", signer: { locator: EVM_EXTERNAL_SIGNER_LOCATOR } },
+                    ]) as any;
+                }
+                return successTx("txn-cb") as any;
+            });
+            mockApiClient.approveTransaction.mockResolvedValue({ id: "txn-cb", status: "pending" } as any);
+
+            const approvePromise = wallet.approve({ transactionId: "txn-cb" });
+            await vi.runAllTimersAsync();
+            await approvePromise;
+
+            expect(callOrder).toEqual(["getTransaction", "onTransactionStart", "sign"]);
+        });
+    });
+});


### PR DESCRIPTION
A small, organized **Wallet-orchestration integration suite** at `packages/wallets/src/tests/e2e/` — **18 tests in 4 by-concern files**, covering behavior that emerges from the `Wallet` wiring services together (mocked `ApiClient`) and that the colocated unit tests can't reach:

| File | Tests | Concern |
|---|---|---|
| `wallet.initialization.test.ts` | 4 | `initDefaultSigner` auto-assembly ladder (0 / 1 / >1 delegated, fail-swallow) |
| `wallet.recovery.test.ts` | 2 | `preAuthIfNeeded` single-flight recover + `ensureAuthenticated` ordering |
| `wallet.transactions.test.ts` | 4 | approval payload selection (by API response shape) + `onTransactionStart` ordering |
| `wallet.factory-rewrap.test.ts` | 8 | `from()` chain-subclass state carryover |

## How this was scoped
Distilled from the refactor's local characterization suite (was never committed). Each candidate was checked against existing coverage and **dropped if redundant**:
- All server-signer wipe/derivation behavior → already in `resolver.test.ts` (unit).
- `recover()` fallback / mapAddressToKey / AuthRejected / resume → already in `wallet.test.ts`.
- `useSigner` per-type, `addSigner`/`removeSigner`, payload shapes → `wallet.test.ts` / `descriptors.test.ts` / `chain-adapter.test.ts`.
- Stale pins (pre-fix behavior the reliability PRs reversed) → dropped outright.

Result: only genuinely-unique, current-behavior orchestration remains — no duplicate coverage, no resolver internals re-tested through a full `Wallet`.

## Verification
18/18 green; `tsc` clean; `biome` error-gate exits 0. Test-only (no `src/` logic touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)