### PR TITLE
docs: add auth product to SDK reference docs generation (Node.js/TypeScript server SDK)

### DIFF
--- a/.changeset/auth-sdk-reference-docs-typescript.md
+++ b/.changeset/auth-sdk-reference-docs-typescript.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/server-sdk": patch
+---
+
+Add SDK reference docs generation (TypeDoc) and JSDoc comments for the auth API. Also export the `CrossmintAuthServerOptions`, `GenericRequest`, and `GenericResponse` types.

--- a/.github/workflows/sdk-reference-docs-generate.yml
+++ b/.github/workflows/sdk-reference-docs-generate.yml
@@ -144,11 +144,11 @@ jobs:
               working-directory: packages/server
               run: |
                   pnpm generate:docs
-                  if [ -f docs/globals.mdx ]; then
-                    mv docs/globals.mdx docs/reference.mdx
+                  if [ -f docs/auth/globals.mdx ]; then
+                    mv docs/auth/globals.mdx docs/auth/reference.mdx
                   fi
-                  if [ -f docs/README.mdx ]; then
-                    mv docs/README.mdx docs/overview.mdx
+                  if [ -f docs/auth/README.mdx ]; then
+                    mv docs/auth/README.mdx docs/auth/overview.mdx
                   fi
 
             - name: Collect generated files
@@ -199,8 +199,8 @@ jobs:
                     cp -r packages/client/ui/react-native/docs/auth/. sdk-reference/auth/react-native/
                   fi
 
-                  if [ "$AUTH_TYPESCRIPT_ENABLED" == "true" ] && [ -d packages/server/docs ]; then
-                    cp -r packages/server/docs/. sdk-reference/auth/typescript/
+                  if [ "$AUTH_TYPESCRIPT_ENABLED" == "true" ] && [ -d packages/server/docs/auth ]; then
+                    cp -r packages/server/docs/auth/. sdk-reference/auth/typescript/
                   fi
 
             - name: Verify at least one package was generated

--- a/.github/workflows/sdk-reference-docs-generate.yml
+++ b/.github/workflows/sdk-reference-docs-generate.yml
@@ -8,6 +8,11 @@ on:
             - "packages/wallets/typedoc.json"
             - "packages/wallets/tsconfig.typedoc.json"
             - "packages/wallets/typedoc-custom-plugin.mjs"
+            - "packages/server/src/**"
+            - "packages/server/README.md"
+            - "packages/server/typedoc.json"
+            - "packages/server/tsconfig.typedoc.json"
+            - "packages/server/typedoc-custom-plugin.mjs"
             - "packages/client/ui/react-ui/src/**"
             - "packages/client/ui/react-ui/scripts/**"
             - "packages/client/ui/react-ui/examples.json"
@@ -27,9 +32,9 @@ on:
     workflow_dispatch:
         inputs:
             packages:
-                description: "Comma-separated list of packages to generate docs for (wallets/react, wallets/react-native, wallets/typescript, checkout/react, checkout/react-native, auth/react, auth/react-native). Defaults to all."
+                description: "Comma-separated list of packages to generate docs for (wallets/react, wallets/react-native, wallets/typescript, checkout/react, checkout/react-native, auth/react, auth/react-native, auth/typescript). Defaults to all."
                 required: false
-                default: "wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native,auth/react,auth/react-native"
+                default: "wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native,auth/react,auth/react-native,auth/typescript"
                 type: string
 
 permissions:
@@ -56,7 +61,7 @@ jobs:
             - name: Parse package selection
               id: packages
               env:
-                  PACKAGES_INPUT: ${{ inputs.packages || 'wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native,auth/react,auth/react-native' }}
+                  PACKAGES_INPUT: ${{ inputs.packages || 'wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native,auth/react,auth/react-native,auth/typescript' }}
               run: |
                   PACKAGES="$PACKAGES_INPUT"
                   echo "wallets_react=false" >> $GITHUB_OUTPUT
@@ -66,6 +71,7 @@ jobs:
                   echo "checkout_react_native=false" >> $GITHUB_OUTPUT
                   echo "auth_react=false" >> $GITHUB_OUTPUT
                   echo "auth_react_native=false" >> $GITHUB_OUTPUT
+                  echo "auth_typescript=false" >> $GITHUB_OUTPUT
                   if echo ",$PACKAGES," | grep -q ",wallets/react,"; then
                     echo "wallets_react=true" >> $GITHUB_OUTPUT
                   fi
