### PR TITLE
fix(e2e): reuse persistent test wallets to stop devnet faucet failures

### DIFF
--- a/.github/workflows/e2e-regression-tests.yml
+++ b/.github/workflows/e2e-regression-tests.yml
@@ -55,6 +55,10 @@ jobs:
                   MAILOSAUR_SERVER_ID: ${{ secrets.SERVER_ID_MAILOSAUR }}
                   MAILOSAUR_PHONE_NUMBER: ${{ secrets.PHONE_NUMBER_MAILOSAUR }}
                   PLAYWRIGHT_BASE_URL: "http://localhost:3000"
+                  # Per-browser wallet identity: browser jobs run concurrently, and
+                  # simultaneous OTP requests for the same email get rate-limited/blocked.
+                  # Each browser gets its own persistent wallet, reused across runs.
+                  TESTS_WALLET_EMAIL_SUFFIX: e2e-${{ matrix.browser }}
               run: |
                   mkdir -p test-results
                   pnpm exec playwright test --project=${{ matrix.browser }} || true

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -56,6 +56,9 @@ jobs:
                   MAILOSAUR_SERVER_ID: ${{ secrets.SERVER_ID_MAILOSAUR }}
                   MAILOSAUR_PHONE_NUMBER: ${{ secrets.PHONE_NUMBER_MAILOSAUR }}
                   PLAYWRIGHT_BASE_URL: "http://localhost:3000"
+                  # Dedicated persistent wallet identity so smoke runs never share
+                  # emails (and OTP requests) with concurrently running e2e jobs.
+                  TESTS_WALLET_EMAIL_SUFFIX: smoke
               run: |
                   pnpm exec playwright test --project=smoke
 

