### PR TITLE
fix(react-native-ui): make device-signer storage helper static for Swift 6 @Sendable closures

### DIFF
--- a/.changeset/rn-ios-swift6-sendable-fix.md
+++ b/.changeset/rn-ios-swift6-sendable-fix.md
@@ -1,0 +1,9 @@
+---
+"@crossmint/client-sdk-react-native-ui": minor
+---
+
+Fix iOS build failure under Swift 6 strict concurrency (Expo SDK 56+).
+
+The native `DeviceSignerModule` called an instance helper (`self.defaultStorage()`) inside Expo's `AsyncFunction` closures. Those closures are `@Sendable` in newer `ExpoModulesCore`, and `DeviceSignerModule` (an `ExpoModulesCore.Module` subclass) is not `Sendable`, so capturing `self` is an error under the Swift 6 language mode that newer Xcode toolchains enforce.
+
+The storage-selection helper is now a `static` method, so the closures no longer capture `self`. Behavior is unchanged — it reads only compile-time (`targetEnvironment`) and global (`SecureEnclave.isAvailable`) state.

--- a/packages/client/ui/react-native/ios/DeviceSignerModule.swift
+++ b/packages/client/ui/react-native/ios/DeviceSignerModule.swift
@@ -27,7 +27,7 @@ public class DeviceSignerModule: Module {
         // Generates a new P-256 key and persists it.
         AsyncFunction("generateKey") { (address: String?) async throws -> String in
             do {
-                return try await self.defaultStorage().generateKey(address: address)
+                return try await DeviceSignerModule.defaultStorage().generateKey(address: address)
             } catch {
                 throw Exception(
                     name: "GenerateKeyFailed",
@@ -39,7 +39,7 @@ public class DeviceSignerModule: Module {
         // Renames the pending Keychain entry to a wallet-address entry.
         AsyncFunction("mapAddressToKey") { (address: String, publicKeyBase64: String) async throws in
             do {
-                try await self.defaultStorage().mapAddressToKey(address: address, publicKeyBase64: publicKeyBase64)
+                try await DeviceSignerModule.defaultStorage().mapAddressToKey(address: address, publicKeyBase64: publicKeyBase64)
             } catch {
                 throw Exception(name: "MapAddressToKeyFailed", description: "mapAddressToKey failed: \(error)")
             }
@@ -47,18 +47,18 @@ public class DeviceSignerModule: Module {
 
         // Returns the stored public key for a wallet address, or nil.
         AsyncFunction("getKey") { (address: String) async -> String? in
-            await self.defaultStorage().getKey(address: address)
+            await DeviceSignerModule.defaultStorage().getKey(address: address)
         }
 
         // Returns true if the private key for the given public key is present on this device.
         AsyncFunction("hasKey") { (publicKeyBase64: String) -> Bool in
-            self.defaultStorage().hasKey(publicKeyBase64: publicKeyBase64)
+            DeviceSignerModule.defaultStorage().hasKey(publicKeyBase64: publicKeyBase64)
         }
 
         // Signs a base64-encoded message; returns { r, s } hex strings.
         AsyncFunction("signMessage") { (address: String, message: String) async throws -> [String: String] in
             do {
-                let sig = try await self.defaultStorage().signMessage(address: address, message: message)
+                let sig = try await DeviceSignerModule.defaultStorage().signMessage(address: address, message: message)
                 return ["r": sig.r, "s": sig.s]
             } catch {
                 throw Exception(name: "SignMessageFailed", description: "signMessage failed: \(error)")
@@ -67,18 +67,25 @@ public class DeviceSignerModule: Module {
 
         // Deletes the key for a wallet address.
         AsyncFunction("deleteKey") { (address: String) async throws in
-            try await self.defaultStorage().deleteKey(address: address)
+            try await DeviceSignerModule.defaultStorage().deleteKey(address: address)
         }
 
         // Deletes a pending key that was never promoted to a wallet-address key.
         AsyncFunction("deletePendingKey") { (publicKeyBase64: String) async throws in
-            try await self.defaultStorage().deletePendingKey(publicKeyBase64: publicKeyBase64)
+            try await DeviceSignerModule.defaultStorage().deletePendingKey(publicKeyBase64: publicKeyBase64)
         }
     }
 
     // MARK: - Private helpers
 
-    private func defaultStorage() -> any DeviceSignerKeyStorage {
+    // Declared `static` so the `@Sendable` `AsyncFunction` closures above don't
+    // capture `self`. `DeviceSignerModule` is a `Module` subclass and is not
+    // `Sendable`, so capturing it in a `@Sendable` closure is an error under Swift 6
+    // strict concurrency (the closures became `@Sendable` in newer `ExpoModulesCore`).
+    // Backend selection reads only compile-time (`targetEnvironment`) and global
+    // (`SecureEnclave.isAvailable`) state, so no per-instance context is needed —
+    // behavior is identical to the previous instance method.
+    private static func defaultStorage() -> any DeviceSignerKeyStorage {
         #if targetEnvironment(simulator)
         return KeychainKeyStorage()
         #else


### PR DESCRIPTION
## Problem

On newer Expo SDKs (56+) and Xcode toolchains, `expo-modules-core` marks `AsyncFunction` body closures `@Sendable`. `DeviceSignerModule` is an `ExpoModulesCore.Module` subclass (which is not `Sendable`) and called an instance helper `self.defaultStorage()` inside those closures, so under the Swift 6 language mode the iOS pod fails to compile:

```
error: capture of 'self' with non-Sendable type 'DeviceSignerModule' in a '@Sendable' closure
```

(6 errors — one per `async` `AsyncFunction` closure.)

## Fix

Make `defaultStorage()` a `static` method and call it as `DeviceSignerModule.defaultStorage()` so the closures no longer capture `self`. Behavior is unchanged — it reads only compile-time (`targetEnvironment`) and global (`SecureEnclave.isAvailable`) state.

## Test plan

Verified against the latest Expo SDK (56), Xcode 26.3 / Swift 6.2:

- iOS build before the fix: fails with 6× `capture of 'self'` (exit 65).
- After the fix: `** BUILD SUCCEEDED **` (exit 0), no concurrency errors.
- End-to-end on the iOS simulator: app boots, the native device signer loads, and an EVM smart wallet is created and signs.

## Versioning

Minor — this changes native iOS code (requires a native rebuild; not shippable via JS-only OTA updates).

## Follow-up

A separate PR will widen this package's Expo dependency ranges to officially support the latest Expo SDK.

<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/crossmint-sdk/pull/1958" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->