@@ -86,6 +92,9 @@ jobs:
                   fi
                   if echo ",$PACKAGES," | grep -q ",auth/react-native,"; then
                     echo "auth_react_native=true" >> $GITHUB_OUTPUT
+                  fi
+                  if echo ",$PACKAGES," | grep -q ",auth/typescript,"; then
+                    echo "auth_typescript=true" >> $GITHUB_OUTPUT
                   fi
 
             - name: Generate React UI docs (wallets)
@@ -130,6 +139,18 @@ jobs:
                     mv docs/README.mdx docs/overview.mdx
                   fi
 
+            - name: Generate Node Server SDK docs (auth)
+              if: steps.packages.outputs.auth_typescript == 'true'
+              working-directory: packages/server
+              run: |
+                  pnpm generate:docs
+                  if [ -f docs/globals.mdx ]; then
+                    mv docs/globals.mdx docs/reference.mdx
+                  fi
+                  if [ -f docs/README.mdx ]; then
+                    mv docs/README.mdx docs/overview.mdx
+                  fi
+
             - name: Collect generated files
               env:
                   WALLETS_REACT_ENABLED: ${{ steps.packages.outputs.wallets_react }}
@@ -139,6 +160,7 @@ jobs:
                   CHECKOUT_REACT_NATIVE_ENABLED: ${{ steps.packages.outputs.checkout_react_native }}
                   AUTH_REACT_ENABLED: ${{ steps.packages.outputs.auth_react }}
                   AUTH_REACT_NATIVE_ENABLED: ${{ steps.packages.outputs.auth_react_native }}
+                  AUTH_TYPESCRIPT_ENABLED: ${{ steps.packages.outputs.auth_typescript }}
               run: |
                   mkdir -p sdk-reference/wallets/react
                   mkdir -p sdk-reference/wallets/react-native
@@ -147,6 +169,7 @@ jobs:
                   mkdir -p sdk-reference/checkout/react-native
                   mkdir -p sdk-reference/auth/react
                   mkdir -p sdk-reference/auth/react-native
+                  mkdir -p sdk-reference/auth/typescript
 
                   if [ "$WALLETS_REACT_ENABLED" == "true" ] && [ -d packages/client/ui/react-ui/docs/wallets ]; then
                     cp -r packages/client/ui/react-ui/docs/wallets/. sdk-reference/wallets/react/
@@ -174,6 +197,10 @@ jobs:
 
                   if [ "$AUTH_REACT_NATIVE_ENABLED" == "true" ] && [ -d packages/client/ui/react-native/docs/auth ]; then
                     cp -r packages/client/ui/react-native/docs/auth/. sdk-reference/auth/react-native/
+                  fi
+
+                  if [ "$AUTH_TYPESCRIPT_ENABLED" == "true" ] && [ -d packages/server/docs ]; then
+                    cp -r packages/server/docs/. sdk-reference/auth/typescript/
                   fi
 
             - name: Verify at least one package was generated
@@ -206,4 +233,4 @@ jobs:
                   token: ${{ steps.generate_app_token.outputs.token }}
                   repository: Paella-Labs/crossbit-main
                   event-type: sdk-reference-docs-update
-                  client-payload: '{"run_id": "${{ github.run_id }}", "packages": ${{ toJSON(inputs.packages || ''wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native,auth/react,auth/react-native'') }}, "source_repo": "crossmint-sdk", "source_ref": ${{ toJSON(github.ref_name) }}}'
+                  client-payload: '{"run_id": "${{ github.run_id }}", "packages": ${{ toJSON(inputs.packages || ''wallets/react,wallets/react-native,wallets/typescript,checkout/react,checkout/react-native,auth/react,auth/react-native,auth/typescript'') }}, "source_repo": "crossmint-sdk", "source_ref": ${{ toJSON(github.ref_name) }}}'

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -104,7 +104,7 @@ res.end();
 You can also provide a custom refresh route:
 
 ```typescript
-const crossmintAuth = CrossmintAuthClient.from(crossmint, {
+const crossmintAuth = CrossmintAuth.from(crossmint, {
     refreshRoute: "/api/refresh",
 });
 ```

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -40,7 +40,7 @@ With Next.js, fetch the cookies and pass them to the `getSession` method:
 import { cookies } from "next/headers";
 
 const cookieStore = cookies();
