### PR TITLE
docs: add auth product to SDK reference docs generation (TS,React, React native)

### DIFF
--- a/.changeset/auth-sdk-reference-docs-rn.md
+++ b/.changeset/auth-sdk-reference-docs-rn.md
@@ -1,0 +1,6 @@
+---
+"@crossmint/client-sdk-react-native-ui": patch
+"@crossmint/client-sdk-react-base": patch
+---
+
+Add JSDoc descriptions to React Native auth provider, hook, and prop types for SDK reference docs

--- a/.changeset/auth-sdk-reference-docs-typescript.md
+++ b/.changeset/auth-sdk-reference-docs-typescript.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/server-sdk": patch
+---
+
+Add SDK reference docs generation (TypeDoc) and JSDoc comments for the auth API. Also export the `CrossmintAuthServerOptions`, `GenericRequest`, and `GenericResponse` types.

--- a/.changeset/auth-sdk-reference-docs.md
+++ b/.changeset/auth-sdk-reference-docs.md
@@ -1,0 +1,6 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+"@crossmint/client-sdk-react-base": patch
+---
+
+Add JSDoc descriptions to auth provider, hook, and prop types for SDK reference docs

--- a/.github/workflows/sdk-reference-docs-generate.yml
+++ b/.github/workflows/sdk-reference-docs-generate.yml
@@ -8,6 +8,11 @@ on:
             - "packages/wallets/typedoc.json"
             - "packages/wallets/tsconfig.typedoc.json"
             - "packages/wallets/typedoc-custom-plugin.mjs"
+            - "packages/server/src/**"
+            - "packages/server/README.md"
+            - "packages/server/typedoc.json"
+            - "packages/server/tsconfig.typedoc.json"
+            - "packages/server/typedoc-custom-plugin.mjs"
             - "packages/client/ui/react-ui/src/**"
             - "packages/client/ui/react-ui/scripts/**"
             - "packages/client/ui/react-ui/examples.json"
@@ -27,9 +32,9 @@ on:
     workflow_dispatch:
         inputs:
             packages:
-                description: "Comma-separated list of packages to generate docs for (wallets/react, wallets/react-native, wallets/typescript, checkout/react, checkout/react-native, auth/react, auth/react-native). Defaults to all."
+                description: "Comma-separated list of packages to generate docs for (wallets/react, wallets/react-native, wallets/typescript, checkout/react, checkout/react-native, auth/react, auth/react-native, auth/typescript). Defaults to all."
                 required: false
-                default: "wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native,auth/react,auth/react-native"
+                default: "wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native,auth/react,auth/react-native,auth/typescript"
                 type: string
 
 permissions:
@@ -56,7 +61,7 @@ jobs:
             - name: Parse package selection
               id: packages
               env:
-                  PACKAGES_INPUT: ${{ inputs.packages || 'wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native,auth/react,auth/react-native' }}
+                  PACKAGES_INPUT: ${{ inputs.packages || 'wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native,auth/react,auth/react-native,auth/typescript' }}
               run: |
                   PACKAGES="$PACKAGES_INPUT"
                   echo "wallets_react=false" >> $GITHUB_OUTPUT
@@ -66,6 +71,7 @@ jobs:
                   echo "checkout_react_native=false" >> $GITHUB_OUTPUT
                   echo "auth_react=false" >> $GITHUB_OUTPUT
                   echo "auth_react_native=false" >> $GITHUB_OUTPUT
+                  echo "auth_typescript=false" >> $GITHUB_OUTPUT
                   if echo ",$PACKAGES," | grep -q ",wallets/react,"; then
                     echo "wallets_react=true" >> $GITHUB_OUTPUT
                   fi
@@ -86,6 +92,9 @@ jobs:
                   fi
                   if echo ",$PACKAGES," | grep -q ",auth/react-native,"; then
                     echo "auth_react_native=true" >> $GITHUB_OUTPUT
+                  fi
+                  if echo ",$PACKAGES," | grep -q ",auth/typescript,"; then
+                    echo "auth_typescript=true" >> $GITHUB_OUTPUT
                   fi
 
             - name: Generate React UI docs (wallets)
@@ -130,6 +139,18 @@ jobs:
                     mv docs/README.mdx docs/overview.mdx
                   fi
 
+            - name: Generate Node Server SDK docs (auth)
+              if: steps.packages.outputs.auth_typescript == 'true'
+              working-directory: packages/server
+              run: |
+                  pnpm generate:docs
+                  if [ -f docs/auth/globals.mdx ]; then
+                    mv docs/auth/globals.mdx docs/auth/reference.mdx
+                  fi
+                  if [ -f docs/auth/README.mdx ]; then
+                    mv docs/auth/README.mdx docs/auth/overview.mdx
+                  fi
+
             - name: Collect generated files
               env:
                   WALLETS_REACT_ENABLED: ${{ steps.packages.outputs.wallets_react }}
@@ -139,6 +160,7 @@ jobs:
                   CHECKOUT_REACT_NATIVE_ENABLED: ${{ steps.packages.outputs.checkout_react_native }}
                   AUTH_REACT_ENABLED: ${{ steps.packages.outputs.auth_react }}
                   AUTH_REACT_NATIVE_ENABLED: ${{ steps.packages.outputs.auth_react_native }}
+                  AUTH_TYPESCRIPT_ENABLED: ${{ steps.packages.outputs.auth_typescript }}
               run: |
                   mkdir -p sdk-reference/wallets/react
                   mkdir -p sdk-reference/wallets/react-native
@@ -147,6 +169,7 @@ jobs:
                   mkdir -p sdk-reference/checkout/react-native
                   mkdir -p sdk-reference/auth/react
                   mkdir -p sdk-reference/auth/react-native
+                  mkdir -p sdk-reference/auth/typescript
 
                   if [ "$WALLETS_REACT_ENABLED" == "true" ] && [ -d packages/client/ui/react-ui/docs/wallets ]; then
                     cp -r packages/client/ui/react-ui/docs/wallets/. sdk-reference/wallets/react/
@@ -174,6 +197,10 @@ jobs:
 
                   if [ "$AUTH_REACT_NATIVE_ENABLED" == "true" ] && [ -d packages/client/ui/react-native/docs/auth ]; then
                     cp -r packages/client/ui/react-native/docs/auth/. sdk-reference/auth/react-native/
+                  fi
+
+                  if [ "$AUTH_TYPESCRIPT_ENABLED" == "true" ] && [ -d packages/server/docs/auth ]; then
+                    cp -r packages/server/docs/auth/. sdk-reference/auth/typescript/
                   fi
 
             - name: Verify at least one package was generated
@@ -206,4 +233,4 @@ jobs:
                   token: ${{ steps.generate_app_token.outputs.token }}
                   repository: Paella-Labs/crossbit-main
                   event-type: sdk-reference-docs-update
