### PR TITLE
docs: add auth product to SDK reference docs generation (React Native)

### DIFF
--- a/.changeset/auth-sdk-reference-docs-rn.md
+++ b/.changeset/auth-sdk-reference-docs-rn.md
@@ -1,0 +1,6 @@
+---
+"@crossmint/client-sdk-react-native-ui": patch
+"@crossmint/client-sdk-react-base": patch
+---
+
+Add JSDoc descriptions to React Native auth provider, hook, and prop types for SDK reference docs

--- a/.github/workflows/sdk-reference-docs-generate.yml
+++ b/.github/workflows/sdk-reference-docs-generate.yml
@@ -27,9 +27,9 @@ on:
     workflow_dispatch:
         inputs:
             packages:
-                description: "Comma-separated list of packages to generate docs for (wallets/react, wallets/react-native, wallets/typescript, checkout/react, checkout/react-native, auth/react). Defaults to all."
+                description: "Comma-separated list of packages to generate docs for (wallets/react, wallets/react-native, wallets/typescript, checkout/react, checkout/react-native, auth/react, auth/react-native). Defaults to all."
                 required: false
-                default: "wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native,auth/react"
+                default: "wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native,auth/react,auth/react-native"
                 type: string
 
 permissions:
@@ -56,7 +56,7 @@ jobs:
             - name: Parse package selection
               id: packages
               env:
-                  PACKAGES_INPUT: ${{ inputs.packages || 'wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native,auth/react' }}
+                  PACKAGES_INPUT: ${{ inputs.packages || 'wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native,auth/react,auth/react-native' }}
               run: |
                   PACKAGES="$PACKAGES_INPUT"
                   echo "wallets_react=false" >> $GITHUB_OUTPUT
@@ -65,6 +65,7 @@ jobs:
                   echo "checkout_react=false" >> $GITHUB_OUTPUT
                   echo "checkout_react_native=false" >> $GITHUB_OUTPUT
                   echo "auth_react=false" >> $GITHUB_OUTPUT
+                  echo "auth_react_native=false" >> $GITHUB_OUTPUT
                   if echo ",$PACKAGES," | grep -q ",wallets/react,"; then
                     echo "wallets_react=true" >> $GITHUB_OUTPUT
                   fi
@@ -82,6 +83,9 @@ jobs:
                   fi
                   if echo ",$PACKAGES," | grep -q ",auth/react,"; then
                     echo "auth_react=true" >> $GITHUB_OUTPUT
+                  fi
+                  if echo ",$PACKAGES," | grep -q ",auth/react-native,"; then
+                    echo "auth_react_native=true" >> $GITHUB_OUTPUT
                   fi
 
             - name: Generate React UI docs (wallets)
@@ -103,6 +107,11 @@ jobs:
               if: steps.packages.outputs.wallets_react_native == 'true'
               working-directory: packages/client/ui/react-native
               run: pnpm generate:docs --product wallets
+
+            - name: Generate React Native docs (auth)
+              if: steps.packages.outputs.auth_react_native == 'true'
+              working-directory: packages/client/ui/react-native
+              run: pnpm generate:docs --product auth
 
             - name: Generate React Native docs (checkout)
               if: steps.packages.outputs.checkout_react_native == 'true'
@@ -129,6 +138,7 @@ jobs:
                   CHECKOUT_REACT_ENABLED: ${{ steps.packages.outputs.checkout_react }}
                   CHECKOUT_REACT_NATIVE_ENABLED: ${{ steps.packages.outputs.checkout_react_native }}
                   AUTH_REACT_ENABLED: ${{ steps.packages.outputs.auth_react }}
+                  AUTH_REACT_NATIVE_ENABLED: ${{ steps.packages.outputs.auth_react_native }}
               run: |
                   mkdir -p sdk-reference/wallets/react
                   mkdir -p sdk-reference/wallets/react-native
@@ -136,6 +146,7 @@ jobs:
                   mkdir -p sdk-reference/checkout/react
                   mkdir -p sdk-reference/checkout/react-native
                   mkdir -p sdk-reference/auth/react
+                  mkdir -p sdk-reference/auth/react-native
 
                   if [ "$WALLETS_REACT_ENABLED" == "true" ] && [ -d packages/client/ui/react-ui/docs/wallets ]; then
                     cp -r packages/client/ui/react-ui/docs/wallets/. sdk-reference/wallets/react/