--- a/apps/wallets/quickstart-devkit/tests/e2e/specs/wallets/e2e.spec.ts
+++ b/apps/wallets/quickstart-devkit/tests/e2e/specs/wallets/e2e.spec.ts
@@ -54,7 +54,7 @@ test.describe("Wallet E2E", { tag: "@critical" }, () => {
                 const walletAddress = await getWalletAddress(authenticatedPage);
                 // Transfer the minimum practical amount so the reused wallet's funds
                 // last across many runs without needing the faucet.
-                const transferAmount = "0.01";
+                const transferAmount = "0.001";
 
                 // Only hit the faucet when the reused wallet doesn't have enough USDXM
                 const initialBalance = await getWalletBalance(authenticatedPage);
@@ -117,7 +117,7 @@ test.describe("Wallet E2E", { tag: "@critical" }, () => {
 
                 // Transfer the minimum practical amount so the reused wallet's funds
                 // last across many runs without needing the faucet.
-                const transferAmount = "0.01";
+                const transferAmount = "0.001";
                 const walletAddress = await getWalletAddress(authenticatedPage);
 
                 // Only hit the faucet when the reused wallet doesn't have enough USDXM

--- a/apps/wallets/quickstart-devkit/tests/e2e/specs/wallets/e2e.spec.ts
+++ b/apps/wallets/quickstart-devkit/tests/e2e/specs/wallets/e2e.spec.ts
@@ -52,27 +52,27 @@ test.describe("Wallet E2E", { tag: "@critical" }, () => {
 
             test("transfers funds", async ({ authenticatedPage, testConfig }) => {
                 const walletAddress = await getWalletAddress(authenticatedPage);
+                // Transfer the minimum practical amount so the reused wallet's funds
+                // last across many runs without needing the faucet.
+                const transferAmount = "0.01";
 
-                // Fund wallet before transfer test
-                await fundWalletWithCrossmintFaucet(walletAddress, testConfig.chainId);
+                // Only hit the faucet when the reused wallet doesn't have enough USDXM
+                const initialBalance = await getWalletBalance(authenticatedPage);
+                const initialBalanceNum = parseFloat(initialBalance);
+                if (initialBalanceNum < parseFloat(transferAmount)) {
+                    await fundWalletWithCrossmintFaucet(walletAddress, testConfig.chainId);
+                    // Wait a moment for the funding to complete
+                    await authenticatedPage.waitForTimeout(2000);
+                } else {
+                    console.log(`✅ Wallet already holds ${initialBalanceNum} USDXM, skipping faucet`);
+                }
+
                 // Solana token transfers require native SOL for transaction fees.
                 // The Crossmint faucet only funds USDXM; without SOL the tx is
                 // submitted but never confirms (silent on-chain failure).
+                // Skips internally when the reused wallet already holds SOL.
                 if (testConfig.chain === "solana") {
                     await fundWalletWithSolAirdrop(walletAddress);
-                }
-                // Wait a moment for the funding to complete
-                await authenticatedPage.waitForTimeout(2000);
-
-                const initialBalance = await getWalletBalance(authenticatedPage);
-                const initialBalanceNum = parseFloat(initialBalance);
-
-                // Log warning if balance is low but continue with test
-                if (initialBalanceNum < 0.0001) {
-                    console.log(
-                        `⚠️ ${testConfig.chain}:${testConfig.signer}:${walletAddress} wallet balance is low (${initialBalanceNum}). Test may fail if insufficient funds.`
-                    );
-                    console.log(`💡 Please fund wallet: ${walletAddress} with some stablecoin for successful transfer`);
                 }
 
                 let recipientAddress: string;
@@ -86,7 +86,7 @@ test.describe("Wallet E2E", { tag: "@critical" }, () => {
                     throw new Error(`Unknown chain: ${(testConfig as { chain: string }).chain}`);
                 }
 
-                await transferFunds(authenticatedPage, recipientAddress, "10", testConfig.signer);
+                await transferFunds(authenticatedPage, recipientAddress, transferAmount, testConfig.signer);
 
                 console.log(
                     `✅ ${testConfig.provider}/${testConfig.chain}/${testConfig.signer} transfer completed successfully!`
@@ -115,21 +115,20 @@ test.describe("Wallet E2E", { tag: "@critical" }, () => {
                     throw new Error(`Unknown chain: ${(testConfig as { chain: string }).chain}`);
                 }
 
-                const transferAmount = "10";
+                // Transfer the minimum practical amount so the reused wallet's funds
+                // last across many runs without needing the faucet.
+                const transferAmount = "0.01";
                 const walletAddress = await getWalletAddress(authenticatedPage);
 
-                // Fund wallet before prepared transaction test with the same amount we'll transfer
-                await fundWalletWithCrossmintFaucet(walletAddress, testConfig.chainId, 10);
-                // Wait a moment for the funding to complete
-                await authenticatedPage.waitForTimeout(2000);
-
-                // Check wallet balance and log warning if 0
+                // Only hit the faucet when the reused wallet doesn't have enough USDXM
                 const initialBalance = await getWalletBalance(authenticatedPage);
                 const initialBalanceNum = parseFloat(initialBalance);
-
-                if (initialBalanceNum === 0) {
-                    console.log(`⚠️ Wallet ${walletAddress} has 0 balance. Test may fail if insufficient funds.`);
-                    console.log(`💡 Please fund wallet: ${walletAddress} with some USDXM for successful transaction`);
+                if (initialBalanceNum < parseFloat(transferAmount)) {
+                    await fundWalletWithCrossmintFaucet(walletAddress, testConfig.chainId, 10);
+                    // Wait a moment for the funding to complete
+                    await authenticatedPage.waitForTimeout(2000);
+                } else {
+                    console.log(`✅ Wallet already holds ${initialBalanceNum} USDXM, skipping faucet`);
                 }
 
                 const approvalTestHeading = authenticatedPage.locator("text=/Approval Method Test/i").first();

--- a/apps/wallets/quickstart-devkit/tests/shared/constants/globalConstants.ts
+++ b/apps/wallets/quickstart-devkit/tests/shared/constants/globalConstants.ts
@@ -73,7 +73,6 @@ export const TEST_RECIPIENT_WALLET_ADDRESSES = {
 };
 
 // Base email aliases for different signer types
-// Random numbers are appended to prevent email blocking
 const SIGNER_EMAIL_BASE: Record<SignerType, string> = {
     email: "email",
     phone: "phone",
@@ -82,41 +81,24 @@ const SIGNER_EMAIL_BASE: Record<SignerType, string> = {
     // "external-wallet": "external",
 };
 
-// Cache for email addresses per signer type to ensure consistency within a test run
-const emailCache = new Map<SignerType, string>();
-// Cache for timestamp suffix per signer type to ensure alias consistency
-const timestampSuffixCache = new Map<SignerType, number>();
+// Deterministic suffix so the same email (and therefore the same wallet) is reused
+// across test runs, retries, and browsers. Reusing wallets lets funding (USDXM and
+// devnet SOL) persist between runs instead of hammering faucets on every run.
+// Override via TESTS_WALLET_EMAIL_SUFFIX to rotate to a fresh identity if needed.
+const WALLET_EMAIL_SUFFIX = process.env.TESTS_WALLET_EMAIL_SUFFIX || "e2e";
 
-// Generate email address for a specific signer type with timestamp-based suffix to prevent blocking
-// The email is cached per signer type to ensure consistency within a test run
+// Deterministic email address for a specific signer type.
+// Same email every run = same Crossmint user = same (already funded) wallets.
 export function getEmailForSigner(signerType: SignerType): string {
-    // Return cached email if it exists
-    const cached = emailCache.get(signerType);
-    if (cached) {
-        return cached;
-    }
-
     const baseAlias = SIGNER_EMAIL_BASE[signerType];
-    // Use timestamp for unique email addresses (reused for Stellar alias)
-    const timestampSuffix = Date.now();
-    timestampSuffixCache.set(signerType, timestampSuffix);
-    const alias = `${baseAlias}${timestampSuffix}`;
-    const email = `test-${alias}@${AUTH_CONFIG.mailosaurServerId}.mailosaur.net`;
-
-    emailCache.set(signerType, email);
-    console.log(`📧 Generated and cached email for ${signerType}: ${email}`);
-
-    return email;
+    return `test-${baseAlias}-${WALLET_EMAIL_SUFFIX}@${AUTH_CONFIG.mailosaurServerId}.mailosaur.net`;
 }
 
-// Generate a unique alias for Stellar wallets based on the email's timestamp suffix
-// This ensures consistency - same email = same alias
+// Deterministic alias for Stellar wallets, derived from the same suffix as the email.
+// Same email + same alias = the same Stellar wallet is fetched on every run.
 export function getStellarAlias(signerType: SignerType): string {
-    const timestampSuffix = timestampSuffixCache.get(signerType) ?? Date.now();
-    if (!timestampSuffixCache.has(signerType)) {
-        timestampSuffixCache.set(signerType, timestampSuffix);
-    }
-    return `stellartestingwallet${timestampSuffix}`;
+    const sanitizedSuffix = WALLET_EMAIL_SUFFIX.toLowerCase().replace(/[^a-z0-9]/g, "");
+    return `stellartestingwallet${signerType}${sanitizedSuffix}`;
 }
 
 // Build URL with query parameters for testing

--- a/apps/wallets/quickstart-devkit/tests/shared/utils/wallet.ts
+++ b/apps/wallets/quickstart-devkit/tests/shared/utils/wallet.ts
@@ -90,7 +90,15 @@ export async function fundWalletWithSolAirdrop(walletAddress: string): Promise<v
         }
     }
 
-    console.error(`❌ All airdrop attempts failed for ${walletAddress} (balance: ${balanceSol} SOL)`);
+    // Re-check the balance: an airdrop may have landed on-chain even if its
+    // confirmation timed out, in which case the wallet is funded and we can proceed.
+    const finalBalanceSol = (await connection.getBalance(publicKey)) / LAMPORTS_PER_SOL;
+    if (finalBalanceSol >= MIN_SOL_FOR_FEES) {
+        console.log(`✅ Wallet ${walletAddress} holds ${finalBalanceSol} SOL despite airdrop errors, continuing`);
+        return;
+    }
+
+    console.error(`❌ All airdrop attempts failed for ${walletAddress} (balance: ${finalBalanceSol} SOL)`);
     throw lastError;
 }
 

--- a/apps/wallets/quickstart-devkit/tests/shared/utils/wallet.ts
+++ b/apps/wallets/quickstart-devkit/tests/shared/utils/wallet.ts
@@ -48,23 +48,50 @@ export async function fundWalletWithCrossmintFaucet(
     }
 }
 
+const SOLANA_DEVNET_RPC_URL = process.env.SOLANA_DEVNET_RPC_URL || "https://api.devnet.solana.com";
+// Minimum SOL needed to pay transfer fees + recipient ATA rent (~0.002 SOL).
+const MIN_SOL_FOR_FEES = 0.003;
+// Airdrop the maximum the devnet faucet allows, falling back to smaller amounts
+// (the per-request cap varies; large requests can fail with "Internal error").
+// Since test wallets are reused across runs, a single successful airdrop keeps
+// the wallet funded for thousands of transfers.
+const AIRDROP_AMOUNTS_SOL = [5, 2, 1, 0.1];
+
 /**
- * Airdrops native SOL from Solana devnet so the wallet can pay transaction fees.
+ * Ensures the wallet holds native SOL so it can pay transaction fees.
  * The Crossmint faucet only funds USDXM; without SOL the transfer tx is submitted
  * but never confirmed (silent on-chain failure due to insufficient fee balance).
+ *
+ * Skips the airdrop entirely when the (reused) wallet is already funded, so the
+ * heavily rate-limited devnet faucet is only hit when strictly necessary.
  */
-export async function fundWalletWithSolAirdrop(walletAddress: string, amountSol = 0.01): Promise<void> {
-    const connection = new Connection("https://api.devnet.solana.com", "confirmed");
-    console.log(`💰 Requesting SOL airdrop for ${walletAddress} (${amountSol} SOL)...`);
-    try {
-        const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash();
-        const signature = await connection.requestAirdrop(new PublicKey(walletAddress), amountSol * LAMPORTS_PER_SOL);
-        await connection.confirmTransaction({ signature, blockhash, lastValidBlockHeight }, "confirmed");
-        console.log(`✅ SOL airdrop confirmed for ${walletAddress}`);
-    } catch (error) {
-        console.error(`❌ Failed to airdrop SOL to ${walletAddress}:`, error);
-        throw error;
+export async function fundWalletWithSolAirdrop(walletAddress: string): Promise<void> {
+    const connection = new Connection(SOLANA_DEVNET_RPC_URL, "confirmed");
+    const publicKey = new PublicKey(walletAddress);
+
+    const balanceSol = (await connection.getBalance(publicKey)) / LAMPORTS_PER_SOL;
+    if (balanceSol >= MIN_SOL_FOR_FEES) {
+        console.log(`✅ Wallet ${walletAddress} already holds ${balanceSol} SOL, skipping airdrop`);
+        return;
     }
+
+    let lastError: unknown;
+    for (const amountSol of AIRDROP_AMOUNTS_SOL) {
+        console.log(`💰 Requesting SOL airdrop for ${walletAddress} (${amountSol} SOL)...`);
+        try {
+            const { blockhash, lastValidBlockHeight } = await connection.getLatestBlockhash();
+            const signature = await connection.requestAirdrop(publicKey, amountSol * LAMPORTS_PER_SOL);
+            await connection.confirmTransaction({ signature, blockhash, lastValidBlockHeight }, "confirmed");
+            console.log(`✅ SOL airdrop of ${amountSol} SOL confirmed for ${walletAddress}`);
+            return;
+        } catch (error) {
+            lastError = error;
+            console.warn(`⚠️ Airdrop of ${amountSol} SOL failed for ${walletAddress}:`, error);
+        }
+    }
+
+    console.error(`❌ All airdrop attempts failed for ${walletAddress} (balance: ${balanceSol} SOL)`);
+    throw lastError;
 }
 
 export async function getWalletAddress(page: Page): Promise<string> {

--- a/apps/wallets/quickstart-devkit/tests/smoke/specs/wallets/smoke.spec.ts
+++ b/apps/wallets/quickstart-devkit/tests/smoke/specs/wallets/smoke.spec.ts
@@ -107,7 +107,7 @@ test.describe("Wallet Smoke", { tag: "@smoke" }, () => {
         const walletAddress = await getWalletAddress(authenticatedPage);
         // Transfer the minimum practical amount so the reused wallet's funds
         // last across many runs without needing the faucet.
-        const transferAmount = "0.01";
+        const transferAmount = "0.001";
 
         // Only hit the faucet when the reused wallet doesn't have enough USDXM
         const balance = await getWalletBalance(authenticatedPage);
@@ -150,7 +150,7 @@ test.describe("Wallet Smoke", { tag: "@smoke" }, () => {
         const recipientAddress = TEST_RECIPIENT_WALLET_ADDRESSES.evm;
         // Transfer the minimum practical amount so the reused wallet's funds
         // last across many runs without needing the faucet.
-        const transferAmount = "0.01";
+        const transferAmount = "0.001";
         const walletAddress = await getWalletAddress(authenticatedPage);
 
         expectAuth(recipientAddress).toBeTruthy();

--- a/apps/wallets/quickstart-devkit/tests/smoke/specs/wallets/smoke.spec.ts
+++ b/apps/wallets/quickstart-devkit/tests/smoke/specs/wallets/smoke.spec.ts
@@ -105,25 +105,27 @@ test.describe("Wallet Smoke", { tag: "@smoke" }, () => {
 
     test("transfers funds", async ({ authenticatedPage, testConfig }) => {
         const walletAddress = await getWalletAddress(authenticatedPage);
+        // Transfer the minimum practical amount so the reused wallet's funds
+        // last across many runs without needing the faucet.
+        const transferAmount = "0.01";
 
-        // Fund wallet before transfer test
-        await fundWalletWithCrossmintFaucet(walletAddress, testConfig.chainId);
+        // Only hit the faucet when the reused wallet doesn't have enough USDXM
+        const balance = await getWalletBalance(authenticatedPage);
+        const balanceNum = parseFloat(balance);
+        if (balanceNum < parseFloat(transferAmount)) {
+            await fundWalletWithCrossmintFaucet(walletAddress, testConfig.chainId);
+            // Wait a moment for the funding to complete
+            await authenticatedPage.waitForTimeout(2000);
+        } else {
+            console.log(`✅ Wallet already holds ${balanceNum} USDXM, skipping faucet`);
+        }
+
         // Solana token transfers require native SOL for transaction fees.
         // The Crossmint faucet only funds USDXM; without SOL the tx is
         // submitted but never confirms (silent on-chain failure).
+        // Skips internally when the reused wallet already holds SOL.
         if (testConfig.chain === "solana") {
             await fundWalletWithSolAirdrop(walletAddress);
-        }
-        // Wait a moment for the funding to complete
-        await authenticatedPage.waitForTimeout(2000);
-
-        // Check wallet balance and log warning if 0
-        const balance = await getWalletBalance(authenticatedPage);
-        const balanceNum = parseFloat(balance);
-
-        if (balanceNum === 0) {
-            console.log(`⚠️ Wallet ${walletAddress} has 0 balance. Test may fail if insufficient funds.`);
-            console.log(`💡 Please fund wallet: ${walletAddress} with some USDXM to run this test`);
         }
 
         let recipientAddress: string;
@@ -137,7 +139,7 @@ test.describe("Wallet Smoke", { tag: "@smoke" }, () => {
                 : TEST_RECIPIENT_WALLET_ADDRESSES.solana;
         }
 
-        await transferFunds(authenticatedPage, recipientAddress, "10", testConfig.signer);
+        await transferFunds(authenticatedPage, recipientAddress, transferAmount, testConfig.signer);
 
         console.log(
             `✅ ${testConfig.provider}/${testConfig.chain}/${testConfig.signer} transfer completed successfully!`
@@ -146,7 +148,9 @@ test.describe("Wallet Smoke", { tag: "@smoke" }, () => {
 
     test("creates and approves a prepared transaction", async ({ authenticatedPage, testConfig }) => {
         const recipientAddress = TEST_RECIPIENT_WALLET_ADDRESSES.evm;
-        const transferAmount = "10";
+        // Transfer the minimum practical amount so the reused wallet's funds
+        // last across many runs without needing the faucet.
+        const transferAmount = "0.01";
         const walletAddress = await getWalletAddress(authenticatedPage);
 
         expectAuth(recipientAddress).toBeTruthy();
@@ -154,18 +158,15 @@ test.describe("Wallet Smoke", { tag: "@smoke" }, () => {
         expectAuth(recipientAddress.length).toBe(42);
         expectAuth(/^0x[a-fA-F0-9]{40}$/.test(recipientAddress)).toBe(true);
 
-        // Fund wallet before prepared transaction test with the same amount we'll transfer
-        await fundWalletWithCrossmintFaucet(walletAddress, testConfig.chainId, 10);
-        // Wait a moment for the funding to complete
-        await authenticatedPage.waitForTimeout(2000);
-
-        // Check wallet balance and log warning if 0
+        // Only hit the faucet when the reused wallet doesn't have enough USDXM
         const initialBalance = await getWalletBalance(authenticatedPage);
         const initialBalanceNum = parseFloat(initialBalance);
-
-        if (initialBalanceNum === 0) {
-            console.log(`⚠️ Wallet ${walletAddress} has 0 balance. Test may fail if insufficient funds.`);
-            console.log(`💡 Please fund wallet: ${walletAddress} with some USDXM to run this test`);
+        if (initialBalanceNum < parseFloat(transferAmount)) {
+            await fundWalletWithCrossmintFaucet(walletAddress, testConfig.chainId, 10);
+            // Wait a moment for the funding to complete
+            await authenticatedPage.waitForTimeout(2000);
+        } else {
+            console.log(`✅ Wallet already holds ${initialBalanceNum} USDXM, skipping faucet`);
         }
 
         //check approval test heading


### PR DESCRIPTION
## Summary

Fixes the chronic `Wallet E2E › crossmint - solana - email/phone › transfers funds` failures in the scheduled [E2E Regression Tests](https://github.com/Crossmint/crossmint-sdk/actions/runs/28778603481) (failing on all 3 browsers).

**Root cause:** every run created a brand-new wallet and requested a SOL airdrop from the public devnet faucet, which is permanently rate-limited (`429 Too Many Requests`) from shared GitHub Actions IPs — ~18 airdrop requests per run (2 configs × 3 retries × 3 browsers).

**Fix — reuse wallets so faucets are only needed rarely:**
- Test emails are now deterministic (`test-email-e2e@…`, `test-phone-e2e@…`) instead of timestamped, so the same wallets — and their funding — persist across runs, retries, and browsers. Rotate to a fresh identity via `TESTS_WALLET_EMAIL_SUFFIX` if ever needed. The Stellar alias is derived deterministically as well.
- `fundWalletWithSolAirdrop` checks the on-chain SOL balance first and skips the airdrop when the wallet is already funded. When funding is needed it requests the maximum with fallbacks (5 → 2 → 1 → 0.1 SOL), so a single successful airdrop keeps the wallet funded for thousands of transfers. Devnet RPC is overridable via `SOLANA_DEVNET_RPC_URL` (e.g. a Helius key can be slotted in later with no code change).
- The USDXM faucet is only called when the balance is below the transfer amount, and transfers were reduced from 10 to 0.01 USDXM so one 10 USDXM funding lasts ~1000 runs.

Faucet pressure drops from ~18 requests/run to at most 4, and to 0 once the wallet is seeded.

## Test plan

- [x] `tsc --noEmit` and `biome check` clean on changed files (only pre-existing warnings)
- [x] `playwright test --list` discovers all 75 tests
- [x] Ran `crossmint - solana - email` locally: deterministic-email auth passes, persistent wallet received 10 USDXM, balance-check + airdrop fallback chain executes as designed (airdrop itself still 429'd — faucet was dry from this IP today; first successful airdrop anywhere seeds the wallet permanently)
- [ ] Monitor the next scheduled E2E regression runs