### PR TITLE
test(WAL-2382-2384-2386-2387): testIDs for transfer, activity, signers (React Native)

### DIFF
--- a/apps/wallets/expo/snippets/03-wallet-display.tsx
+++ b/apps/wallets/expo/snippets/03-wallet-display.tsx
@@ -27,12 +27,12 @@ export function WalletDisplay() {
             <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "center" }}>
                 <Text style={{ color: "#6B7280" }}>Address</Text>
                 <TouchableOpacity
-                    testID="copy-address-button"
+                    testID="wallet-address-copy-button"
                     onPress={copyAddress}
                     style={{ flexDirection: "row", alignItems: "center", gap: 6 }}
                 >
                     <Text
-                        testID="wallet-address"
+                        testID="wallet-address-label"
                         style={{ fontWeight: "500" }}
                     >{`${wallet.address.slice(0, 6)}...${wallet.address.slice(-6)}`}</Text>
                     <Text style={{ fontSize: 11, color: copied ? "#13b601" : "#6B7280" }}>

--- a/apps/wallets/shared/src/components/ActivityList.tsx
+++ b/apps/wallets/shared/src/components/ActivityList.tsx
@@ -21,11 +21,17 @@ export function ActivityList({ wallet }: { wallet: any }) {
             {transfers.length === 0 && <Text style={{ color: "#6B7280", marginTop: 8 }}>No transactions yet</Text>}
             <ScrollView testID="activity-list" style={{ maxHeight: 200, marginTop: 8 }}>
                 {transfers.map((tx, i) => (
-                    <View key={i} testID={`activity-item-${i}`} style={{ flexDirection: "row", justifyContent: "space-between", paddingVertical: 4 }}>
-                        <Text style={{ color: "#6B7280", fontSize: 13 }}>
+                    <View
+                        key={i}
+                        testID={`activity-item-${i}`}
+                        style={{ flexDirection: "row", justifyContent: "space-between", paddingVertical: 4 }}
+                    >
+                        <Text testID={`activity-item-${i}-token`} style={{ color: "#6B7280", fontSize: 13 }}>
                             {tx.token?.symbol ?? tx.token?.locator} → {tx.recipient?.address?.slice(0, 8)}...
                         </Text>
-                        <Text style={{ fontWeight: "500", fontSize: 13 }}>{tx.token?.amount}</Text>
+                        <Text testID={`activity-item-${i}-amount`} style={{ fontWeight: "500", fontSize: 13 }}>
+                            {tx.token?.amount}
+                        </Text>
                     </View>
                 ))}
             </ScrollView>

--- a/apps/wallets/shared/src/components/ActivityList.tsx
+++ b/apps/wallets/shared/src/components/ActivityList.tsx
@@ -19,9 +19,9 @@ export function ActivityList({ wallet }: { wallet: any }) {
                 </TouchableOpacity>
             </View>
             {transfers.length === 0 && <Text style={{ color: "#6B7280", marginTop: 8 }}>No transactions yet</Text>}
-            <ScrollView style={{ maxHeight: 200, marginTop: 8 }}>
+            <ScrollView testID="activity-list" style={{ maxHeight: 200, marginTop: 8 }}>
                 {transfers.map((tx, i) => (
-                    <View key={i} style={{ flexDirection: "row", justifyContent: "space-between", paddingVertical: 4 }}>
+                    <View key={i} testID={`activity-item-${i}`} style={{ flexDirection: "row", justifyContent: "space-between", paddingVertical: 4 }}>
                         <Text style={{ color: "#6B7280", fontSize: 13 }}>
                             {tx.token?.symbol ?? tx.token?.locator} → {tx.recipient?.address?.slice(0, 8)}...
                         </Text>

--- a/apps/wallets/shared/src/components/Permissions.tsx
+++ b/apps/wallets/shared/src/components/Permissions.tsx
@@ -133,7 +133,7 @@ export function Permissions({
                     <Text style={{ color: "#13b601", fontWeight: "500" }}>Refresh</Text>
                 </TouchableOpacity>
             </View>
-            <ScrollView style={{ maxHeight: 160, marginTop: 8 }}>
+            <ScrollView testID="signers-list" style={{ maxHeight: 160, marginTop: 8 }}>
                 {/* Recovery signer */}
                 {wallet &&
                     (() => {
@@ -276,6 +276,7 @@ export function Permissions({
                     />
                 ))}
             <TouchableOpacity
+                testID="signers-add-button"
                 style={{
                     backgroundColor: "#fff",
                     padding: 12,

--- a/apps/wallets/shared/src/components/TransferForm.tsx
+++ b/apps/wallets/shared/src/components/TransferForm.tsx
@@ -44,7 +44,7 @@ export function TransferForm({ wallet }: { wallet: any }) {
                 {TOKENS.map((t, i) => (
                     <TouchableOpacity
                         key={t}
-                        testID={`token-selector-${t}`}
+                        testID={`transfer-token-option-${t}`}
                         onPress={() => setTokenIdx(i)}
                         style={{
                             padding: 8,
@@ -63,7 +63,7 @@ export function TransferForm({ wallet }: { wallet: any }) {
                 ))}
             </View>
             <TextInput
-                testID="recipient-input"
+                testID="transfer-recipient-input"
                 style={inputStyle}
                 placeholder="Recipient address"
                 value={recipient}
@@ -71,7 +71,7 @@ export function TransferForm({ wallet }: { wallet: any }) {
                 autoCapitalize="none"
             />
             <TextInput
-                testID="amount-input"
+                testID="transfer-amount-input"
                 style={inputStyle}
                 placeholder="Amount"
                 value={amount}
@@ -79,7 +79,7 @@ export function TransferForm({ wallet }: { wallet: any }) {
                 keyboardType="numeric"
             />
             <TouchableOpacity
-                testID="transfer-button"
+                testID="transfer-submit-button"
                 style={{
                     backgroundColor: "#13b601",
                     padding: 14,
@@ -95,10 +95,10 @@ export function TransferForm({ wallet }: { wallet: any }) {
                     {loading ? "Sending..." : `Transfer ${token.toUpperCase()}`}
                 </Text>
             </TouchableOpacity>
-            {error ? <Text style={{ color: "#EF4444", marginTop: 8, fontSize: 13 }}>{error}</Text> : null}
+            {error ? <Text testID="transfer-error-label" style={{ color: "#EF4444", marginTop: 8, fontSize: 13 }}>{error}</Text> : null}
             {txLink ? (
                 <TouchableOpacity
-                    testID="successful-tx-link"
+                    testID="transfer-success-label"
                     onPress={() => Linking.openURL(txLink)}
                     style={{ marginTop: 8 }}
                 >

--- a/apps/wallets/shared/src/components/TransferForm.tsx
+++ b/apps/wallets/shared/src/components/TransferForm.tsx
@@ -95,7 +95,11 @@ export function TransferForm({ wallet }: { wallet: any }) {
                     {loading ? "Sending..." : `Transfer ${token.toUpperCase()}`}
                 </Text>
             </TouchableOpacity>
-            {error ? <Text testID="transfer-error-label" style={{ color: "#EF4444", marginTop: 8, fontSize: 13 }}>{error}</Text> : null}
+            {error ? (
+                <Text testID="transfer-error-label" style={{ color: "#EF4444", marginTop: 8, fontSize: 13 }}>
+                    {error}
+                </Text>
+            ) : null}
             {txLink ? (
                 <TouchableOpacity
                     testID="transfer-success-label"


### PR DESCRIPTION
## Summary

Adds Maestro-compatible `testID` props to the shared React Native demo app components:

- **WAL-2382 (testID contract)** `03-wallet-display.tsx` — renames `wallet-address` → `wallet-address-label` and `copy-address-button` → `wallet-address-copy-button` to align with the canonical IDs in `docs/testid-contract.md`
- **WAL-2384 (transfer)** `TransferForm.tsx` — `transfer-token-option-{symbol}`, `transfer-recipient-input`, `transfer-amount-input`, `transfer-submit-button`, `transfer-success-label`, `transfer-error-label`
- **WAL-2386 (activity)** `ActivityList.tsx` — `activity-list`, `activity-item-{index}`, `activity-item-{index}-token`, `activity-item-{index}-amount`
- **WAL-2387 (signers)** `Permissions.tsx` — `signers-list`, `signers-add-button`

Note: WAL-2383 (chain switching) is N/A for React Native — no chain picker UI exists in the current demo app.

## Test plan

- [ ] Run `flows/wallet/transfer.yaml` against the React Native demo app
- [ ] Run `flows/wallet/activity.yaml` against the React Native demo app
- [ ] Run `flows/signers/signers-list.yaml` against the React Native demo app