-                  client-payload: '{"run_id": "${{ github.run_id }}", "packages": ${{ toJSON(inputs.packages || ''wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native,auth/react,auth/react-native'') }}, "source_repo": "crossmint-sdk", "source_ref": ${{ toJSON(github.ref_name) }}}'
+                  client-payload: '{"run_id": "${{ github.run_id }}", "packages": ${{ toJSON(inputs.packages || ''wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native,auth/react,auth/react-native,auth/typescript'') }}, "source_repo": "crossmint-sdk", "source_ref": ${{ toJSON(github.ref_name) }}}'

--- a/.github/workflows/sdk-reference-docs-generate.yml
+++ b/.github/workflows/sdk-reference-docs-generate.yml
@@ -27,9 +27,9 @@ on:
     workflow_dispatch:
         inputs:
             packages:
-                description: "Comma-separated list of packages to generate docs for (wallets/react, wallets/react-native, wallets/typescript, checkout/react, checkout/react-native, auth/react). Defaults to all."
+                description: "Comma-separated list of packages to generate docs for (wallets/react, wallets/react-native, wallets/typescript, checkout/react, checkout/react-native, auth/react, auth/react-native). Defaults to all."
                 required: false
-                default: "wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native,auth/react"
+                default: "wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native,auth/react,auth/react-native"
                 type: string
 
 permissions:
@@ -56,7 +56,7 @@ jobs:
             - name: Parse package selection
               id: packages
               env:
-                  PACKAGES_INPUT: ${{ inputs.packages || 'wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native,auth/react' }}
+                  PACKAGES_INPUT: ${{ inputs.packages || 'wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native,auth/react,auth/react-native' }}
               run: |
                   PACKAGES="$PACKAGES_INPUT"
                   echo "wallets_react=false" >> $GITHUB_OUTPUT
@@ -65,6 +65,7 @@ jobs:
                   echo "checkout_react=false" >> $GITHUB_OUTPUT
                   echo "checkout_react_native=false" >> $GITHUB_OUTPUT
                   echo "auth_react=false" >> $GITHUB_OUTPUT
+                  echo "auth_react_native=false" >> $GITHUB_OUTPUT
                   if echo ",$PACKAGES," | grep -q ",wallets/react,"; then
                     echo "wallets_react=true" >> $GITHUB_OUTPUT
                   fi
@@ -82,6 +83,9 @@ jobs:
                   fi
                   if echo ",$PACKAGES," | grep -q ",auth/react,"; then
                     echo "auth_react=true" >> $GITHUB_OUTPUT
+                  fi
+                  if echo ",$PACKAGES," | grep -q ",auth/react-native,"; then
+                    echo "auth_react_native=true" >> $GITHUB_OUTPUT
                   fi
 
             - name: Generate React UI docs (wallets)
@@ -103,6 +107,11 @@ jobs:
               if: steps.packages.outputs.wallets_react_native == 'true'
               working-directory: packages/client/ui/react-native
               run: pnpm generate:docs --product wallets
+
+            - name: Generate React Native docs (auth)
+              if: steps.packages.outputs.auth_react_native == 'true'
+              working-directory: packages/client/ui/react-native
+              run: pnpm generate:docs --product auth
 
             - name: Generate React Native docs (checkout)
               if: steps.packages.outputs.checkout_react_native == 'true'
@@ -129,6 +138,7 @@ jobs:
                   CHECKOUT_REACT_ENABLED: ${{ steps.packages.outputs.checkout_react }}
                   CHECKOUT_REACT_NATIVE_ENABLED: ${{ steps.packages.outputs.checkout_react_native }}
                   AUTH_REACT_ENABLED: ${{ steps.packages.outputs.auth_react }}
+                  AUTH_REACT_NATIVE_ENABLED: ${{ steps.packages.outputs.auth_react_native }}
               run: |
                   mkdir -p sdk-reference/wallets/react
                   mkdir -p sdk-reference/wallets/react-native
@@ -136,6 +146,7 @@ jobs:
                   mkdir -p sdk-reference/checkout/react
                   mkdir -p sdk-reference/checkout/react-native
                   mkdir -p sdk-reference/auth/react
+                  mkdir -p sdk-reference/auth/react-native
 
                   if [ "$WALLETS_REACT_ENABLED" == "true" ] && [ -d packages/client/ui/react-ui/docs/wallets ]; then
                     cp -r packages/client/ui/react-ui/docs/wallets/. sdk-reference/wallets/react/
@@ -159,6 +170,10 @@ jobs:
 
                   if [ "$AUTH_REACT_ENABLED" == "true" ] && [ -d packages/client/ui/react-ui/docs/auth ]; then
                     cp -r packages/client/ui/react-ui/docs/auth/. sdk-reference/auth/react/
+                  fi
+
+                  if [ "$AUTH_REACT_NATIVE_ENABLED" == "true" ] && [ -d packages/client/ui/react-native/docs/auth ]; then
+                    cp -r packages/client/ui/react-native/docs/auth/. sdk-reference/auth/react-native/
                   fi
 
             - name: Verify at least one package was generated
@@ -191,4 +206,4 @@ jobs:
                   token: ${{ steps.generate_app_token.outputs.token }}
                   repository: Paella-Labs/crossbit-main
                   event-type: sdk-reference-docs-update
-                  client-payload: '{"run_id": "${{ github.run_id }}", "packages": ${{ toJSON(inputs.packages || ''wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native,auth/react'') }}, "source_repo": "crossmint-sdk", "source_ref": ${{ toJSON(github.ref_name) }}}'
+                  client-payload: '{"run_id": "${{ github.run_id }}", "packages": ${{ toJSON(inputs.packages || ''wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native,auth/react,auth/react-native'') }}, "source_repo": "crossmint-sdk", "source_ref": ${{ toJSON(github.ref_name) }}}'

--- a/.github/workflows/sdk-reference-docs-generate.yml
+++ b/.github/workflows/sdk-reference-docs-generate.yml
@@ -27,9 +27,9 @@ on:
     workflow_dispatch:
         inputs:
             packages:
-                description: "Comma-separated list of packages to generate docs for (wallets/react, wallets/react-native, wallets/typescript, checkout/react, checkout/react-native). Defaults to all."
+                description: "Comma-separated list of packages to generate docs for (wallets/react, wallets/react-native, wallets/typescript, checkout/react, checkout/react-native, auth/react). Defaults to all."
                 required: false
-                default: "wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native"
+                default: "wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native,auth/react"
                 type: string
 
 permissions:
@@ -56,7 +56,7 @@ jobs:
             - name: Parse package selection
               id: packages
               env:
