### PR TITLE
Re-onboard the React Native signer per signature with ephemeral webview storage (iOS)

### DIFF
--- a/.changeset/rn-ios-ephemeral-signer-frame.md
+++ b/.changeset/rn-ios-ephemeral-signer-frame.md
@@ -1,0 +1,9 @@
+---
+"@crossmint/wallets-sdk": patch
+"@crossmint/client-sdk-react-base": patch
+"@crossmint/client-sdk-react-native-ui": patch
+---
+
+On iOS, the React Native non-custodial signer stops relying on the signer webview's storage, which isn't reliable across launches and could drop the device identity and break signing. The signer frame now uses non-persistent storage with in-memory device storage, and reloads to re-onboard with a fresh OTP before each signature.
+
+Android keeps its existing persistent behavior.

--- a/.changeset/signer-otp-reissue-on-frame-reload.md
+++ b/.changeset/signer-otp-reissue-on-frame-reload.md
@@ -1,0 +1,7 @@
+---
+"@crossmint/client-sdk-window": patch
+"@crossmint/wallets-sdk": patch
+"@crossmint/client-sdk-react-base": patch
+---
+
+Recover the non-custodial signer OTP flow when the signer frame reloads between sending and verifying the code. This happens with the ephemeral iOS frame if the web content process is terminated mid-onboarding, which would otherwise lose the in-memory device and dead-end with an OTP error. The signer now detects the reload, requests a fresh code, and keeps the prompt open so the user can enter the new one.

--- a/packages/client/react-base/src/hooks/useSignerAuth.ts
+++ b/packages/client/react-base/src/hooks/useSignerAuth.ts
@@ -1,5 +1,5 @@
 import { useState, useRef, useCallback, type MutableRefObject } from "react";
