### PR TITLE
ci: rename dispatch package names to {product}/{lang} format

### DIFF
--- a/.github/workflows/sdk-reference-docs-generate.yml
+++ b/.github/workflows/sdk-reference-docs-generate.yml
@@ -27,9 +27,9 @@ on:
     workflow_dispatch:
         inputs:
             packages:
-                description: "Comma-separated list of packages to generate docs for (react-ui, react-native, node-wallets, react-checkout, react-native-checkout). Defaults to all."
+                description: "Comma-separated list of packages to generate docs for (wallets/react, wallets/react-native, wallets/typescript, checkout/react, checkout/react-native). Defaults to all."
                 required: false
-                default: "react-ui,react-native,node-wallets,react-checkout,react-native-checkout"
+                default: "wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native"
                 type: string
 
 permissions:
@@ -56,52 +56,52 @@ jobs:
             - name: Parse package selection
               id: packages
               env:
-                  PACKAGES_INPUT: ${{ inputs.packages || 'react-ui,react-native,node-wallets,react-checkout,react-native-checkout' }}
+                  PACKAGES_INPUT: ${{ inputs.packages || 'wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native' }}
               run: |
                   PACKAGES="$PACKAGES_INPUT"
-                  echo "react_ui=false" >> $GITHUB_OUTPUT
-                  echo "react_native=false" >> $GITHUB_OUTPUT
-                  echo "node_wallets=false" >> $GITHUB_OUTPUT
-                  echo "react_checkout=false" >> $GITHUB_OUTPUT
-                  echo "react_native_checkout=false" >> $GITHUB_OUTPUT
-                  if echo ",$PACKAGES," | grep -q ",react-ui,"; then
-                    echo "react_ui=true" >> $GITHUB_OUTPUT
+                  echo "wallets_react=false" >> $GITHUB_OUTPUT
+                  echo "wallets_react_native=false" >> $GITHUB_OUTPUT
+                  echo "wallets_typescript=false" >> $GITHUB_OUTPUT
+                  echo "checkout_react=false" >> $GITHUB_OUTPUT
+                  echo "checkout_react_native=false" >> $GITHUB_OUTPUT
+                  if echo ",$PACKAGES," | grep -q ",wallets/react,"; then
+                    echo "wallets_react=true" >> $GITHUB_OUTPUT
                   fi
-                  if echo ",$PACKAGES," | grep -q ",react-native,"; then
-                    echo "react_native=true" >> $GITHUB_OUTPUT
+                  if echo ",$PACKAGES," | grep -q ",wallets/react-native,"; then
+                    echo "wallets_react_native=true" >> $GITHUB_OUTPUT
                   fi
-                  if echo ",$PACKAGES," | grep -q ",node-wallets,"; then
-                    echo "node_wallets=true" >> $GITHUB_OUTPUT
+                  if echo ",$PACKAGES," | grep -q ",wallets/typescript,"; then
+                    echo "wallets_typescript=true" >> $GITHUB_OUTPUT
                   fi
-                  if echo ",$PACKAGES," | grep -q ",react-checkout,"; then
-                    echo "react_checkout=true" >> $GITHUB_OUTPUT
+                  if echo ",$PACKAGES," | grep -q ",checkout/react,"; then
+                    echo "checkout_react=true" >> $GITHUB_OUTPUT
                   fi
-                  if echo ",$PACKAGES," | grep -q ",react-native-checkout,"; then
-                    echo "react_native_checkout=true" >> $GITHUB_OUTPUT
+                  if echo ",$PACKAGES," | grep -q ",checkout/react-native,"; then
+                    echo "checkout_react_native=true" >> $GITHUB_OUTPUT
                   fi
 
             - name: Generate React UI docs (wallets)
-              if: steps.packages.outputs.react_ui == 'true'
+              if: steps.packages.outputs.wallets_react == 'true'
               working-directory: packages/client/ui/react-ui
               run: pnpm generate:docs --product wallets
 
             - name: Generate React UI docs (checkout)
-              if: steps.packages.outputs.react_checkout == 'true'
+              if: steps.packages.outputs.checkout_react == 'true'
               working-directory: packages/client/ui/react-ui
               run: pnpm generate:docs --product checkout
 
             - name: Generate React Native docs (wallets)
-              if: steps.packages.outputs.react_native == 'true'
+              if: steps.packages.outputs.wallets_react_native == 'true'
               working-directory: packages/client/ui/react-native
               run: pnpm generate:docs --product wallets
 
             - name: Generate React Native docs (checkout)
-              if: steps.packages.outputs.react_native_checkout == 'true'
+              if: steps.packages.outputs.checkout_react_native == 'true'
               working-directory: packages/client/ui/react-native
               run: pnpm generate:docs --product checkout
 
             - name: Generate Node Wallets SDK docs
-              if: steps.packages.outputs.node_wallets == 'true'
+              if: steps.packages.outputs.wallets_typescript == 'true'
               working-directory: packages/wallets
               run: |
                   pnpm generate:docs
@@ -114,11 +114,11 @@ jobs:
 
             - name: Collect generated files
               env:
