### PR TITLE
[GEN-2382] Add wallet-address-label testID to expo wallet display

### DIFF
--- a/apps/wallets/expo/snippets/03-wallet-display.tsx
+++ b/apps/wallets/expo/snippets/03-wallet-display.tsx
@@ -32,7 +32,7 @@ export function WalletDisplay() {
                     style={{ flexDirection: "row", alignItems: "center", gap: 6 }}
                 >
                     <Text
-                        testID="wallet-address"
+                        testID="wallet-address-label"
                         style={{ fontWeight: "500" }}
                     >{`${wallet.address.slice(0, 6)}...${wallet.address.slice(-6)}`}</Text>
                     <Text style={{ fontSize: 11, color: copied ? "#13b601" : "#6B7280" }}>


### PR DESCRIPTION
## Summary

Renames the existing `testID="wallet-address"` to `testID="wallet-address-label"` on the truncated wallet address `Text` in `apps/wallets/expo/snippets/03-wallet-display.tsx`.

This aligns the React Native demo app with the testID contract in `crossmint-mobile-e2e-tests/docs/testid-contract.md` so the shared Maestro `wallet-display.yaml` flow can target the element consistently across all SDKs.

## Changes

- `apps/wallets/expo/snippets/03-wallet-display.tsx` — rename testID `wallet-address` → `wallet-address-label`

## Test plan

- [ ] Verify with \`maestro studio\` against a running React Native simulator that \`wallet-address-label\` appears in the element tree on the wallet dashboard