@@ -159,6 +170,10 @@ jobs:
 
                   if [ "$AUTH_REACT_ENABLED" == "true" ] && [ -d packages/client/ui/react-ui/docs/auth ]; then
                     cp -r packages/client/ui/react-ui/docs/auth/. sdk-reference/auth/react/
+                  fi
+
+                  if [ "$AUTH_REACT_NATIVE_ENABLED" == "true" ] && [ -d packages/client/ui/react-native/docs/auth ]; then
+                    cp -r packages/client/ui/react-native/docs/auth/. sdk-reference/auth/react-native/
                   fi
 
             - name: Verify at least one package was generated
@@ -191,4 +206,4 @@ jobs:
                   token: ${{ steps.generate_app_token.outputs.token }}
                   repository: Paella-Labs/crossbit-main
                   event-type: sdk-reference-docs-update
-                  client-payload: '{"run_id": "${{ github.run_id }}", "packages": ${{ toJSON(inputs.packages || ''wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native,auth/react'') }}, "source_repo": "crossmint-sdk", "source_ref": ${{ toJSON(github.ref_name) }}}'
+                  client-payload: '{"run_id": "${{ github.run_id }}", "packages": ${{ toJSON(inputs.packages || ''wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native,auth/react,auth/react-native'') }}, "source_repo": "crossmint-sdk", "source_ref": ${{ toJSON(github.ref_name) }}}'

--- a/packages/client/react-base/src/types/auth.ts
+++ b/packages/client/react-base/src/types/auth.ts
@@ -32,6 +32,6 @@ export type CrossmintAuthBaseProviderProps = {
     refreshRoute?: string;
     /** Custom route for logging out, for server-side session management. */
     logoutRoute?: string;
-    /** Custom storage provider for auth material. Defaults to browser cookies. */
+    /** Custom storage provider for auth material. Defaults to browser cookies on web and secure device storage on React Native. */
     storageProvider?: StorageProvider;
 };

--- a/packages/client/ui/react-native/examples.json
+++ b/packages/client/ui/react-native/examples.json
@@ -37,6 +37,24 @@
         "language": "tsx",
         "note": "Only works with email and phone signers. Will not render for passkey or external wallet signers."
     },