-const jwtCookie = cookieStore.get("crossmint-session")?.value;
+const jwtCookie = cookieStore.get("crossmint-jwt")?.value;
 const refreshCookie = cookieStore.get("crossmint-refresh-token")?.value;
 
 const { jwt, userId } = await crossmintAuth.getSession({

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -17,11 +17,17 @@
     "scripts": {
         "build": "tsup",
         "dev": "tsup --watch",
+        "generate:docs": "typedoc",
         "test:vitest": "vitest run"
     },
     "dependencies": {
         "@crossmint/common-sdk-auth": "workspace:*",
         "@crossmint/common-sdk-base": "workspace:*",
         "jose": "5.9.6"
+    },
+    "devDependencies": {
+        "typedoc": "0.28.17",
+        "typedoc-plugin-frontmatter": "1.3.0",
+        "typedoc-plugin-markdown": "4.5.2"
     }
 }

--- a/packages/server/src/auth/CrossmintAuthServer.ts
+++ b/packages/server/src/auth/CrossmintAuthServer.ts
@@ -24,9 +24,17 @@ import { verifyCrossmintJwt } from "./utils/jwt";
 import type { JSONWebKeySet } from "jose";
 
 export type CrossmintAuthServerOptions = CrossmintAuthOptions & {
+    /** Options applied to the auth cookies set by the SDK (e.g. `domain`). */
     cookieOptions?: CookieOptions;
 };
 
+/**
+ * Server-side Crossmint authentication client: validate sessions, verify JWTs, refresh tokens,
+ * fetch users, and manage auth cookies. Works with both Node.js (`IncomingMessage`/`ServerResponse`)
+ * and Fetch API (`Request`/`Response`) request/response objects.
+ *
+ * Create an instance with {@link CrossmintAuthServer.from}.
+ */
 export class CrossmintAuthServer extends CrossmintAuth {
     private cookieOptions: CookieOptions;
 
@@ -35,10 +43,19 @@ export class CrossmintAuthServer extends CrossmintAuth {
         this.cookieOptions = options.cookieOptions ?? {};
     }
 
+    /** Create a `CrossmintAuth` instance from a `Crossmint` object (created with `createCrossmint`). */
     public static from(crossmint: Crossmint, options: CrossmintAuthServerOptions = {}): CrossmintAuthServer {
         return new CrossmintAuthServer(crossmint, CrossmintAuth.defaultApiClient(crossmint), options);
     }
 
+    /**
+     * Validate the user's session and return it, refreshing it if expired.
+     * Accepts either a request object (auth material is read from cookies) or the auth material
+     * itself (`{ jwt, refreshToken }`). If a response object is provided, refreshed auth material
+     * is stored in its cookies.
+     *
+     * @throws CrossmintAuthenticationError if no valid session can be established.
+     */
     public async getSession(
         options: GenericRequest | AuthMaterialBasic,
         response?: GenericResponse
@@ -65,6 +82,7 @@ export class CrossmintAuthServer extends CrossmintAuth {
         }
     }
 
+    /** Fetch the Crossmint user associated with the given external user ID. */
     public async getUser(externalUserId: string) {
         const result = await this.apiClient.get(`api/${CROSSMINT_API_VERSION}/sdk/auth/user/${externalUserId}`, {
             headers: {
@@ -76,6 +94,11 @@ export class CrossmintAuthServer extends CrossmintAuth {
         return user;
     }
 
+    /**
+     * Handle a token refresh request on a custom refresh route. Reads the refresh token from the
+     * request body or cookies, refreshes the session, and returns a response with the new auth
+     * material stored in cookies. Returns a 401 response if the refresh fails.
+     */
     public async handleCustomRefresh(request: GenericRequest, response?: GenericResponse): Promise<GenericResponse> {
         const requestAdapter = isNodeRequest(request)
             ? new NodeRequestAdapter(request)
@@ -127,6 +150,7 @@ export class CrossmintAuthServer extends CrossmintAuth {
         }
     }
 
+    /** Verify a Crossmint-issued JWT and return its decoded payload. Uses Crossmint's JWKS endpoint unless a key set is provided. */
     public verifyCrossmintJwt(token: string, jwks?: JSONWebKeySet) {
         if (jwks != null) {
             return verifyCrossmintJwt(token, jwks);
@@ -134,10 +158,12 @@ export class CrossmintAuthServer extends CrossmintAuth {
         return verifyCrossmintJwt(token, this.getJwksUri());
     }
 
+    /** Store auth material (JWT and refresh token) in the response's cookies. */
     public storeAuthMaterial(response: GenericResponse, authMaterial: AuthMaterial) {
         setAuthCookies(response, authMaterial, this.cookieOptions);
     }
 
+    /** Log the user out: invalidate the refresh token with Crossmint and clear the auth cookies on the response. */
     public async logout(request?: GenericRequest, response?: GenericResponse) {
         try {
             // It's not necessary to call the logout endpoint, but desirable

--- a/packages/server/src/auth/index.ts
+++ b/packages/server/src/auth/index.ts
@@ -1,2 +1,3 @@
-export { CrossmintAuthServer as CrossmintAuth } from "./CrossmintAuthServer";
+export { CrossmintAuthServer as CrossmintAuth, type CrossmintAuthServerOptions } from "./CrossmintAuthServer";
+export type { GenericRequest, GenericResponse } from "./types/request";
 export * from "./utils";

--- a/packages/server/src/auth/utils/jwt.ts
+++ b/packages/server/src/auth/utils/jwt.ts
@@ -2,8 +2,10 @@ import { jwtVerify, errors, type createRemoteJWKSet, createLocalJWKSet, type JSO
 
 import { createJWKSClient } from "./jwksClient";
 
+/** A JWKS endpoint URI or an inline JSON Web Key Set. */
 export type JWKSInput = string | JSONWebKeySet;
 
+/** Verify a Crossmint-issued JWT against the given JWKS (endpoint URI or key set) and return its decoded payload. */
 export async function verifyCrossmintJwt(token: string, jwks: JWKSInput) {
     try {
         const signingKey = typeof jwks === "string" ? createJWKSClient(jwks) : createLocalJWKSet(jwks);

--- a/packages/server/tsconfig.typedoc.json
+++ b/packages/server/tsconfig.typedoc.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "module": "commonjs",
+        "esModuleInterop": true,
+        "skipLibCheck": true
+    }
+}

--- a/packages/server/typedoc-custom-plugin.mjs
+++ b/packages/server/typedoc-custom-plugin.mjs
@@ -1,0 +1,67 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { MarkdownPageEvent } from "typedoc-plugin-markdown";
+
+const pkg = JSON.parse(readFileSync(join(dirname(fileURLToPath(import.meta.url)), "package.json"), "utf8"));
+
+// README.mdx is renamed to overview.mdx in the workflow; its typedoc-derived
+// title is the package name, which collides with reference.mdx in nav. Give
+// the overview page a distinct, human-friendly title here.
+const TITLE_OVERRIDES = {
+    "README.mdx": "Getting Started",
+    "globals.mdx": "Reference",
+};
+
+const NPM_BADGE = `### Latest Node.js SDK version - <a href="https://www.npmjs.com/package/${pkg.name}" target="_blank" rel="noopener" style={{display: "inline-block", verticalAlign: "middle", textDecoration: "none", borderBottom: "none"}}><img src="https://img.shields.io/npm/v/${pkg.name}" alt="npm" style={{display: "inline-block", verticalAlign: "middle", margin: 0}} noZoom /></a>`;
+
+export function load(app) {
+    app.renderer.postRenderAsyncJobs.push(async (renderer) => {
+        const navigation = renderer.navigation;
+
+        const resultArray = navigation.map((item) => ({
+            group: item.title,
+            pages: item.children.map((child) => `sdk-reference/auth/typescript/${child.path.replace(".mdx", "")}`),
+        }));
+
+        // simply output to console, we then manually copy/paste into docs.json in Mintlify
+        console.log(JSON.stringify(resultArray));
+    });
+
+    // this adds the title to top of every mdx file as Mintlify expects
+    app.renderer.on(MarkdownPageEvent.BEGIN, (page) => {
+        page.frontmatter = {
+            title: TITLE_OVERRIDES[page.url] ?? page.model?.name,
+            ...page.frontmatter,
+        };
+    });
+
+    app.renderer.on(MarkdownPageEvent.END, (page) => {
+        // remove .mdx from links so it works with mintlify
+        page.contents = page.contents.replace(/\.mdx/g, "");
+
+        // add "./" to bare relative links (so Mintlify keeps them in-tab) — leave
+        // absolute paths (/...), parent-relative (../), and full URLs alone.
+        page.contents = page.contents.replace(/\]\((?!http|\/|\.{2}\/)/g, "](./");
+
+        // Strip angle brackets from SCREAMING_SNAKE_CASE placeholders in quoted
+        // strings, e.g. "<YOUR_API_KEY>" -> "YOUR_API_KEY" (Mintlify style guide).
+        page.contents = page.contents.replace(/"<([A-Z][A-Z0-9_]+)>"/g, '"$1"');
+
+        // For the overview (README) page: strip the H1 heading (already covered by
+        // the frontmatter title) and insert the npm version badge.
+        if (page.url === "README.mdx") {
+            page.contents = page.contents.replace(/^# [^\n]+\n\n?/m, "");
+            const before = page.contents;
+            page.contents = page.contents.replace(
+                /This SDK provides/,
+                `${NPM_BADGE}\n\nThe Crossmint server SDK (\`${pkg.name}\`) provides`
+            );
+            if (page.contents === before) {
+                console.warn(
+                    "[typedoc-custom-plugin] npm badge insertion failed — README description may have changed"
+                );
+            }
+        }
+    });
+}

--- a/packages/server/typedoc.json
+++ b/packages/server/typedoc.json
@@ -1,0 +1,19 @@
+{
+    "entryPoints": ["src/index.ts"],
+    "out": "docs",
+    "plugin": ["typedoc-plugin-markdown", "typedoc-plugin-frontmatter", "./typedoc-custom-plugin.mjs"],
+    "tsconfig": "tsconfig.typedoc.json",
+    "fileExtension": ".mdx",
+    "skipErrorChecking": true,
+    "excludeNotDocumented": false,
+    "excludeInternal": true,
+    "excludePrivate": true,
+    "excludeProtected": true,
+    "sanitizeComments": true,
+    "hidePageHeader": true,
+    "hideBreadcrumbs": true,
+    "hidePageTitle": true,
+    "parametersFormat": "table",
+    "classPropertiesFormat": "table",
+    "gitRevision": "main"
+}

--- a/packages/server/typedoc.json
+++ b/packages/server/typedoc.json
@@ -1,6 +1,6 @@
 {
     "entryPoints": ["src/index.ts"],
-    "out": "docs",
+    "out": "docs/auth",
     "plugin": ["typedoc-plugin-markdown", "typedoc-plugin-frontmatter", "./typedoc-custom-plugin.mjs"],
     "tsconfig": "tsconfig.typedoc.json",
     "fileExtension": ".mdx",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,7 +110,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: 3.2.6
-        version: 3.2.6(@types/debug@4.1.12)(@types/node@20.14.8)(jsdom@23.2.0)(lightningcss@1.30.2)(terser@5.44.1)
+        version: 3.2.6(@types/debug@4.1.12)(@types/node@20.14.8)(jsdom@23.2.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)
       vitest-mock-extended:
         specifier: 2.0.2
         version: 2.0.2(typescript@5.5.3)(vitest@3.2.6(@types/debug@4.1.12)(@types/node@20.14.8)(jsdom@23.2.0)(lightningcss@1.30.2)(terser@5.44.1))
@@ -613,7 +613,7 @@ importers:
         version: 19.1.1(react@19.1.1)
       vitest:
         specifier: 3.2.6
-        version: 3.2.6(@types/debug@4.1.12)(@types/node@20.14.8)(jsdom@23.2.0)(lightningcss@1.30.2)(terser@5.44.1)
+        version: 3.2.6(@types/debug@4.1.12)(@types/node@20.14.8)(jsdom@23.2.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)
 
   packages/client/signers:
     dependencies:
@@ -1026,6 +1026,16 @@ importers:
       jose:
         specifier: 5.9.6
         version: 5.9.6
+    devDependencies:
+      typedoc:
+        specifier: 0.28.17
+        version: 0.28.17(typescript@5.5.3)
+      typedoc-plugin-frontmatter:
+        specifier: 1.3.0
+        version: 1.3.0(typedoc-plugin-markdown@4.5.2(typedoc@0.28.17(typescript@5.5.3)))
+      typedoc-plugin-markdown:
+        specifier: 4.5.2
+        version: 4.5.2(typedoc@0.28.17(typescript@5.5.3))
 
   packages/wallets:
     dependencies:
@@ -19547,7 +19557,7 @@ snapshots:
       '@jest/globals': 29.7.0
       '@types/jest': 29.5.4
       jest: 29.6.4(@types/node@20.14.8)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.14.8)(typescript@5.5.3))
-      vitest: 3.2.6(@types/debug@4.1.12)(@types/node@20.14.8)(jsdom@23.2.0)(lightningcss@1.30.2)(terser@5.44.1)
+      vitest: 3.2.6(@types/debug@4.1.12)(@types/node@20.14.8)(jsdom@23.2.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)
 
   '@testing-library/react@13.4.0(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
@@ -29663,9 +29673,9 @@ snapshots:
     dependencies:
       ts-essentials: 10.1.1(typescript@5.5.3)
       typescript: 5.5.3
-      vitest: 3.2.6(@types/debug@4.1.12)(@types/node@20.14.8)(jsdom@23.2.0)(lightningcss@1.30.2)(terser@5.44.1)
+      vitest: 3.2.6(@types/debug@4.1.12)(@types/node@20.14.8)(jsdom@23.2.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1)
 
-  vitest@3.2.6(@types/debug@4.1.12)(@types/node@20.14.8)(jsdom@23.2.0)(lightningcss@1.30.2)(terser@5.44.1):
+  vitest@3.2.6(@types/debug@4.1.12)(@types/node@20.14.8)(jsdom@23.2.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(lightningcss@1.30.2)(terser@5.44.1):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6


### PR DESCRIPTION
## Description

Third package for [DVRL-779](https://linear.app/crossmint/issue/DVRL-779/create-sdk-docs-for-auth) (after React #1970 and React Native #1971): adds TypeDoc-based SDK reference docs generation for `@crossmint/server-sdk`, producing the `auth/typescript` package for the docs sync pipeline. Follows the same setup as the existing `wallets/typescript` reference in `packages/wallets`.

- `packages/server`: new `typedoc.json`, `tsconfig.typedoc.json`, and `typedoc-custom-plugin.mjs` (frontmatter titles, mdx link fixes, npm badge on the overview page — no version banner since server-sdk has no v0 docs), plus a `generate:docs` script and typedoc devDependencies (same versions as `packages/wallets`)
- JSDoc added to `CrossmintAuthServer` and its public methods (`from`, `getSession`, `getUser`, `handleCustomRefresh`, `verifyCrossmintJwt`, `storeAuthMaterial`, `logout`), `CrossmintAuthServerOptions`, and `verifyCrossmintJwt`/`JWKSInput` so descriptions appear in the generated reference
- Public exports: added type-only exports for `CrossmintAuthServerOptions`, `GenericRequest`, and `GenericResponse` (previously referenced by public method signatures but not exported/documented)
- `.github/workflows/sdk-reference-docs-generate.yml`: `auth/typescript` added to defaults/parse/generation/collection/dispatch, with the same `globals.mdx → reference.mdx` / `README.mdx → overview.mdx` renames as `wallets/typescript`; `packages/server` paths added to the push trigger

Generated pages: `overview`, `reference`, plus per-symbol pages under `classes/` (CrossmintAuth), `type-aliases/` (CrossmintAuthServerOptions, GenericRequest, GenericResponse, JWKSInput), `functions/` (createCrossmint, verifyCrossmintJwt), and `variables/` (CROSSMINT_API_VERSION, SDK_NAME, SDK_VERSION).

Receiver-side wiring: Paella-Labs/crossbit-main PR (allowlist + sdkConfigs) to follow.

## Test plan

* Ran `pnpm generate:docs` in `packages/server` locally (after `pnpm build:libs`-equivalent dep build) — 12 mdx pages generated with resolved types and JSDoc descriptions, 0 errors
* `pnpm --filter @crossmint/server-sdk test:vitest` — 36 tests pass
* `pnpm lint:fix` — clean

## Package updates

* `@crossmint/server-sdk` (patch) — changeset added (`.changeset/auth-sdk-reference-docs-typescript.md`): JSDoc comments + new type-only exports

Link to Devin session: https://crossmint.devinenterprise.com/sessions/9b97d1dc72df4b26bc030f87db1048db
Requested by: @jmderby