-import type { Callbacks } from "@crossmint/wallets-sdk";
+import { OnboardingSessionExpiredError, type Callbacks } from "@crossmint/wallets-sdk";
 
 const throwNotAvailable = (functionName: string) => () => {
     throw new Error(`${functionName} is not available. Make sure you're using an email or phone signer wallet.`);
@@ -74,6 +74,12 @@ export function useSignerAuth(): SignerAuthState & SignerAuthHandlers {
             setEmailSignerDialogStep("initial");
             setActiveAuthEmail(undefined);
         } catch (error) {
+            if (error instanceof OnboardingSessionExpiredError) {
+                // The signer frame was reloaded mid-onboarding and a fresh code was already sent.
+                // Keep the dialog open so the user can enter the new code.
+                console.warn("Signer session expired, a new code was sent");
+                return;
+            }
             console.error("Failed to verify OTP", error);
             rejectRef.current(new Error("Failed to verify OTP"));
         }
@@ -106,6 +112,12 @@ export function useSignerAuth(): SignerAuthState & SignerAuthHandlers {
             setPhoneSignerDialogStep("initial");
             setActiveAuthPhone(undefined);
         } catch (error) {
+            if (error instanceof OnboardingSessionExpiredError) {
+                // The signer frame was reloaded mid-onboarding and a fresh code was already sent.
+                // Keep the dialog open so the user can enter the new code.
+                console.warn("Signer session expired, a new code was sent");
+                return;
+            }
             console.error("Failed to verify phone OTP", error);
             rejectRef.current(new Error("Failed to verify phone OTP"));
         }

--- a/packages/client/react-base/src/providers/CrossmintWalletBaseProvider.tsx
+++ b/packages/client/react-base/src/providers/CrossmintWalletBaseProvider.tsx
@@ -94,6 +94,8 @@ export interface CrossmintWalletBaseProviderProps {
     children: ReactNode;
     /** @internal */
     clientTEEConnection?: () => HandshakeParent<typeof signerOutboundEvents, typeof signerInboundEvents>;
+    /** @internal Resets and reloads the signer frame before each signature. Provided by the React Native iOS provider. */
+    resetSignerFrame?: () => Promise<void>;
     /** @internal */
     initializeWebView?: () => Promise<void>;
     /** @internal */
@@ -119,6 +121,7 @@ export function CrossmintWalletBaseProvider({
     createOnLogin,
     callbacks,
     clientTEEConnection,
+    resetSignerFrame,
     deviceSignerKeyStorage,
     initializeWebView,
     appearance,
@@ -211,6 +214,7 @@ export function CrossmintWalletBaseProvider({
         (argsOptions?: WalletOptions): WalletOptions => {
             return {
                 clientTEEConnection: clientTEEConnection?.(),
+                resetSignerFrame,
                 callbacks: {
                     onWalletCreationStart:
                         argsOptions?.callbacks?.onWalletCreationStart ?? updateCallbacks?.onWalletCreationStart,
@@ -221,7 +225,7 @@ export function CrossmintWalletBaseProvider({
                 deviceSignerKeyStorage,
             };
         },
-        [clientTEEConnection, updateCallbacks, deviceSignerKeyStorage, wrappedOnAuthRequired]
+        [clientTEEConnection, resetSignerFrame, updateCallbacks, deviceSignerKeyStorage, wrappedOnAuthRequired]
     );
 
     const getOrCreateWallet = useCallback(

--- a/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
@@ -50,6 +50,12 @@ export interface CrossmintWalletProviderProps {
 
 const MAX_HANDSHAKE_RETRIES = 2;
 
+// iOS only: the signer webview's storage isn't reliable across launches, so we don't rely on it.
+// This query tells the signer frame to keep the device key in memory, and we reload the frame
+// before each signature so it re-onboards with a fresh OTP every time. Android is left untouched.
+const EPHEMERAL_DEVICE_STORAGE_QUERY = "deviceStorage=memory";
+const USES_EPHEMERAL_DEVICE_STORAGE = Platform.OS === "ios";
+
 const PASSKEY_RN_ERROR =
     "Passkey signers are not supported in React Native. Use a different signer type such as 'device', or 'external-wallet'.";
 
@@ -126,7 +132,11 @@ function CrossmintWalletProviderInternal({
     }, [apiKey]);
 
     const frameUrl = useMemo(() => {
-        return environmentUrlConfig[parsedAPIKey.environment];
+        const baseUrl = environmentUrlConfig[parsedAPIKey.environment];
+        if (USES_EPHEMERAL_DEVICE_STORAGE) {
+            return `${baseUrl}?${EPHEMERAL_DEVICE_STORAGE_QUERY}`;
+        }
+        return baseUrl;
     }, [parsedAPIKey.environment]);
 
     const webviewRef = useRef<WebView>(null);
@@ -282,6 +292,49 @@ function CrossmintWalletProviderInternal({
         await performHandshake("onLoadEnd");
     }, [logger, performHandshake]);
 
+    // Reload the signer frame and wait for a fresh handshake. The wallets SDK calls this before
+    // each non-custodial signature (via the resetSignerFrame option) so the signer re-onboards
+    // with a new OTP every time, instead of relying on webview storage that iOS can drop across
+    // launches. Only wired up on iOS; Android keeps its persistent frame.
+    const resetSignerFrame = useCallback(async () => {
+        const parent = webViewParentRef.current;
+        if (webviewRef.current == null || parent == null) {
+            logger.warn("react-native.wallet.webview.reset.skip", { reason: "webview not ready" });
+            return;
+        }
+
+        logger.info("react-native.wallet.webview.reset.start", { generation: handshakeGenerationRef.current });
+
+        // Invalidate any in-flight handshake so stale attempts don't reconnect the old frame.
+        handshakeGenerationRef.current++;
+        handshakeTriggeredRef.current = false;
+        handshakeInProgressRef.current = false;
+        handshakeRetryCountRef.current = 0;
+        parent.isConnected = false;
+
+        webviewRef.current.reload();
+        // Start polling immediately; performHandshake waits for the reloaded child to come up.
+        performHandshake("eager");
+
+        // Block until the reloaded frame finishes its handshake, so the subsequent status check
+        // and OTP flow run against the fresh frame.
+        const startTime = Date.now();
+        const timeoutMs = 30_000;
+        while (!parent.isConnected && Date.now() - startTime < timeoutMs) {
+            await new Promise((resolve) => setTimeout(resolve, 50));
+        }
+
+        if (!parent.isConnected) {
+            logger.error("react-native.wallet.webview.reset.timeout", { durationMs: Date.now() - startTime });
+            throw new Error("Timed out reloading the signer frame");
+        }
+
+        logger.info("react-native.wallet.webview.reset.complete", {
+            durationMs: Date.now() - startTime,
+            generation: handshakeGenerationRef.current,
+        });
+    }, [logger, performHandshake]);
+
     const handleMessage = useCallback(
         (event: WebViewMessageEvent) => {
             const parent = webViewParentRef.current;
@@ -415,6 +468,7 @@ function CrossmintWalletProviderInternal({
             callbacks={callbacks}
             renderUI={renderNativeUI}
             clientTEEConnection={getClientTEEConnection}
+            resetSignerFrame={USES_EPHEMERAL_DEVICE_STORAGE ? resetSignerFrame : undefined}
             deviceSignerKeyStorage={deviceSignerKeyStorage}
         >
             <PasskeyGuard>{children}</PasskeyGuard>
@@ -486,7 +540,7 @@ function CrossmintWalletProviderInternal({
                         javaScriptCanOpenWindowsAutomatically={false}
                         thirdPartyCookiesEnabled={false}
                         sharedCookiesEnabled={false}
-                        incognito={false}
+                        incognito={USES_EPHEMERAL_DEVICE_STORAGE}
                         setSupportMultipleWindows={false}
                         originWhitelist={[environmentUrlConfig[parsedAPIKey.environment]]}
                         cacheEnabled={true}

--- a/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
@@ -51,10 +51,11 @@ export interface CrossmintWalletProviderProps {
 const MAX_HANDSHAKE_RETRIES = 2;
 
 // iOS only: the signer webview's storage isn't reliable across launches, so we don't rely on it.
-// This query tells the signer frame to keep the device key in memory, and we reload the frame
-// before each signature so it re-onboards with a fresh OTP every time. Android is left untouched.
-const EPHEMERAL_DEVICE_STORAGE_QUERY = "deviceStorage=memory";
+// We tell the signer frame to keep the device key in memory, use a non-persistent webview store,
+// and reload the frame before each signature so it re-onboards with a fresh OTP. Android is untouched.
 const USES_EPHEMERAL_DEVICE_STORAGE = Platform.OS === "ios";
+const DEVICE_STORAGE_QUERY_PARAM = "deviceStorage";
+const DEVICE_STORAGE_MEMORY = "memory";
 
 const PASSKEY_RN_ERROR =
     "Passkey signers are not supported in React Native. Use a different signer type such as 'device', or 'external-wallet'.";
@@ -134,7 +135,9 @@ function CrossmintWalletProviderInternal({
     const frameUrl = useMemo(() => {
         const baseUrl = environmentUrlConfig[parsedAPIKey.environment];
         if (USES_EPHEMERAL_DEVICE_STORAGE) {
-            return `${baseUrl}?${EPHEMERAL_DEVICE_STORAGE_QUERY}`;
+            const url = new URL(baseUrl);
+            url.searchParams.set(DEVICE_STORAGE_QUERY_PARAM, DEVICE_STORAGE_MEMORY);
+            return url.toString();
         }
         return baseUrl;
     }, [parsedAPIKey.environment]);
@@ -543,7 +546,7 @@ function CrossmintWalletProviderInternal({
                         incognito={USES_EPHEMERAL_DEVICE_STORAGE}
                         setSupportMultipleWindows={false}
                         originWhitelist={[environmentUrlConfig[parsedAPIKey.environment]]}
-                        cacheEnabled={true}
+                        cacheEnabled={!USES_EPHEMERAL_DEVICE_STORAGE}
                         cacheMode="LOAD_DEFAULT"
                     />
                 </View>

--- a/packages/client/window/src/handshake/Parent.ts
+++ b/packages/client/window/src/handshake/Parent.ts
@@ -18,6 +18,12 @@ export class HandshakeParent<IncomingEvents extends EventMap, OutgoingEvents ext
 > {
     handshakeOptions: Required<HandshakeOptions>;
     isConnected = false;
+    /**
+     * Increments every time a handshake completes, i.e. once on first connect and again after each
+     * reload/reconnect. Consumers can capture it before an operation and compare afterwards to detect
+     * that the child frame was reloaded mid-flight (and therefore lost any in-memory state).
+     */
+    connectionGeneration = 0;
     private _ongoingHandshakeWithChild?: Promise<void>;
 
     constructor(
@@ -81,6 +87,7 @@ export class HandshakeParent<IncomingEvents extends EventMap, OutgoingEvents ext
         });
 
         this.isConnected = true;
+        this.connectionGeneration++;
         console.info("[HandshakeParent] Handshake completed");
     }
 

--- a/packages/wallets/src/index.ts
+++ b/packages/wallets/src/index.ts
@@ -42,6 +42,7 @@ export {
     isExportableSignerAdapter,
     AuthRejectedError,
     KeyExportError,
+    OnboardingSessionExpiredError,
     OtpValidationError,
     SignerStatusError,
 } from "./signers/types";

--- a/packages/wallets/src/signers/non-custodial/ncs-signer.test.ts
+++ b/packages/wallets/src/signers/non-custodial/ncs-signer.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 
 import type { EmailInternalSignerConfig } from "../types";
+import { OnboardingSessionExpiredError, OtpValidationError } from "../types";
 import { EVMNonCustodialSigner } from "./ncs-evm-signer";
 
 function makeReadyConnection(onSendAction?: () => void) {
@@ -59,5 +60,110 @@ describe("NonCustodialSigner.ensureAuthenticated", () => {
 
         await expect(signer.ensureAuthenticated()).resolves.toBeUndefined();
         expect(clientTEEConnection.sendAction).toHaveBeenCalledTimes(1);
+    });
+});
+
+type CompleteOnboardingResult = { status: string; error?: string; code?: string; signerStatus?: string };
+
+function makeScriptedConnection(completeOnboarding: (callIndex: number) => CompleteOnboardingResult) {
+    let completeCalls = 0;
+    return {
+        // Mutable: the test advances this to simulate the frame reloading mid-onboarding.
+        connectionGeneration: 1,
+        sendAction: vi.fn(async (args: { event: string }) => {
+            switch (args.event) {
+                case "request:get-status":
+                    return { status: "success", signerStatus: "new-device" };
+                case "request:start-onboarding":
+                    return { status: "success", signerStatus: "new-device" };
+                case "request:complete-onboarding":
+                    return completeOnboarding(completeCalls++);
+                default:
+                    return { status: "success" };
+            }
+        }),
+    };
+}
+
+describe("NonCustodialSigner onboarding recovery", () => {
+    function setup(completeOnboarding: (callIndex: number) => CompleteOnboardingResult) {
+        const connection = makeScriptedConnection(completeOnboarding);
+        let sendOtp: (() => Promise<void>) | undefined;
+        let verifyOtp: ((otp: string) => Promise<void>) | undefined;
+        // Capture the OTP callbacks from the first (needsAuth) onAuthRequired invocation.
+        const onAuthRequired = vi.fn(
+            async (
+                _type: string,
+                _locator: string,
+                needsAuth: boolean,
+                send: () => Promise<void>,
+                verify: (otp: string) => Promise<void>
+            ) => {
+                if (needsAuth && sendOtp == null) {
+                    sendOtp = send;
+                    verifyOtp = verify;
+                }
+            }
+        );
+        const signer = new EVMNonCustodialSigner(
+            makeConfig({ clientTEEConnection: connection as never, onAuthRequired: onAuthRequired as never })
+        );
+        return { signer, connection, getSendOtp: () => sendOtp, getVerifyOtp: () => verifyOtp };
+    }
+
+    const startCount = (connection: ReturnType<typeof makeScriptedConnection>) =>
+        connection.sendAction.mock.calls.filter((c) => c[0].event === "request:start-onboarding").length;
+
+    const flush = () => new Promise((resolve) => setTimeout(resolve, 10));
+
+    it("re-issues a fresh OTP and keeps the flow alive when the frame reloads mid-onboarding", async () => {
+        // complete-onboarding fails once (frame reloaded), then succeeds with the new code.
+        const { signer, connection, getSendOtp, getVerifyOtp } = setup((i) =>
+            i === 0 ? { status: "error", error: "no onboarding in progress" } : { status: "success" }
+        );
+
+        const authSettled = signer.ensureAuthenticated().then(
+            () => "resolved",
+            () => "rejected"
+        );
+        await flush();
+
+        const sendOtp = getSendOtp();
+        const verifyOtp = getVerifyOtp();
+        expect(sendOtp).toBeDefined();
+        expect(verifyOtp).toBeDefined();
+
+        // OTP issued on connection generation 1.
+        await sendOtp?.();
+
+        // Process killed: the frame reloads and re-handshakes, advancing the generation.
+        connection.connectionGeneration = 2;
+
+        // The stale OTP fails to complete onboarding; a fresh OTP is requested and the flow stays alive.
+        await expect(verifyOtp?.("stale-otp")).rejects.toBeInstanceOf(OnboardingSessionExpiredError);
+        expect(startCount(connection)).toBe(2); // initial + re-issued
+
+        // User enters the new code; onboarding completes and auth resolves.
+        await verifyOtp?.("fresh-otp");
+        await expect(authSettled).resolves.toBe("resolved");
+    });
+
+    it("rejects with OtpValidationError and does not re-issue when the OTP is simply wrong", async () => {
+        const { signer, connection, getSendOtp, getVerifyOtp } = setup(() => ({
+            status: "error",
+            error: "invalid OTP",
+        }));
+
+        const authSettled = signer.ensureAuthenticated().then(
+            () => "resolved",
+            () => "rejected"
+        );
+        await flush();
+
+        await getSendOtp()?.();
+        // Frame was NOT reloaded (generation unchanged): a genuine wrong-OTP error.
+        await expect(getVerifyOtp()?.("wrong-otp")).rejects.toBeInstanceOf(OtpValidationError);
+        expect(startCount(connection)).toBe(1); // no re-issue
+        await expect(authSettled).resolves.toBe("rejected");
     });
 });

--- a/packages/wallets/src/signers/non-custodial/ncs-signer.test.ts
+++ b/packages/wallets/src/signers/non-custodial/ncs-signer.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from "vitest";
+
+import type { EmailInternalSignerConfig } from "../types";
+import { EVMNonCustodialSigner } from "./ncs-evm-signer";
+
+function makeReadyConnection(onSendAction?: () => void) {
+    return {
+        sendAction: vi.fn(async () => {
+            onSendAction?.();
+            return { status: "success", signerStatus: "ready" };
+        }),
+    };
+}
+
+function makeConfig(overrides: Partial<EmailInternalSignerConfig> = {}): EmailInternalSignerConfig {
+    return {
+        type: "email",
+        email: "test@example.com",
+        locator: "email:test@example.com",
+        address: "0x0000000000000000000000000000000000000000",
+        crossmint: { apiKey: "ck_staging_test", jwt: "test-jwt" },
+        clientTEEConnection: makeReadyConnection(),
+        // Required by handleAuthRequired; not invoked when the signer reports "ready".
+        onAuthRequired: vi.fn(async () => {}),
+        ...overrides,
+    } as unknown as EmailInternalSignerConfig;
+}
+
+describe("NonCustodialSigner.ensureAuthenticated", () => {
+    it("resets the signer frame before checking signer status", async () => {
+        const calls: string[] = [];
+        const resetSignerFrame = vi.fn(async () => {
+            calls.push("reset");
+        });
+        const clientTEEConnection = makeReadyConnection(() => calls.push("get-status"));
+        const signer = new EVMNonCustodialSigner(makeConfig({ resetSignerFrame, clientTEEConnection }));
+
+        await signer.ensureAuthenticated();
+
+        expect(resetSignerFrame).toHaveBeenCalledTimes(1);
+        expect(clientTEEConnection.sendAction).toHaveBeenCalledTimes(1);
+        // The reset must run before the status check so the OTP flow targets the fresh frame.
+        expect(calls).toEqual(["reset", "get-status"]);
+    });
+
+    it("resets the signer frame on every signature", async () => {
+        const resetSignerFrame = vi.fn(async () => {});
+        const signer = new EVMNonCustodialSigner(makeConfig({ resetSignerFrame }));
+
+        await signer.ensureAuthenticated();
+        await signer.ensureAuthenticated();
+
+        expect(resetSignerFrame).toHaveBeenCalledTimes(2);
+    });
+
+    it("is a no-op when no reset hook is provided", async () => {
+        const clientTEEConnection = makeReadyConnection();
+        const signer = new EVMNonCustodialSigner(makeConfig({ clientTEEConnection, resetSignerFrame: undefined }));
+
+        await expect(signer.ensureAuthenticated()).resolves.toBeUndefined();
+        expect(clientTEEConnection.sendAction).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/wallets/src/signers/non-custodial/ncs-signer.ts
+++ b/packages/wallets/src/signers/non-custodial/ncs-signer.ts
@@ -212,6 +212,13 @@ export abstract class NonCustodialSigner implements SignerAdapter {
     }
 
     public async ensureAuthenticated(): Promise<void> {
+        // Re-onboard the signer frame before each signature when the host provides a reset hook
+        // (React Native on iOS). The signer webview's storage isn't reliable across launches there,
+        // so we force a fresh device and OTP every time. No-op on other platforms, where the hook
+        // is left undefined.
+        if (this.config.resetSignerFrame != null) {
+            await this.config.resetSignerFrame();
+        }
         await this.handleAuthRequired();
     }
 

--- a/packages/wallets/src/signers/non-custodial/ncs-signer.ts
+++ b/packages/wallets/src/signers/non-custodial/ncs-signer.ts
@@ -7,7 +7,13 @@ import type {
     PhoneSignerLocator,
     SignerAdapter,
 } from "../types";
-import { AuthRejectedError, KeyExportError, OtpValidationError, SignerStatusError } from "../types";
+import {
+    AuthRejectedError,
+    KeyExportError,
+    OnboardingSessionExpiredError,
+    OtpValidationError,
+    SignerStatusError,
+} from "../types";
 import { NcsIframeManager } from "./ncs-iframe-manager";
 import { validateAPIKey, WithLoggerContext } from "@crossmint/common-sdk-base";
 import type { SignerOutputEvent } from "@crossmint/client-signers";
@@ -22,6 +28,11 @@ export abstract class NonCustodialSigner implements SignerAdapter {
         reject: (error: Error) => void;
     } | null = null;
     private _initializationPromise: Promise<void> | null = null;
+    /**
+     * The TEE connection generation that issued the in-flight OTP. Used to detect that the signer
+     * frame was reloaded (losing the onboarding) between start-onboarding and complete-onboarding.
+     */
+    private _onboardingConnectionGeneration: number | null = null;
 
     constructor(protected config: EmailInternalSignerConfig | PhoneInternalSignerConfig) {
         // Only initialize the signer if running client-side
@@ -264,6 +275,9 @@ export abstract class NonCustodialSigner implements SignerAdapter {
             options: DEFAULT_EVENT_OPTIONS,
         });
         const durationMs = Date.now() - startTime;
+        // Record which frame connection issued this OTP. If the frame reloads before the user enters
+        // the code, the generation will have advanced and verifyOtp re-issues a fresh OTP.
+        this._onboardingConnectionGeneration = handshakeParent.connectionGeneration;
         walletsLogger.info("start-onboarding: response received", {
             status: response?.status,
             durationMs,
@@ -314,9 +328,7 @@ export abstract class NonCustodialSigner implements SignerAdapter {
             });
         } catch (err) {
             walletsLogger.error("complete-onboarding: error", { error: err });
-            this._needsAuth = true;
-            this._authPromise?.reject(err as Error);
-            throw err;
+            return await this.handleOnboardingVerificationFailure(err as Error);
         }
 
         if (response?.status === "success") {
@@ -341,13 +353,41 @@ export abstract class NonCustodialSigner implements SignerAdapter {
             error: response?.status === "error" ? response.error : undefined,
             code: response?.status === "error" ? response.code : undefined,
         });
-        this._needsAuth = true;
         const errorMessage =
             response?.status === "error"
                 ? response.error || "Failed to validate encrypted OTP"
                 : "Failed to validate encrypted OTP";
         const errorCode = response?.status === "error" ? response.code : undefined;
-        const error = new OtpValidationError(errorMessage, errorCode);
+        return await this.handleOnboardingVerificationFailure(new OtpValidationError(errorMessage, errorCode));
+    }
+
+    /**
+     * Decide how to recover from a failed complete-onboarding. If the signer frame was reloaded since
+     * the OTP was issued (its connection generation advanced), the in-memory onboarding is gone, so we
+     * request a fresh OTP and surface {@link OnboardingSessionExpiredError} without rejecting the auth
+     * promise — the flow stays alive for the user to enter the new code. Otherwise the OTP was simply
+     * wrong, so we reject as before.
+     */
+    private async handleOnboardingVerificationFailure(error: Error): Promise<never> {
+        this._needsAuth = true;
+
+        const connection = this.config.clientTEEConnection;
+        const frameReloaded =
+            this._onboardingConnectionGeneration != null &&
+            connection != null &&
+            connection.connectionGeneration !== this._onboardingConnectionGeneration;
+
+        if (frameReloaded) {
+            walletsLogger.warn("complete-onboarding: signer frame reloaded mid-onboarding, re-issuing OTP", {
+                onboardingGeneration: this._onboardingConnectionGeneration,
+                currentGeneration: connection?.connectionGeneration,
+            });
+            // Re-run onboarding so the backend issues a fresh OTP against the reloaded frame. Do not
+            // reject the auth promise: the signing flow continues so the user can enter the new code.
+            await this.sendMessageWithOtp();
+            throw new OnboardingSessionExpiredError();
+        }
+
         this._authPromise?.reject(error);
         throw error;
     }

--- a/packages/wallets/src/signers/types.ts
+++ b/packages/wallets/src/signers/types.ts
@@ -131,6 +131,11 @@ type BaseInternalSignerConfig = {
     address: string;
     crossmint: Crossmint;
     clientTEEConnection?: HandshakeParent<typeof signerOutboundEvents, typeof signerInboundEvents>;
+    /**
+     * @internal
+     * Re-onboards the signer frame before each signature. See {@link WalletOptions.resetSignerFrame}.
+     */
+    resetSignerFrame?: () => Promise<void>;
 };
 
 export type EmailInternalSignerConfig = EmailSignerConfig &

--- a/packages/wallets/src/signers/types.ts
+++ b/packages/wallets/src/signers/types.ts
@@ -66,6 +66,18 @@ export class KeyExportError extends Error {
         this.code = code;
     }
 }
+
+/**
+ * Thrown when the signer frame was reloaded between starting and completing onboarding, so the
+ * in-memory onboarding state (and the OTP issued for it) is gone. A fresh OTP has already been
+ * requested when this is thrown; the caller should prompt the user to enter the new code.
+ */
+export class OnboardingSessionExpiredError extends Error {
+    constructor(message = "The signer session expired before the code could be verified. A new code has been sent.") {
+        super(message);
+        this.name = "OnboardingSessionExpiredError";
+    }
+}
 export type EmailSignerConfig = {
     type: "email";
     email?: string;

--- a/packages/wallets/src/wallets/types.ts
+++ b/packages/wallets/src/wallets/types.ts
@@ -213,6 +213,13 @@ export type WalletPlugin<C extends Chain> = C extends StellarChain ? StellarWall
 export type WalletOptions = {
     callbacks?: Callbacks;
     clientTEEConnection?: HandshakeParent<typeof signerOutboundEvents, typeof signerInboundEvents>;
+    /**
+     * @internal
+     * Invoked before each non-custodial signature to reset and reload the signer frame so it
+     * re-onboards from scratch. Provided by the React Native iOS provider, where the signer
+     * webview's storage isn't reliable across launches. Left undefined elsewhere, where it is a no-op.
+     */
+    resetSignerFrame?: () => Promise<void>;
     deviceSignerKeyStorage?: DeviceSignerKeyStorage;
 };
 

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -1898,6 +1898,7 @@ export class Wallet<C extends Chain> {
                     address: this.address,
                     crossmint: this.#apiClient.crossmint,
                     clientTEEConnection: this.#options?.clientTEEConnection,
+                    resetSignerFrame: this.#options?.resetSignerFrame,
                     onAuthRequired: this.#options?.callbacks?.onAuthRequired,
                 } as InternalSignerConfig<C>;
             case "phone":
@@ -1908,6 +1909,7 @@ export class Wallet<C extends Chain> {
                     address: this.address,
                     crossmint: this.#apiClient.crossmint,
                     clientTEEConnection: this.#options?.clientTEEConnection,
+                    resetSignerFrame: this.#options?.resetSignerFrame,
                     onAuthRequired: this.#options?.callbacks?.onAuthRequired,
                 } as InternalSignerConfig<C>;
             case "passkey": {


### PR DESCRIPTION
Ports [crossmint-swift-sdk#107](https://github.com/Crossmint/crossmint-swift-sdk/pull/107) to the React Native SDK, for iOS only. Android keeps its current behavior.

On iOS the non-custodial signer runs in a hidden WebView whose storage isn't reliable across launches, so the device identity can disappear and break signing. This stops relying on that persistence: the signer frame uses non-persistent storage with in-memory device storage, and reloads to re-onboard with a fresh OTP before each signature.

The per-signature reset can't live entirely in the React Native provider, because the sign and auth flow runs in the shared wallets SDK before any provider callback fires. It is threaded through as an optional `resetSignerFrame` hook that only the iOS provider supplies, and stays undefined on Android and web where the flow is unchanged.

## Changes
- `wallets-sdk`: add an optional `resetSignerFrame` option, pass it into the email/phone signer config, and call it at the start of `NonCustodialSigner.ensureAuthenticated` so it runs before the status check.
- `react-base`: forward `resetSignerFrame` from the provider into the wallet options.
- `react-native-ui`: on iOS, append `deviceStorage=memory` to the signer frame URL, set the WebView to non-persistent storage via `incognito`, and implement `resetSignerFrame` to reload the frame and wait for a fresh handshake. The hook is only wired up on iOS.
- Add a unit test covering that `ensureAuthenticated` resets the frame before the status check, resets on every signature, and is a no-op when no hook is provided.

## Testing
- `pnpm --filter @crossmint/wallets-sdk test:vitest` (352 passed)
- Built `wallets-sdk`, `react-base`, and `react-native-ui`
- Biome lint clean on the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)