-                  REACT_UI_ENABLED: ${{ steps.packages.outputs.react_ui }}
-                  REACT_NATIVE_ENABLED: ${{ steps.packages.outputs.react_native }}
-                  NODE_WALLETS_ENABLED: ${{ steps.packages.outputs.node_wallets }}
-                  CHECKOUT_ENABLED: ${{ steps.packages.outputs.react_checkout }}
-                  RN_CHECKOUT_ENABLED: ${{ steps.packages.outputs.react_native_checkout }}
+                  WALLETS_REACT_ENABLED: ${{ steps.packages.outputs.wallets_react }}
+                  WALLETS_REACT_NATIVE_ENABLED: ${{ steps.packages.outputs.wallets_react_native }}
+                  WALLETS_TYPESCRIPT_ENABLED: ${{ steps.packages.outputs.wallets_typescript }}
+                  CHECKOUT_REACT_ENABLED: ${{ steps.packages.outputs.checkout_react }}
+                  CHECKOUT_REACT_NATIVE_ENABLED: ${{ steps.packages.outputs.checkout_react_native }}
               run: |
                   mkdir -p sdk-reference/wallets/react
                   mkdir -p sdk-reference/wallets/react-native
@@ -126,23 +126,23 @@ jobs:
                   mkdir -p sdk-reference/checkout/react
                   mkdir -p sdk-reference/checkout/react-native
 
-                  if [ "$REACT_UI_ENABLED" == "true" ] && [ -d packages/client/ui/react-ui/docs/wallets ]; then
+                  if [ "$WALLETS_REACT_ENABLED" == "true" ] && [ -d packages/client/ui/react-ui/docs/wallets ]; then
                     cp -r packages/client/ui/react-ui/docs/wallets/. sdk-reference/wallets/react/
                   fi
 
-                  if [ "$REACT_NATIVE_ENABLED" == "true" ] && [ -d packages/client/ui/react-native/docs/wallets ]; then
+                  if [ "$WALLETS_REACT_NATIVE_ENABLED" == "true" ] && [ -d packages/client/ui/react-native/docs/wallets ]; then
                     cp -r packages/client/ui/react-native/docs/wallets/. sdk-reference/wallets/react-native/
                   fi
 
-                  if [ "$NODE_WALLETS_ENABLED" == "true" ] && [ -d packages/wallets/docs ]; then
+                  if [ "$WALLETS_TYPESCRIPT_ENABLED" == "true" ] && [ -d packages/wallets/docs ]; then
                     cp -r packages/wallets/docs/. sdk-reference/wallets/typescript/
                   fi
 
-                  if [ "$CHECKOUT_ENABLED" == "true" ] && [ -d packages/client/ui/react-ui/docs/checkout ]; then
+                  if [ "$CHECKOUT_REACT_ENABLED" == "true" ] && [ -d packages/client/ui/react-ui/docs/checkout ]; then
                     cp -r packages/client/ui/react-ui/docs/checkout/. sdk-reference/checkout/react/
                   fi
 
-                  if [ "$RN_CHECKOUT_ENABLED" == "true" ] && [ -d packages/client/ui/react-native/docs/checkout ]; then
+                  if [ "$CHECKOUT_REACT_NATIVE_ENABLED" == "true" ] && [ -d packages/client/ui/react-native/docs/checkout ]; then
                     cp -r packages/client/ui/react-native/docs/checkout/. sdk-reference/checkout/react-native/
                   fi
 
@@ -176,4 +176,4 @@ jobs:
                   token: ${{ steps.generate_app_token.outputs.token }}
                   repository: Paella-Labs/crossbit-main
                   event-type: sdk-reference-docs-update
-                  client-payload: '{"run_id": "${{ github.run_id }}", "packages": ${{ toJSON(inputs.packages || ''react-ui,react-native,node-wallets,react-checkout,react-native-checkout'') }}, "source_repo": "crossmint-sdk", "source_ref": ${{ toJSON(github.ref_name) }}}'
+                  client-payload: '{"run_id": "${{ github.run_id }}", "packages": ${{ toJSON(inputs.packages || ''wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native'') }}, "source_repo": "crossmint-sdk", "source_ref": ${{ toJSON(github.ref_name) }}}'


### PR DESCRIPTION
## Description

Part of [DVRL-1307](https://linear.app/crossmint/issue/DVRL-1307): renames all dispatch package names in `sdk-reference-docs-generate.yml` from legacy flat names to `{product}/{lang}` format.

```diff
# packages input default
- "react-ui,react-native,node-wallets,react-checkout,react-native-checkout"
+ "wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native"

# dispatch payload
- "packages": "react-ui,react-native,node-wallets,react-checkout,react-native-checkout"
+ "packages": "wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native"
```

All step output variable names and env vars updated to match (`wallets_react`, `checkout_react_native`, etc.). The receiver in crossbit-main ([PR #27234](https://github.com/Paella-Labs/crossbit-main/pull/27234)) already accepts both old and new formats.

## Test plan

- Workflow-only change; no runtime code or packages affected
- The crossbit-main receiver workflow already accepts the new format via `resolvePackage()` split-on-`/` parsing
- Old format is also still accepted via `legacyPackageMap` fallback during the transition

## Package updates

No package updates.

Link to Devin session: https://crossmint.devinenterprise.com/sessions/887eb0cd4b564b41bf40bcc42d343d0d
Requested by: @jmderby