-                  PACKAGES_INPUT: ${{ inputs.packages || 'wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native' }}
+                  PACKAGES_INPUT: ${{ inputs.packages || 'wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native,auth/react' }}
               run: |
                   PACKAGES="$PACKAGES_INPUT"
                   echo "wallets_react=false" >> $GITHUB_OUTPUT
@@ -64,6 +64,7 @@ jobs:
                   echo "wallets_typescript=false" >> $GITHUB_OUTPUT
                   echo "checkout_react=false" >> $GITHUB_OUTPUT
                   echo "checkout_react_native=false" >> $GITHUB_OUTPUT
+                  echo "auth_react=false" >> $GITHUB_OUTPUT
                   if echo ",$PACKAGES," | grep -q ",wallets/react,"; then
                     echo "wallets_react=true" >> $GITHUB_OUTPUT
                   fi
@@ -79,6 +80,9 @@ jobs:
                   if echo ",$PACKAGES," | grep -q ",checkout/react-native,"; then
                     echo "checkout_react_native=true" >> $GITHUB_OUTPUT
                   fi
+                  if echo ",$PACKAGES," | grep -q ",auth/react,"; then
+                    echo "auth_react=true" >> $GITHUB_OUTPUT
+                  fi
 
             - name: Generate React UI docs (wallets)
               if: steps.packages.outputs.wallets_react == 'true'
@@ -89,6 +93,11 @@ jobs:
               if: steps.packages.outputs.checkout_react == 'true'
               working-directory: packages/client/ui/react-ui
               run: pnpm generate:docs --product checkout
+
+            - name: Generate React UI docs (auth)
+              if: steps.packages.outputs.auth_react == 'true'
+              working-directory: packages/client/ui/react-ui
+              run: pnpm generate:docs --product auth
 
             - name: Generate React Native docs (wallets)
               if: steps.packages.outputs.wallets_react_native == 'true'
@@ -119,12 +128,14 @@ jobs:
                   WALLETS_TYPESCRIPT_ENABLED: ${{ steps.packages.outputs.wallets_typescript }}
                   CHECKOUT_REACT_ENABLED: ${{ steps.packages.outputs.checkout_react }}
                   CHECKOUT_REACT_NATIVE_ENABLED: ${{ steps.packages.outputs.checkout_react_native }}
+                  AUTH_REACT_ENABLED: ${{ steps.packages.outputs.auth_react }}
               run: |
                   mkdir -p sdk-reference/wallets/react
                   mkdir -p sdk-reference/wallets/react-native
                   mkdir -p sdk-reference/wallets/typescript
                   mkdir -p sdk-reference/checkout/react
                   mkdir -p sdk-reference/checkout/react-native
+                  mkdir -p sdk-reference/auth/react
 
                   if [ "$WALLETS_REACT_ENABLED" == "true" ] && [ -d packages/client/ui/react-ui/docs/wallets ]; then
                     cp -r packages/client/ui/react-ui/docs/wallets/. sdk-reference/wallets/react/
@@ -144,6 +155,10 @@ jobs:
 
                   if [ "$CHECKOUT_REACT_NATIVE_ENABLED" == "true" ] && [ -d packages/client/ui/react-native/docs/checkout ]; then
                     cp -r packages/client/ui/react-native/docs/checkout/. sdk-reference/checkout/react-native/
+                  fi
+
+                  if [ "$AUTH_REACT_ENABLED" == "true" ] && [ -d packages/client/ui/react-ui/docs/auth ]; then
+                    cp -r packages/client/ui/react-ui/docs/auth/. sdk-reference/auth/react/
                   fi
 
             - name: Verify at least one package was generated
@@ -176,4 +191,4 @@ jobs:
                   token: ${{ steps.generate_app_token.outputs.token }}
                   repository: Paella-Labs/crossbit-main
                   event-type: sdk-reference-docs-update
-                  client-payload: '{"run_id": "${{ github.run_id }}", "packages": ${{ toJSON(inputs.packages || ''wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native'') }}, "source_repo": "crossmint-sdk", "source_ref": ${{ toJSON(github.ref_name) }}}'
+                  client-payload: '{"run_id": "${{ github.run_id }}", "packages": ${{ toJSON(inputs.packages || ''wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native,auth/react'') }}, "source_repo": "crossmint-sdk", "source_ref": ${{ toJSON(github.ref_name) }}}'

--- a/packages/client/react-base/src/types/auth.ts
+++ b/packages/client/react-base/src/types/auth.ts
@@ -26,8 +26,12 @@ export type CrossmintAuthBaseContextType = {
 
 export type CrossmintAuthBaseProviderProps = {
     children: ReactNode;
+    /** Callback invoked when the user successfully logs in. */
     onLoginSuccess?: () => void;
+    /** Custom route for refreshing the auth token, for server-side session management. */
     refreshRoute?: string;
+    /** Custom route for logging out, for server-side session management. */
     logoutRoute?: string;
+    /** Custom storage provider for auth material. Defaults to browser cookies. */
     storageProvider?: StorageProvider;
 };

--- a/packages/client/react-base/src/types/auth.ts
+++ b/packages/client/react-base/src/types/auth.ts
@@ -32,6 +32,6 @@ export type CrossmintAuthBaseProviderProps = {
     refreshRoute?: string;
     /** Custom route for logging out, for server-side session management. */
     logoutRoute?: string;
-    /** Custom storage provider for auth material. Defaults to browser cookies. */
+    /** Custom storage provider for auth material. Defaults to browser cookies on web and secure device storage on React Native. */
     storageProvider?: StorageProvider;
 };

--- a/packages/client/ui/react-native/examples.json
+++ b/packages/client/ui/react-native/examples.json
@@ -37,6 +37,24 @@
         "language": "tsx",
         "note": "Only works with email and phone signers. Will not render for passkey or external wallet signers."
     },