+    "rnAuthProviderSetup": {
+        "code": "import {\n    CrossmintProvider,\n    CrossmintAuthProvider,\n} from \"@crossmint/client-sdk-react-native-ui\";\n\nfunction App() {\n    return (\n        <CrossmintProvider apiKey=\"YOUR_CLIENT_API_KEY\">\n            <CrossmintAuthProvider appSchema=\"myapp://\">\n                {/* Your app components */}\n            </CrossmintAuthProvider>\n        </CrossmintProvider>\n    );\n}",
+        "language": "tsx"
+    },
+    "rnAuthQuickExample": {
+        "code": "import { useCrossmintAuth } from \"@crossmint/client-sdk-react-native-ui\";\nimport { View, Text, TouchableOpacity } from \"react-native\";\n\nfunction LoginScreen() {\n    const { loginWithOAuth, logout, user, status } = useCrossmintAuth();\n\n    if (status === \"initializing\") return <Text>Loading...</Text>;\n\n    if (user == null) {\n        return (\n            <TouchableOpacity onPress={() => loginWithOAuth(\"google\")}>\n                <Text>Sign in with Google</Text>\n            </TouchableOpacity>\n        );\n    }\n\n    return (\n        <View>\n            <Text>Welcome, {user.email}</Text>\n            <TouchableOpacity onPress={logout}>\n                <Text>Log out</Text>\n            </TouchableOpacity>\n        </View>\n    );\n}",
+        "language": "tsx"
+    },
+    "CrossmintAuthProvider": {
+        "code": "import {\n    CrossmintProvider,\n    CrossmintAuthProvider,\n} from \"@crossmint/client-sdk-react-native-ui\";\n\nfunction App() {\n    return (\n        <CrossmintProvider apiKey=\"YOUR_CLIENT_API_KEY\">\n            <CrossmintAuthProvider appSchema=\"myapp://\">\n                {/* Your app content */}\n            </CrossmintAuthProvider>\n        </CrossmintProvider>\n    );\n}",
+        "language": "tsx",
+        "note": "CrossmintAuthProvider must be nested inside CrossmintProvider. Set appSchema to your app's deep link scheme so OAuth redirects return to your app."
+    },
+    "useCrossmintAuth": {
+        "code": "import { useCrossmintAuth } from \"@crossmint/client-sdk-react-native-ui\";\nimport { View, Text, TouchableOpacity } from \"react-native\";\n\nfunction AuthStatus() {\n    const { loginWithOAuth, logout, user, jwt, status } = useCrossmintAuth();\n\n    if (status === \"initializing\") return <Text>Loading...</Text>;\n\n    return (\n        <View>\n            {user == null ? (\n                <TouchableOpacity onPress={() => loginWithOAuth(\"google\")}>\n                    <Text>Log in</Text>\n                </TouchableOpacity>\n            ) : (\n                <TouchableOpacity onPress={logout}>\n                    <Text>Log out ({user.email})</Text>\n                </TouchableOpacity>\n            )}\n        </View>\n    );\n}",
+        "language": "tsx",
+        "note": "Must be used within a CrossmintAuthProvider."
+    },
     "rnCheckoutProviderSetup": {
         "code": "import {\n    CrossmintProvider,\n    CrossmintCheckoutProvider,\n} from \"@crossmint/client-sdk-react-native-ui\";\n\nfunction App() {\n    return (\n        <CrossmintProvider apiKey=\"YOUR_CLIENT_API_KEY\">\n            <CrossmintCheckoutProvider>\n                {/* Your checkout components */}\n            </CrossmintCheckoutProvider>\n        </CrossmintProvider>\n    );\n}",
         "language": "tsx"

--- a/packages/client/ui/react-native/scripts/generate-reference.mjs
+++ b/packages/client/ui/react-native/scripts/generate-reference.mjs
@@ -48,6 +48,26 @@ see the [previous version of this page](/sdk-reference/wallets/v0/react-native/{
             quickExampleIntro: "Once providers are set up, use hooks to access wallet state:",
         },
     },
+    auth: {
+        outdir: "auth",
+        navPrefix: "sdk-reference/auth/react-native",
+        title: "React Native SDK",
+        description: "React Native SDK reference for Crossmint authentication",
+        packageName: "@crossmint/client-sdk-react-native-ui",
+        npmUrl: "https://www.npmjs.com/package/@crossmint/client-sdk-react-native-ui",
+        installSnippet: "client-sdk-react-native-ui-installation-cmd.mdx",
+        intro: "The Crossmint React Native SDK (`@crossmint/client-sdk-react-native-ui`) provides React Native providers and hooks for integrating Crossmint authentication into your mobile application, including email OTP, social login (OAuth), and session management.",
+        exports: ["CrossmintProvider", "CrossmintAuthProvider", "useCrossmintAuth"],
+        descriptions: {
+            CrossmintProvider: "SDK initialization (required for all Crossmint features)",
+            CrossmintAuthProvider: "Authentication state, login/logout, and the auth flow",
+        },
+        getStartedExamples: {
+            setup: "rnAuthProviderSetup",
+            quickExample: "rnAuthQuickExample",
+            quickExampleIntro: "Once providers are set up, use the `useCrossmintAuth` hook to access auth state:",
+        },
+    },
     checkout: {
         outdir: "checkout",
         navPrefix: "sdk-reference/checkout/react-native",

--- a/packages/client/ui/react-native/src/hooks/useAuth.ts
+++ b/packages/client/ui/react-native/src/hooks/useAuth.ts
@@ -8,6 +8,10 @@ interface RNCrossmintAuthContext extends CrossmintAuthBaseContextType {
     createAuthSession: (urlOrOneTimeSecret: string) => Promise<AuthMaterialWithUser | null>;
 }
 
+/**
+ * Access Crossmint authentication state and actions: `loginWithOAuth`, `logout`, the current `user`, `jwt`, and auth `status`.
+ * Must be used within a `CrossmintAuthProvider`.
+ */
 export function useCrossmintAuth(): RNCrossmintAuthContext {
     const context = useContext(AuthContext);
     if (context == null) {

--- a/packages/client/ui/react-native/src/providers/CrossmintAuthProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintAuthProvider.tsx
@@ -165,6 +165,11 @@ function CrossmintAuthProviderContent({
     );
 }
 
+/**
+ * Provides Crossmint authentication to your React Native app: social login (OAuth) and session management.
+ * Exposes auth state via the `useCrossmintAuth` hook and stores auth material in secure device storage.
+ * Must be nested inside `CrossmintProvider`.
+ */
 export function CrossmintAuthProvider({ children, ...props }: RNCrossmintAuthProviderProps) {
     const appSchema = props.appSchema ?? Constants.expoConfig?.scheme;
     const customStorageProvider = useMemo(() => props.storageProvider ?? new SecureStorage(), [props.storageProvider]);

--- a/packages/client/ui/react-native/src/types/auth.ts
+++ b/packages/client/ui/react-native/src/types/auth.ts
@@ -3,14 +3,20 @@ import type { CrossmintAuthBaseContextType, CrossmintAuthBaseProviderProps } fro
 import type { AuthMaterialWithUser, OAuthProvider, SDKExternalUser } from "@crossmint/common-sdk-auth";
 
 export interface RNAuthContext extends CrossmintAuthBaseContextType {
+    /** The currently authenticated user, if any. */
     user?: SDKExternalUser;
+    /** Initiate a login flow with the specified OAuth provider (e.g. "google", "twitter"). */
     loginWithOAuth: (provider: OAuthProvider) => Promise<void>;
+    /** Complete authentication from an OAuth callback URL or one-time secret (e.g. from a deep link). */
     createAuthSession: (urlOrOneTimeSecret: string) => Promise<AuthMaterialWithUser | null>;
 }
 
 export interface RNCrossmintAuthProviderProps extends CrossmintAuthBaseProviderProps {
+    /** Whether to prefetch OAuth provider URLs when the provider mounts. */
     prefetchOAuthUrls?: boolean;
+    /** Custom title for the auth modal. */
     authModalTitle?: string;
     children: ReactNode;
+    /** Your app's deep link scheme(s) (e.g. `"myapp://"`), used for OAuth redirects back into your app. */
     appSchema?: string | string[];
 }

--- a/packages/client/ui/react-native/typedoc.json
+++ b/packages/client/ui/react-native/typedoc.json
@@ -1,6 +1,7 @@
 {
     "entryPoints": [
         "src/index.ts",
+        "src/types/auth.ts",
         "../../base/src/types/embed/v3/CrossmintEmbeddedCheckoutV3Props.ts",
         "../../base/src/types/index.ts",
         "../../../common/base/src/types/uiconfig.ts"


### PR DESCRIPTION
## Description

Second package for [DVRL-779](https://linear.app/crossmint/issue/DVRL-779/create-sdk-docs-for-auth) — adds the `auth` product to the React Native SDK reference docs generation, following the same pattern as the React PR (#1970, which this is stacked on).

- New `auth` product config in `packages/client/ui/react-native/scripts/generate-reference.mjs` with exports scoped to `CrossmintProvider`, `CrossmintAuthProvider`, `useCrossmintAuth` (RN has no `EmbeddedAuthForm`)
- RN auth examples in `examples.json` (`rnAuthProviderSetup`, `rnAuthQuickExample`, `CrossmintAuthProvider`, `useCrossmintAuth`)
- JSDoc on `RNCrossmintAuthProviderProps` / `RNAuthContext`, the `CrossmintAuthProvider` component, and the `useCrossmintAuth` hook so descriptions appear in generated docs
- Added `src/types/auth.ts` to `typedoc.json` entry points so props resolve
- Wired `auth/react-native` into `.github/workflows/sdk-reference-docs-generate.yml` (defaults, parsing, generation step, artifact collection, dispatch payload)
- Reworded shared `storageProvider` JSDoc in `react-base` to be platform-neutral (browser cookies on web, secure device storage on RN)

Generated pages: `get-started`, `providers`, `hooks` under `sdk-reference/auth/react-native/`.

## Test plan

- Ran `pnpm generate:docs --product auth` locally in `packages/client/ui/react-native`; verified 3 pages generate with full props tables and no wallet/checkout symbols leaking in
- `pnpm lint:fix` clean on touched files

## Package updates

- `@crossmint/client-sdk-react-native-ui` (patch) and `@crossmint/client-sdk-react-base` (patch) — changeset `auth-sdk-reference-docs-rn.md`


Link to Devin session: https://crossmint.devinenterprise.com/sessions/9b97d1dc72df4b26bc030f87db1048db
Requested by: @jmderby