### PR TITLE
docs: fix React Native SDK reference generation — install tabs and props resolution

### DIFF
--- a/packages/client/ui/react-native/scripts/generate-reference.mjs
+++ b/packages/client/ui/react-native/scripts/generate-reference.mjs
@@ -16,7 +16,7 @@ const PRODUCTS = {
         description: "React Native SDK reference for Crossmint wallets",
         packageName: "@crossmint/client-sdk-react-native-ui",
         npmUrl: "https://www.npmjs.com/package/@crossmint/client-sdk-react-native-ui",
-        installSnippet: null,
+        installSnippet: "client-sdk-react-native-ui-installation-cmd.mdx",
         intro: "The Crossmint React Native SDK (`@crossmint/client-sdk-react-native-ui`) provides React Native components and hooks for integrating Crossmint wallets into your mobile application.",
         versionBanner: `<Note>
 **This page has been updated for Wallets SDK V1.** If you are using the previous version,
@@ -55,7 +55,7 @@ see the [previous version of this page](/sdk-reference/wallets/v0/react-native/{
         description: "React Native SDK reference for Crossmint checkout",
         packageName: "@crossmint/client-sdk-react-native-ui",
         npmUrl: "https://www.npmjs.com/package/@crossmint/client-sdk-react-native-ui",
-        installSnippet: null,
+        installSnippet: "client-sdk-react-native-ui-installation-cmd.mdx",
         intro: "The Crossmint React Native SDK (`@crossmint/client-sdk-react-native-ui`) provides React Native components and hooks for integrating Crossmint checkout into your mobile application. It supports embedded checkout via a WebView.",
         exports: [
             "CrossmintProvider",

--- a/packages/client/ui/react-native/tsconfig.typedoc.json
+++ b/packages/client/ui/react-native/tsconfig.typedoc.json
@@ -4,7 +4,11 @@
         "rootDir": "src",
         "baseUrl": ".",
         "paths": {
+            "@/types": ["../../base/src/types/index.ts"],
+            "@/types/*": ["../../base/src/types/*"],
             "@/*": ["src/*"],
+            "@crossmint/client-sdk-base": ["../../base/src/index.ts"],
+            "@crossmint/client-sdk-base/*": ["../../base/src/*"],
             "@crossmint/client-sdk-react-base": ["../../react-base/src/index.ts"],
             "@crossmint/client-sdk-react-base/*": ["../../react-base/src/*"],
             "@crossmint/wallets-sdk": ["../../../wallets/src/index.ts"],
@@ -17,6 +21,12 @@
         "esModuleInterop": true,
         "skipLibCheck": true
     },
-    "include": ["src/**/*", "../../react-base/src/**/*", "../../../wallets/src/**/*", "../../../common/base/src/**/*"],
+    "include": [
+        "src/**/*",
+        "../../base/src/**/*",
+        "../../react-base/src/**/*",
+        "../../../wallets/src/**/*",
+        "../../../common/base/src/**/*"
+    ],
     "exclude": ["__tests__"]
 }

--- a/packages/client/ui/react-native/typedoc.json
+++ b/packages/client/ui/react-native/typedoc.json
@@ -1,5 +1,10 @@
 {
-    "entryPoints": ["src/index.ts", "../../../common/base/src/types/uiconfig.ts"],
+    "entryPoints": [
+        "src/index.ts",
+        "../../base/src/types/embed/v3/CrossmintEmbeddedCheckoutV3Props.ts",
+        "../../base/src/types/index.ts",
+        "../../../common/base/src/types/uiconfig.ts"
+    ],
     "tsconfig": "tsconfig.typedoc.json",
     "json": "api.json",
     "skipErrorChecking": true,


### PR DESCRIPTION
## Description

The React Native SDK reference docs were missing two things compared to the React version:

1. **Installation section** showed a single `npm install` command instead of the tabbed component (npm/pnpm/yarn/bun). Fixed by setting `installSnippet: "client-sdk-react-native-ui-installation-cmd.mdx"` in both wallets and checkout configs.

2. **CrossmintEmbeddedCheckout props** were not being generated on the components page. Root cause: the TypeDoc config for the React Native package was missing the `@crossmint/client-sdk-base` entry points and path mappings needed to resolve `CrossmintEmbeddedCheckoutV3Props` (which lives in the base package). Fixed by aligning `typedoc.json` and `tsconfig.typedoc.json` with the React UI package's config.

Also verified: the `payment.crypto.payer` sample code (`handleChainSwitch`, `handleSignAndSendTransaction`) is correct per the `EmbeddedCheckoutPayer` type signatures.

## Test plan

* Ran `pnpm generate:docs` locally in the react-native package — confirmed:
  - `get-started.mdx` now uses `<Snippet file="client-sdk-react-native-ui-installation-cmd.mdx" />`
  - `components.mdx` now generates 212 lines with full `CrossmintEmbeddedCheckout` props (was previously empty/minimal)
  - Props output matches the React UI equivalent (appearance, payment with crypto.payer expandable, fiat, lineItems, recipient, locale, metadata)

## Package updates

No package source code changes — only docs generation config files (typedoc.json, tsconfig.typedoc.json, generate-reference.mjs). No changeset needed.

Link to Devin session: https://crossmint.devinenterprise.com/sessions/a38c0a2e6de24f848da2a3756404038e
Requested by: @jmderby