+    "rnAuthProviderSetup": {
+        "code": "import {\n    CrossmintProvider,\n    CrossmintAuthProvider,\n} from \"@crossmint/client-sdk-react-native-ui\";\n\nfunction App() {\n    return (\n        <CrossmintProvider apiKey=\"YOUR_CLIENT_API_KEY\">\n            <CrossmintAuthProvider appSchema=\"myapp://\">\n                {/* Your app components */}\n            </CrossmintAuthProvider>\n        </CrossmintProvider>\n    );\n}",
+        "language": "tsx"
+    },
+    "rnAuthQuickExample": {
+        "code": "import { useCrossmintAuth } from \"@crossmint/client-sdk-react-native-ui\";\nimport { View, Text, TouchableOpacity } from \"react-native\";\n\nfunction LoginScreen() {\n    const { loginWithOAuth, logout, user, status } = useCrossmintAuth();\n\n    if (status === \"initializing\") return <Text>Loading...</Text>;\n\n    if (user == null) {\n        return (\n            <TouchableOpacity onPress={() => loginWithOAuth(\"google\")}>\n                <Text>Sign in with Google</Text>\n            </TouchableOpacity>\n        );\n    }\n\n    return (\n        <View>\n            <Text>Welcome, {user.email}</Text>\n            <TouchableOpacity onPress={logout}>\n                <Text>Log out</Text>\n            </TouchableOpacity>\n        </View>\n    );\n}",
+        "language": "tsx"
+    },
+    "CrossmintAuthProvider": {
+        "code": "import {\n    CrossmintProvider,\n    CrossmintAuthProvider,\n} from \"@crossmint/client-sdk-react-native-ui\";\n\nfunction App() {\n    return (\n        <CrossmintProvider apiKey=\"YOUR_CLIENT_API_KEY\">\n            <CrossmintAuthProvider appSchema=\"myapp://\">\n                {/* Your app content */}\n            </CrossmintAuthProvider>\n        </CrossmintProvider>\n    );\n}",
+        "language": "tsx",
+        "note": "CrossmintAuthProvider must be nested inside CrossmintProvider. Set appSchema to your app's deep link scheme so OAuth redirects return to your app."
+    },
+    "useCrossmintAuth": {
+        "code": "import { useCrossmintAuth } from \"@crossmint/client-sdk-react-native-ui\";\nimport { View, Text, TouchableOpacity } from \"react-native\";\n\nfunction AuthStatus() {\n    const { loginWithOAuth, logout, user, jwt, status } = useCrossmintAuth();\n\n    if (status === \"initializing\") return <Text>Loading...</Text>;\n\n    return (\n        <View>\n            {user == null ? (\n                <TouchableOpacity onPress={() => loginWithOAuth(\"google\")}>\n                    <Text>Log in</Text>\n                </TouchableOpacity>\n            ) : (\n                <TouchableOpacity onPress={logout}>\n                    <Text>Log out ({user.email})</Text>\n                </TouchableOpacity>\n            )}\n        </View>\n    );\n}",
+        "language": "tsx",
+        "note": "Must be used within a CrossmintAuthProvider."
+    },
     "rnCheckoutProviderSetup": {
         "code": "import {\n    CrossmintProvider,\n    CrossmintCheckoutProvider,\n} from \"@crossmint/client-sdk-react-native-ui\";\n\nfunction App() {\n    return (\n        <CrossmintProvider apiKey=\"YOUR_CLIENT_API_KEY\">\n            <CrossmintCheckoutProvider>\n                {/* Your checkout components */}\n            </CrossmintCheckoutProvider>\n        </CrossmintProvider>\n    );\n}",
         "language": "tsx"

--- a/packages/client/ui/react-native/scripts/generate-reference.mjs
+++ b/packages/client/ui/react-native/scripts/generate-reference.mjs
@@ -48,6 +48,26 @@ see the [previous version of this page](/sdk-reference/wallets/v0/react-native/{
             quickExampleIntro: "Once providers are set up, use hooks to access wallet state:",
         },
     },
+    auth: {
+        outdir: "auth",
+        navPrefix: "sdk-reference/auth/react-native",
+        title: "React Native SDK",
+        description: "React Native SDK reference for Crossmint authentication",
+        packageName: "@crossmint/client-sdk-react-native-ui",
+        npmUrl: "https://www.npmjs.com/package/@crossmint/client-sdk-react-native-ui",
+        installSnippet: "client-sdk-react-native-ui-installation-cmd.mdx",
+        intro: "The Crossmint React Native SDK (`@crossmint/client-sdk-react-native-ui`) provides React Native providers and hooks for integrating Crossmint authentication into your mobile application, including email OTP, social login (OAuth), and session management.",
+        exports: ["CrossmintProvider", "CrossmintAuthProvider", "useCrossmintAuth"],
+        descriptions: {
+            CrossmintProvider: "SDK initialization (required for all Crossmint features)",
+            CrossmintAuthProvider: "Authentication state, login/logout, and the auth flow",
+        },
+        getStartedExamples: {
+            setup: "rnAuthProviderSetup",
+            quickExample: "rnAuthQuickExample",
+            quickExampleIntro: "Once providers are set up, use the `useCrossmintAuth` hook to access auth state:",
+        },
+    },
     checkout: {
         outdir: "checkout",
         navPrefix: "sdk-reference/checkout/react-native",

--- a/packages/client/ui/react-native/src/hooks/useAuth.ts
+++ b/packages/client/ui/react-native/src/hooks/useAuth.ts
@@ -8,6 +8,10 @@ interface RNCrossmintAuthContext extends CrossmintAuthBaseContextType {
     createAuthSession: (urlOrOneTimeSecret: string) => Promise<AuthMaterialWithUser | null>;
 }
 
+/**
+ * Access Crossmint authentication state and actions: `loginWithOAuth`, `logout`, the current `user`, `jwt`, and auth `status`.
+ * Must be used within a `CrossmintAuthProvider`.
+ */
 export function useCrossmintAuth(): RNCrossmintAuthContext {
     const context = useContext(AuthContext);
     if (context == null) {

--- a/packages/client/ui/react-native/src/providers/CrossmintAuthProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintAuthProvider.tsx
@@ -165,6 +165,11 @@ function CrossmintAuthProviderContent({
     );
 }
 
+/**
+ * Provides Crossmint authentication to your React Native app: social login (OAuth) and session management.
+ * Exposes auth state via the `useCrossmintAuth` hook and stores auth material in secure device storage.
+ * Must be nested inside `CrossmintProvider`.
+ */
 export function CrossmintAuthProvider({ children, ...props }: RNCrossmintAuthProviderProps) {
     const appSchema = props.appSchema ?? Constants.expoConfig?.scheme;
     const customStorageProvider = useMemo(() => props.storageProvider ?? new SecureStorage(), [props.storageProvider]);

--- a/packages/client/ui/react-native/src/types/auth.ts
+++ b/packages/client/ui/react-native/src/types/auth.ts
@@ -3,14 +3,20 @@ import type { CrossmintAuthBaseContextType, CrossmintAuthBaseProviderProps } fro
 import type { AuthMaterialWithUser, OAuthProvider, SDKExternalUser } from "@crossmint/common-sdk-auth";
 
 export interface RNAuthContext extends CrossmintAuthBaseContextType {
+    /** The currently authenticated user, if any. */
     user?: SDKExternalUser;
+    /** Initiate a login flow with the specified OAuth provider (e.g. "google", "twitter"). */
     loginWithOAuth: (provider: OAuthProvider) => Promise<void>;
+    /** Complete authentication from an OAuth callback URL or one-time secret (e.g. from a deep link). */
     createAuthSession: (urlOrOneTimeSecret: string) => Promise<AuthMaterialWithUser | null>;
 }
 
 export interface RNCrossmintAuthProviderProps extends CrossmintAuthBaseProviderProps {
+    /** Whether to prefetch OAuth provider URLs when the provider mounts. */
     prefetchOAuthUrls?: boolean;
+    /** Custom title for the auth modal. */
     authModalTitle?: string;
     children: ReactNode;
+    /** Your app's deep link scheme(s) (e.g. `"myapp://"`), used for OAuth redirects back into your app. */
     appSchema?: string | string[];
 }

--- a/packages/client/ui/react-native/typedoc.json
+++ b/packages/client/ui/react-native/typedoc.json
@@ -1,6 +1,7 @@
 {
     "entryPoints": [
         "src/index.ts",
+        "src/types/auth.ts",
         "../../base/src/types/embed/v3/CrossmintEmbeddedCheckoutV3Props.ts",
         "../../base/src/types/index.ts",
         "../../../common/base/src/types/uiconfig.ts"

--- a/packages/client/ui/react-ui/examples.json
+++ b/packages/client/ui/react-ui/examples.json
@@ -33,7 +33,7 @@
         "language": "tsx"
     },
     "EmbeddedAuthForm": {
-        "code": "import { CrossmintAuthProvider, EmbeddedAuthForm, useCrossmintAuth } from \"@crossmint/client-sdk-react-ui\";\n\nfunction LoginPage() {\n    const { status } = useCrossmintAuth();\n\n    if (status === \"logged-in\") {\n        return <p>You are logged in!</p>;\n    }\n\n    return (\n        <div style={{ maxWidth: 400, margin: \"0 auto\" }}>\n            <EmbeddedAuthForm />\n        </div>\n    );\n}",
+        "code": "import { EmbeddedAuthForm, useCrossmintAuth } from \"@crossmint/client-sdk-react-ui\";\n\nfunction LoginPage() {\n    const { status } = useCrossmintAuth();\n\n    if (status === \"logged-in\") {\n        return <p>You are logged in!</p>;\n    }\n\n    return (\n        <div style={{ maxWidth: 400, margin: \"0 auto\" }}>\n            <EmbeddedAuthForm />\n        </div>\n    );\n}",
         "language": "tsx",
         "note": "Must be rendered inside CrossmintAuthProvider. Renders the same auth form shown in the login modal, but inline in your page."
     },

--- a/packages/client/ui/react-ui/examples.json
+++ b/packages/client/ui/react-ui/examples.json
@@ -28,8 +28,22 @@
         "language": "tsx",
         "note": "CrossmintWalletProvider must be nested inside CrossmintProvider."
     },
-    "useAuth": {
-        "code": "import { useAuth } from \"@crossmint/client-sdk-react-ui\";\n\nfunction LoginButton() {\n    const { login, logout, user, status } = useAuth();\n\n    if (status === \"logged-in\") {\n        return (\n            <div>\n                <p>Welcome, {user?.email}</p>\n                <button onClick={logout}>Logout</button>\n            </div>\n        );\n    }\n\n    return <button onClick={() => login()}>Sign In</button>;\n}",
+    "useCrossmintAuth": {
+        "code": "import { useCrossmintAuth } from \"@crossmint/client-sdk-react-ui\";\n\nfunction LoginButton() {\n    const { login, logout, user, status } = useCrossmintAuth();\n\n    if (status === \"logged-in\") {\n        return (\n            <div>\n                <p>Welcome, {user?.email}</p>\n                <button onClick={logout}>Logout</button>\n            </div>\n        );\n    }\n\n    return <button onClick={() => login()}>Sign In</button>;\n}",
+        "language": "tsx"
+    },
+    "EmbeddedAuthForm": {
+        "code": "import { CrossmintAuthProvider, EmbeddedAuthForm, useCrossmintAuth } from \"@crossmint/client-sdk-react-ui\";\n\nfunction LoginPage() {\n    const { status } = useCrossmintAuth();\n\n    if (status === \"logged-in\") {\n        return <p>You are logged in!</p>;\n    }\n\n    return (\n        <div style={{ maxWidth: 400, margin: \"0 auto\" }}>\n            <EmbeddedAuthForm />\n        </div>\n    );\n}",
+        "language": "tsx",
+        "note": "Must be rendered inside CrossmintAuthProvider. Renders the same auth form shown in the login modal, but inline in your page."
+    },
+    "authProviderSetup": {
+        "code": "import {\n    CrossmintProvider,\n    CrossmintAuthProvider,\n} from \"@crossmint/client-sdk-react-ui\";\n\nfunction App() {\n    return (\n        <CrossmintProvider apiKey=\"YOUR_CLIENT_API_KEY\">\n            <CrossmintAuthProvider loginMethods={[\"email\", \"google\"]}>\n                {/* Your app content */}\n            </CrossmintAuthProvider>\n        </CrossmintProvider>\n    );\n}",
+        "language": "tsx",
+        "note": "CrossmintAuthProvider must be nested inside CrossmintProvider."
+    },
+    "authQuickExample": {
+        "code": "import { useCrossmintAuth } from \"@crossmint/client-sdk-react-ui\";\n\nfunction AuthButton() {\n    const { login, logout, user, status } = useCrossmintAuth();\n\n    if (status === \"logged-in\") {\n        return (\n            <div>\n                <p>Welcome, {user?.email}</p>\n                <button onClick={logout}>Logout</button>\n            </div>\n        );\n    }\n\n    return <button onClick={() => login()}>Sign In</button>;\n}",
         "language": "tsx"
     },
     "useWallet": {

--- a/packages/client/ui/react-ui/scripts/generate-reference.mjs
+++ b/packages/client/ui/react-ui/scripts/generate-reference.mjs
@@ -42,6 +42,27 @@ see the [previous version of this page](/sdk-reference/wallets/v0/react/{page}) 
             quickExampleIntro: "Once providers are set up, use hooks to access wallet state:",
         },
     },
+    auth: {
+        outdir: "auth",
+        navPrefix: "sdk-reference/auth/react",
+        title: "React SDK",
+        description: "React SDK reference for Crossmint authentication",
+        packageName: "@crossmint/client-sdk-react-ui",
+        npmUrl: "https://www.npmjs.com/package/@crossmint/client-sdk-react-ui",
+        installSnippet: "client-sdk-react-ui-installation-cmd.mdx",
+        intro: "The Crossmint React SDK (`@crossmint/client-sdk-react-ui`) provides React components and hooks for integrating Crossmint authentication into your application, including email OTP, social login (OAuth), and session management.",
+        exports: ["CrossmintProvider", "CrossmintAuthProvider", "useCrossmintAuth", "EmbeddedAuthForm"],
+        descriptions: {
+            CrossmintProvider: "SDK initialization (required for all Crossmint features)",
+            CrossmintAuthProvider: "Authentication state, login/logout, and the auth modal",
+            EmbeddedAuthForm: "Renders the Crossmint auth form inline instead of in a modal",
+        },
+        getStartedExamples: {
+            setup: "authProviderSetup",
+            quickExample: "authQuickExample",
+            quickExampleIntro: "Once providers are set up, use the `useCrossmintAuth` hook to access auth state:",
+        },
+    },
     checkout: {
         outdir: "checkout",
         navPrefix: "sdk-reference/checkout/react",

--- a/packages/client/ui/react-ui/src/components/auth/EmbeddedAuthForm.tsx
+++ b/packages/client/ui/react-ui/src/components/auth/EmbeddedAuthForm.tsx
@@ -1,5 +1,9 @@
 import { AuthForm } from "./AuthForm";
 
+/**
+ * Renders the Crossmint auth form inline in your page instead of in a modal.
+ * Displays the same login methods configured on `CrossmintAuthProvider`, which it must be rendered inside of.
+ */
 export function EmbeddedAuthForm() {
     return <AuthForm style={{ width: "100%" }} />;
 }

--- a/packages/client/ui/react-ui/src/hooks/useAuth.ts
+++ b/packages/client/ui/react-ui/src/hooks/useAuth.ts
@@ -4,9 +4,14 @@ import type { OAuthProvider } from "@crossmint/common-sdk-auth";
 import { AuthContext } from "@/providers";
 
 export interface CrossmintAuthContext extends CrossmintAuthBaseContextType {
+    /** Initiate a login flow with the specified OAuth provider (e.g. "google", "twitter"). */
     loginWithOAuth: (provider: OAuthProvider) => Promise<void>;
 }
 
+/**
+ * Access Crossmint authentication state and actions: `login`, `logout`, the current `user`, `jwt`, and auth `status`.
+ * Must be used within a `CrossmintAuthProvider`.
+ */
 export function useCrossmintAuth(): CrossmintAuthContext {
     const context = useContext(AuthContext);
     if (context == null) {

--- a/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.tsx
+++ b/packages/client/ui/react-ui/src/providers/CrossmintAuthProvider.tsx
@@ -169,6 +169,11 @@ function AuthWrapper({
     return <>{children}</>;
 }
 
+/**
+ * Provides Crossmint authentication to your app: email OTP, social login (OAuth), and session management.
+ * Exposes auth state via the `useCrossmintAuth` hook and renders the login modal when `login()` is called.
+ * Must be nested inside `CrossmintProvider`.
+ */
 export function CrossmintAuthProvider({
     children,
     appearance,

--- a/packages/client/ui/react-ui/src/types/auth.ts
+++ b/packages/client/ui/react-ui/src/types/auth.ts
@@ -15,10 +15,15 @@ export type OtpEmailPayload = {
 };
 
 export interface CrossmintAuthProviderProps extends CrossmintAuthBaseProviderProps {
+    /** Custom UI configuration for the auth modal (colors, fonts, border radius). */
     appearance?: UIConfig;
+    /** Custom title for the auth modal. */
     authModalTitle?: string;
     children: ReactNode;
+    /** Login methods to enable (e.g. `["email", "google"]`). Defaults to `["email", "google"]`. */
     loginMethods?: LoginMethod[];
+    /** Whether to prefetch OAuth provider URLs when the provider mounts. Defaults to `true`. */
     prefetchOAuthUrls?: boolean;
+    /** Custom terms of service text shown in the auth modal. */
     termsOfServiceText?: string | ReactNode;
 }

--- a/packages/client/ui/react-ui/typedoc.json
+++ b/packages/client/ui/react-ui/typedoc.json
@@ -1,6 +1,7 @@
 {
     "entryPoints": [
         "src/index.ts",
+        "src/types/auth.ts",
         "../../base/src/types/embed/v3/CrossmintEmbeddedCheckoutV3Props.ts",
         "../../base/src/types/hosted/v3/CrossmintHostedCheckoutV3Props.ts",
         "../../base/src/types/index.ts",

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -40,7 +40,7 @@ With Next.js, fetch the cookies and pass them to the `getSession` method:
 import { cookies } from "next/headers";
 
 const cookieStore = cookies();
-const jwtCookie = cookieStore.get("crossmint-session")?.value;
+const jwtCookie = cookieStore.get("crossmint-jwt")?.value;
 const refreshCookie = cookieStore.get("crossmint-refresh-token")?.value;
 
 const { jwt, userId } = await crossmintAuth.getSession({
@@ -104,7 +104,7 @@ res.end();
 You can also provide a custom refresh route:
 
 ```typescript
-const crossmintAuth = CrossmintAuthClient.from(crossmint, {
+const crossmintAuth = CrossmintAuth.from(crossmint, {
     refreshRoute: "/api/refresh",
 });
 ```

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -17,11 +17,17 @@
     "scripts": {
         "build": "tsup",
         "dev": "tsup --watch",
+        "generate:docs": "typedoc",
         "test:vitest": "vitest run"
     },
     "dependencies": {
         "@crossmint/common-sdk-auth": "workspace:*",
         "@crossmint/common-sdk-base": "workspace:*",
         "jose": "5.9.6"
+    },
+    "devDependencies": {
+        "typedoc": "0.28.17",
+        "typedoc-plugin-frontmatter": "1.3.0",
+        "typedoc-plugin-markdown": "4.5.2"
     }
 }

--- a/packages/server/src/auth/CrossmintAuthServer.ts
+++ b/packages/server/src/auth/CrossmintAuthServer.ts
@@ -24,9 +24,17 @@ import { verifyCrossmintJwt } from "./utils/jwt";
 import type { JSONWebKeySet } from "jose";
 
 export type CrossmintAuthServerOptions = CrossmintAuthOptions & {
+    /** Options applied to the auth cookies set by the SDK (e.g. `domain`). */
     cookieOptions?: CookieOptions;
 };
 
+/**
+ * Server-side Crossmint authentication client: validate sessions, verify JWTs, refresh tokens,
+ * fetch users, and manage auth cookies. Works with both Node.js (`IncomingMessage`/`ServerResponse`)
+ * and Fetch API (`Request`/`Response`) request/response objects.
+ *
+ * Create an instance with {@link CrossmintAuthServer.from}.
+ */
 export class CrossmintAuthServer extends CrossmintAuth {
     private cookieOptions: CookieOptions;
 
@@ -35,10 +43,19 @@ export class CrossmintAuthServer extends CrossmintAuth {
         this.cookieOptions = options.cookieOptions ?? {};
     }
 
+    /** Create a `CrossmintAuth` instance from a `Crossmint` object (created with `createCrossmint`). */
     public static from(crossmint: Crossmint, options: CrossmintAuthServerOptions = {}): CrossmintAuthServer {
         return new CrossmintAuthServer(crossmint, CrossmintAuth.defaultApiClient(crossmint), options);
     }
 
+    /**
+     * Validate the user's session and return it, refreshing it if expired.
+     * Accepts either a request object (auth material is read from cookies) or the auth material
+     * itself (`{ jwt, refreshToken }`). If a response object is provided, refreshed auth material
+     * is stored in its cookies.
+     *
+     * @throws CrossmintAuthenticationError if no valid session can be established.
+     */
     public async getSession(
         options: GenericRequest | AuthMaterialBasic,
         response?: GenericResponse
@@ -65,6 +82,7 @@ export class CrossmintAuthServer extends CrossmintAuth {
         }
     }
 
+    /** Fetch the Crossmint user associated with the given external user ID. */
     public async getUser(externalUserId: string) {
         const result = await this.apiClient.get(`api/${CROSSMINT_API_VERSION}/sdk/auth/user/${externalUserId}`, {
             headers: {
@@ -76,6 +94,11 @@ export class CrossmintAuthServer extends CrossmintAuth {
         return user;
     }
 
+    /**
+     * Handle a token refresh request on a custom refresh route. Reads the refresh token from the
+     * request body or cookies, refreshes the session, and returns a response with the new auth
+     * material stored in cookies. Returns a 401 response if the refresh fails.
+     */
     public async handleCustomRefresh(request: GenericRequest, response?: GenericResponse): Promise<GenericResponse> {
         const requestAdapter = isNodeRequest(request)
             ? new NodeRequestAdapter(request)
@@ -127,6 +150,7 @@ export class CrossmintAuthServer extends CrossmintAuth {
         }
     }
 
+    /** Verify a Crossmint-issued JWT and return its decoded payload. Uses Crossmint's JWKS endpoint unless a key set is provided. */
     public verifyCrossmintJwt(token: string, jwks?: JSONWebKeySet) {
         if (jwks != null) {
             return verifyCrossmintJwt(token, jwks);
@@ -134,10 +158,12 @@ export class CrossmintAuthServer extends CrossmintAuth {
         return verifyCrossmintJwt(token, this.getJwksUri());
     }
 
+    /** Store auth material (JWT and refresh token) in the response's cookies. */
     public storeAuthMaterial(response: GenericResponse, authMaterial: AuthMaterial) {
         setAuthCookies(response, authMaterial, this.cookieOptions);
     }
 
+    /** Log the user out: invalidate the refresh token with Crossmint and clear the auth cookies on the response. */
     public async logout(request?: GenericRequest, response?: GenericResponse) {
         try {
             // It's not necessary to call the logout endpoint, but desirable

--- a/packages/server/src/auth/index.ts
+++ b/packages/server/src/auth/index.ts
@@ -1,2 +1,3 @@
-export { CrossmintAuthServer as CrossmintAuth } from "./CrossmintAuthServer";
+export { CrossmintAuthServer as CrossmintAuth, type CrossmintAuthServerOptions } from "./CrossmintAuthServer";
+export type { GenericRequest, GenericResponse } from "./types/request";
 export * from "./utils";

--- a/packages/server/src/auth/utils/jwt.ts
+++ b/packages/server/src/auth/utils/jwt.ts
@@ -2,8 +2,10 @@ import { jwtVerify, errors, type createRemoteJWKSet, createLocalJWKSet, type JSO
 
 import { createJWKSClient } from "./jwksClient";
 
+/** A JWKS endpoint URI or an inline JSON Web Key Set. */
 export type JWKSInput = string | JSONWebKeySet;
 
+/** Verify a Crossmint-issued JWT against the given JWKS (endpoint URI or key set) and return its decoded payload. */
 export async function verifyCrossmintJwt(token: string, jwks: JWKSInput) {
     try {
         const signingKey = typeof jwks === "string" ? createJWKSClient(jwks) : createLocalJWKSet(jwks);

--- a/packages/server/tsconfig.typedoc.json
+++ b/packages/server/tsconfig.typedoc.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "module": "commonjs",
+        "esModuleInterop": true,
+        "skipLibCheck": true
+    }
+}

--- a/packages/server/typedoc-custom-plugin.mjs
+++ b/packages/server/typedoc-custom-plugin.mjs
@@ -1,0 +1,67 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { MarkdownPageEvent } from "typedoc-plugin-markdown";
+
+const pkg = JSON.parse(readFileSync(join(dirname(fileURLToPath(import.meta.url)), "package.json"), "utf8"));
+
+// README.mdx is renamed to overview.mdx in the workflow; its typedoc-derived
+// title is the package name, which collides with reference.mdx in nav. Give
+// the overview page a distinct, human-friendly title here.
+const TITLE_OVERRIDES = {
+    "README.mdx": "Getting Started",
+    "globals.mdx": "Reference",
+};
+
+const NPM_BADGE = `### Latest Node.js SDK version - <a href="https://www.npmjs.com/package/${pkg.name}" target="_blank" rel="noopener" style={{display: "inline-block", verticalAlign: "middle", textDecoration: "none", borderBottom: "none"}}><img src="https://img.shields.io/npm/v/${pkg.name}" alt="npm" style={{display: "inline-block", verticalAlign: "middle", margin: 0}} noZoom /></a>`;
+
+export function load(app) {
+    app.renderer.postRenderAsyncJobs.push(async (renderer) => {
+        const navigation = renderer.navigation;
+
+        const resultArray = navigation.map((item) => ({
+            group: item.title,
+            pages: item.children.map((child) => `sdk-reference/auth/typescript/${child.path.replace(".mdx", "")}`),
+        }));
+
+        // simply output to console, we then manually copy/paste into docs.json in Mintlify
+        console.log(JSON.stringify(resultArray));
+    });
+
+    // this adds the title to top of every mdx file as Mintlify expects
+    app.renderer.on(MarkdownPageEvent.BEGIN, (page) => {
+        page.frontmatter = {
+            title: TITLE_OVERRIDES[page.url] ?? page.model?.name,
+            ...page.frontmatter,
+        };
+    });
+
+    app.renderer.on(MarkdownPageEvent.END, (page) => {
+        // remove .mdx from links so it works with mintlify
+        page.contents = page.contents.replace(/\.mdx/g, "");
+
+        // add "./" to bare relative links (so Mintlify keeps them in-tab) — leave
+        // absolute paths (/...), parent-relative (../), and full URLs alone.
+        page.contents = page.contents.replace(/\]\((?!http|\/|\.{2}\/)/g, "](./");
+
+        // Strip angle brackets from SCREAMING_SNAKE_CASE placeholders in quoted
+        // strings, e.g. "<YOUR_API_KEY>" -> "YOUR_API_KEY" (Mintlify style guide).
+        page.contents = page.contents.replace(/"<([A-Z][A-Z0-9_]+)>"/g, '"$1"');
+
+        // For the overview (README) page: strip the H1 heading (already covered by
+        // the frontmatter title) and insert the npm version badge.
+        if (page.url === "README.mdx") {
+            page.contents = page.contents.replace(/^# [^\n]+\n\n?/m, "");
+            const before = page.contents;
+            page.contents = page.contents.replace(
+                /This SDK provides/,
+                `${NPM_BADGE}\n\nThe Crossmint server SDK (\`${pkg.name}\`) provides`
+            );
+            if (page.contents === before) {
+                console.warn(
+                    "[typedoc-custom-plugin] npm badge insertion failed — README description may have changed"
+                );
+            }
+        }
+    });
+}

--- a/packages/server/typedoc.json
+++ b/packages/server/typedoc.json
@@ -1,0 +1,19 @@
+{
+    "entryPoints": ["src/index.ts"],
+    "out": "docs/auth",
+    "plugin": ["typedoc-plugin-markdown", "typedoc-plugin-frontmatter", "./typedoc-custom-plugin.mjs"],
+    "tsconfig": "tsconfig.typedoc.json",
+    "fileExtension": ".mdx",
+    "skipErrorChecking": true,
+    "excludeNotDocumented": false,
+    "excludeInternal": true,
+    "excludePrivate": true,
+    "excludeProtected": true,
+    "sanitizeComments": true,
+    "hidePageHeader": true,
+    "hideBreadcrumbs": true,
+    "hidePageTitle": true,
+    "parametersFormat": "table",
+    "classPropertiesFormat": "table",
+    "gitRevision": "main"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,7 +110,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: 3.2.6
-        version: 3.2.6(@types/debug@4.1.12)(@types/node@20.14.8)(jsdom@23.2.0)(lightningcss@1.30.2)(terser@5.44.1)
+        version: 3.2.6(@types/debug@4.1.12)(@types/node@20.14.8)(jsdom@23.2.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)
       vitest-mock-extended:
         specifier: 2.0.2
         version: 2.0.2(typescript@5.5.3)(vitest@3.2.6(@types/debug@4.1.12)(@types/node@20.14.8)(jsdom@23.2.0)(lightningcss@1.30.2)(terser@5.44.1))
@@ -613,7 +613,7 @@ importers:
         version: 19.1.1(react@19.1.1)
       vitest:
         specifier: 3.2.6
-        version: 3.2.6(@types/debug@4.1.12)(@types/node@20.14.8)(jsdom@23.2.0)(lightningcss@1.30.2)(terser@5.44.1)
+        version: 3.2.6(@types/debug@4.1.12)(@types/node@20.14.8)(jsdom@23.2.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)
 
   packages/client/signers:
     dependencies:
@@ -1026,6 +1026,16 @@ importers:
       jose:
         specifier: 5.9.6
         version: 5.9.6
+    devDependencies:
+      typedoc:
+        specifier: 0.28.17
+        version: 0.28.17(typescript@5.5.3)
+      typedoc-plugin-frontmatter:
+        specifier: 1.3.0
+        version: 1.3.0(typedoc-plugin-markdown@4.5.2(typedoc@0.28.17(typescript@5.5.3)))
+      typedoc-plugin-markdown:
+        specifier: 4.5.2
+        version: 4.5.2(typedoc@0.28.17(typescript@5.5.3))
 
   packages/wallets:
     dependencies:
@@ -19547,7 +19557,7 @@ snapshots:
       '@jest/globals': 29.7.0
       '@types/jest': 29.5.4
       jest: 29.6.4(@types/node@20.14.8)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.8)(typescript@5.5.3))
-      vitest: 3.2.6(@types/debug@4.1.12)(@types/node@20.14.8)(jsdom@23.2.0)(lightningcss@1.30.2)(terser@5.44.1)
+      vitest: 3.2.6(@types/debug@4.1.12)(@types/node@20.14.8)(jsdom@23.2.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)
 
   '@testing-library/react@13.4.0(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
@@ -29663,9 +29673,9 @@ snapshots:
     dependencies:
       ts-essentials: 10.1.1(typescript@5.5.3)
       typescript: 5.5.3
-      vitest: 3.2.6(@types/debug@4.1.12)(@types/node@20.14.8)(jsdom@23.2.0)(lightningcss@1.30.2)(terser@5.44.1)
+      vitest: 3.2.6(@types/debug@4.1.12)(@types/node@20.14.8)(jsdom@23.2.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)
 
-  vitest@3.2.6(@types/debug@4.1.12)(@types/node@20.14.8)(jsdom@23.2.0)(lightningcss@1.30.2)(terser@5.44.1):
+  vitest@3.2.6(@types/debug@4.1.12)(@types/node@20.14.8)(jsdom@23.2.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6


### PR DESCRIPTION
## Description

First step of [DVRL-779](https://linear.app/crossmint/issue/DVRL-779/create-sdk-docs-for-auth): add `auth` as a product to the SDK reference docs pipeline, starting with the React SDK only (per plan, remaining SDKs will follow one at a time).

- New `auth` product config in `packages/client/ui/react-ui/scripts/generate-reference.mjs`, scoped to the auth surface: `CrossmintProvider`, `CrossmintAuthProvider`, `useCrossmintAuth()`, `EmbeddedAuthForm` (no wallet/checkout symbols)
- Auth examples in `examples.json` (`authProviderSetup`, `authQuickExample`, `EmbeddedAuthForm`; renamed the stale `useAuth` key to the actual export `useCrossmintAuth`)
- `src/types/auth.ts` added as TypeDoc entry point so `CrossmintAuthProviderProps` resolves into props tables
- JSDoc added to `CrossmintAuthProvider`, `useCrossmintAuth`, `EmbeddedAuthForm`, and the auth prop types (react-ui + react-base) — these render as descriptions in the generated pages
- Workflow: `auth/react` wired into `sdk-reference-docs-generate.yml` (package selection, generation step, artifact collection, dispatch default)

Generated output: `auth/react/{get-started, providers, hooks, components}.mdx`.

Companion PR in crossbit-main will add `auth/react` to the receiver allowlist + `sdkConfigs`.

## Test plan

* Ran `pnpm generate:docs --product auth` locally and reviewed all 4 generated pages (props, returns, and examples render correctly)
* Regenerated `wallets` and `checkout` products locally to confirm no regressions and no cross-product symbol leakage (grepped auth output for wallet/checkout types)
* Biome check clean on all changed files

## Package updates

* `@crossmint/client-sdk-react-ui` (patch) — JSDoc-only additions
* `@crossmint/client-sdk-react-base` (patch) — JSDoc-only additions
* Changeset added: `.changeset/auth-sdk-reference-docs.md`


Link to Devin session: https://crossmint.devinenterprise.com/sessions/9b97d1dc72df4b26bc030f87db1048db
Requested by: @jmderby