### PR TITLE
fix(wallets): surface JWT/auth errors from approve instead of wallet:no-transaction

### DIFF
--- a/.changeset/jwt-expired-approve-surfacing.md
+++ b/.changeset/jwt-expired-approve-surfacing.md
@@ -1,5 +1,9 @@
 ---
+"@crossmint/common-sdk-base": minor
 "@crossmint/wallets-sdk": minor
+"@crossmint/client-sdk-base": patch
 ---
 
-Surface authentication failures (e.g. expired JWTs) from `wallet.approve` and transaction/signature polling instead of masking them behind generic `wallet:no-transaction` / `wallet:no-signature` errors. When the API responds with an auth error code, the SDK now throws a typed `JWTExpiredError` (carrying `expiredAt`), `JWTInvalidError`, `JWTDecryptionError`, `JWTIdentifierError`, or `NotAuthorizedError`, all exported from the package root.
+Surface authentication failures (e.g. expired JWTs) from `wallet.approve` and transaction/signature polling instead of masking them behind generic `wallet:no-transaction` / `wallet:no-signature` errors. When the API responds with an auth error code, the SDK now throws a typed `JWTExpiredError` (carrying `expiredAt`), `JWTInvalidError`, `JWTDecryptionError`, `JWTIdentifierError`, or `NotAuthorizedError`.
+
+The canonical auth error classes now live in `@crossmint/common-sdk-base` and are re-exported from `@crossmint/client-sdk-base` and `@crossmint/wallets-sdk`, so `instanceof` checks work across packages. `client-sdk-base`'s `APIErrorService` also now maps the correct backend identifier code (`ERROR_JWT_IDENTIFIER_ERROR`) and handles `ERROR_JWT_AUDIENCE_MISMATCH`.

--- a/.changeset/jwt-expired-approve-surfacing.md
+++ b/.changeset/jwt-expired-approve-surfacing.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": minor
+---
+
+Surface authentication failures (e.g. expired JWTs) from `wallet.approve` and transaction/signature polling instead of masking them behind generic `wallet:no-transaction` / `wallet:no-signature` errors. When the API responds with an auth error code, the SDK now throws a typed `JWTExpiredError` (carrying `expiredAt`), `JWTInvalidError`, `JWTDecryptionError`, `JWTIdentifierError`, or `NotAuthorizedError`, all exported from the package root.

--- a/packages/client/base/src/error/index.ts
+++ b/packages/client/base/src/error/index.ts
@@ -6,56 +6,20 @@ import {
     CrossmintErrors,
 } from "@crossmint/common-sdk-base";
 
+export {
+    NotAuthorizedError,
+    JWTExpiredError,
+    JWTInvalidError,
+    JWTDecryptionError,
+    JWTIdentifierError,
+} from "@crossmint/common-sdk-base";
+
 export class CrossmintServiceError extends CrossmintSDKError {
     public status?: number;
 
     constructor(message: string, status?: number) {
         super(message, CrossmintErrors.CROSSMINT_SERVICE);
         this.status = status;
-    }
-}
-
-export class NotAuthorizedError extends CrossmintSDKError {
-    constructor(message: string) {
-        super(message, CrossmintErrors.NOT_AUTHORIZED);
-    }
-}
-
-export class JWTExpiredError extends NotAuthorizedError {
-    public readonly code = CrossmintErrors.JWT_EXPIRED;
-
-    /**
-     * The expiry time of the JWT as an ISO 8601 timestamp.
-     */
-    public readonly expiredAt: string;
-
-    constructor(expiredAt: Date) {
-        super(`JWT provided expired at timestamp ${expiredAt}`);
-        this.expiredAt = expiredAt.toISOString();
-    }
-}
-
-export class JWTInvalidError extends NotAuthorizedError {
-    public readonly code = CrossmintErrors.JWT_INVALID;
-    constructor() {
-        super("Invalid JWT provided");
-    }
-}
-
-export class JWTDecryptionError extends NotAuthorizedError {
-    public readonly code = CrossmintErrors.JWT_DECRYPTION;
-    constructor() {
-        super("Error decrypting JWT");
-    }
-}
-
-export class JWTIdentifierError extends NotAuthorizedError {
-    public readonly code = CrossmintErrors.JWT_IDENTIFIER;
-    public readonly identifierKey: string;
-
-    constructor(identifierKey: string) {
-        super(`Missing required identifier '${identifierKey}' in the JWT`);
-        this.identifierKey = identifierKey;
     }
 }
 

--- a/packages/client/base/src/services/api/APIErrorService.ts
+++ b/packages/client/base/src/services/api/APIErrorService.ts
@@ -6,14 +6,16 @@ import {
     JWTExpiredError,
     JWTIdentifierError,
     JWTInvalidError,
+    NotAuthorizedError,
     OutOfCreditsError,
 } from "../../error";
 
 export type CrossmintAPIErrorCodes =
     | "ERROR_JWT_INVALID"
     | "ERROR_JWT_DECRYPTION"
-    | "ERROR_JWT_IDENTIFIER"
-    | "ERROR_JWT_EXPIRED";
+    | "ERROR_JWT_IDENTIFIER_ERROR"
+    | "ERROR_JWT_EXPIRED"
+    | "ERROR_JWT_AUDIENCE_MISMATCH";
 
 export class APIErrorService<PackageErrorCodes extends string> {
     constructor(
@@ -22,8 +24,10 @@ export class APIErrorService<PackageErrorCodes extends string> {
             ERROR_JWT_INVALID: () => new JWTInvalidError(),
             ERROR_JWT_DECRYPTION: () => new JWTDecryptionError(),
             ERROR_JWT_EXPIRED: ({ expiredAt }: { expiredAt: string }) => new JWTExpiredError(new Date(expiredAt)),
-            ERROR_JWT_IDENTIFIER: ({ identifierKey }: { identifierKey: string }) =>
+            ERROR_JWT_IDENTIFIER_ERROR: ({ identifierKey }: { identifierKey: string }) =>
                 new JWTIdentifierError(identifierKey),
+            ERROR_JWT_AUDIENCE_MISMATCH: ({ message }: { message?: string }) =>
+                new NotAuthorizedError(message ?? "JWT audience does not match the expected value for this project"),
         }
     ) {}
 

--- a/packages/common/base/src/error/index.ts
+++ b/packages/common/base/src/error/index.ts
@@ -1,4 +1,4 @@
-import type { CrossmintErrors } from "@/types";
+import { CrossmintErrors } from "@/types";
 
 export class CrossmintSDKError extends Error {
     constructor(
@@ -7,5 +7,58 @@ export class CrossmintSDKError extends Error {
         public readonly details?: string
     ) {
         super(message);
+    }
+}
+
+export class NotAuthorizedError extends CrossmintSDKError {
+    constructor(message: string, details?: string) {
+        super(message, CrossmintErrors.NOT_AUTHORIZED, details);
+    }
+}
+
+export class JWTExpiredError extends NotAuthorizedError {
+    public readonly code = CrossmintErrors.JWT_EXPIRED;
+
+    /** The expiry time of the JWT as an ISO 8601 timestamp, when reported by the API. */
+    public readonly expiredAt?: string;
+
+    constructor(expiredAt?: string | Date, details?: string) {
+        const expiredAtIso = expiredAt instanceof Date ? expiredAt.toISOString() : expiredAt;
+        super(
+            expiredAtIso != null ? `JWT provided expired at timestamp ${expiredAtIso}` : "JWT provided has expired",
+            details
+        );
+        this.expiredAt = expiredAtIso;
+    }
+}
+
+export class JWTInvalidError extends NotAuthorizedError {
+    public readonly code = CrossmintErrors.JWT_INVALID;
+
+    constructor(details?: string) {
+        super("Invalid JWT provided", details);
+    }
+}
+
+export class JWTDecryptionError extends NotAuthorizedError {
+    public readonly code = CrossmintErrors.JWT_DECRYPTION;
+
+    constructor(details?: string) {
+        super("Error decrypting JWT", details);
+    }
+}
+
+export class JWTIdentifierError extends NotAuthorizedError {
+    public readonly code = CrossmintErrors.JWT_IDENTIFIER;
+    public readonly identifierKey?: string;
+
+    constructor(identifierKey?: string, details?: string) {
+        super(
+            identifierKey != null
+                ? `Missing required identifier '${identifierKey}' in the JWT`
+                : "Missing required identifier in the JWT",
+            details
+        );
+        this.identifierKey = identifierKey;
     }
 }

--- a/packages/wallets/src/index.ts
+++ b/packages/wallets/src/index.ts
@@ -2,7 +2,16 @@
 export { createCrossmint, CrossmintWallets } from "./sdk";
 
 // Errors
-export { WalletNotAvailableError, InvalidTransferAmountError, UnsupportedBrowserError } from "./utils/errors";
+export {
+    WalletNotAvailableError,
+    InvalidTransferAmountError,
+    UnsupportedBrowserError,
+    NotAuthorizedError,
+    JWTExpiredError,
+    JWTInvalidError,
+    JWTDecryptionError,
+    JWTIdentifierError,
+} from "./utils/errors";
 
 // API
 export { ApiClient as WalletsApiClient, type RegisterSignerPasskeyParams, type Scope, type TransferScope } from "./api";

--- a/packages/wallets/src/utils/errors.test.ts
+++ b/packages/wallets/src/utils/errors.test.ts
@@ -1,5 +1,5 @@
 import { CrossmintErrors } from "@crossmint/common-sdk-base";
-import { describe, expect, it } from "vitest";
+import { describe, expect, test } from "vitest";
 
 import {
     JWTDecryptionError,
@@ -11,7 +11,7 @@ import {
 } from "./errors";
 
 describe("throwIfCrossmintApiAuthError", () => {
-    it("throws JWTExpiredError with the reported expiry when the code is ERROR_JWT_EXPIRED", () => {
+    test("throws JWTExpiredError with the reported expiry when the code is ERROR_JWT_EXPIRED", () => {
         const expiredAt = "2026-07-07T21:28:41.000Z";
         const body = { error: true, message: "expired", code: "ERROR_JWT_EXPIRED", expiredAt };
 
@@ -26,17 +26,17 @@ describe("throwIfCrossmintApiAuthError", () => {
         }
     });
 
-    it("throws JWTInvalidError when the code is ERROR_JWT_INVALID", () => {
+    test("throws JWTInvalidError when the code is ERROR_JWT_INVALID", () => {
         expect(() => throwIfCrossmintApiAuthError({ error: true, code: "ERROR_JWT_INVALID" })).toThrow(JWTInvalidError);
     });
 
-    it("throws JWTDecryptionError when the code is ERROR_JWT_DECRYPTION", () => {
+    test("throws JWTDecryptionError when the code is ERROR_JWT_DECRYPTION", () => {
         expect(() => throwIfCrossmintApiAuthError({ error: true, code: "ERROR_JWT_DECRYPTION" })).toThrow(
             JWTDecryptionError
         );
     });
 
-    it("throws JWTIdentifierError with the identifier key when the code is ERROR_JWT_IDENTIFIER_ERROR", () => {
+    test("throws JWTIdentifierError with the identifier key when the code is ERROR_JWT_IDENTIFIER_ERROR", () => {
         try {
             throwIfCrossmintApiAuthError({ error: true, code: "ERROR_JWT_IDENTIFIER_ERROR", identifierKey: "sub" });
             expect.fail("Expected throwIfCrossmintApiAuthError to throw");
@@ -46,13 +46,13 @@ describe("throwIfCrossmintApiAuthError", () => {
         }
     });
 
-    it("throws NotAuthorizedError when the code is ERROR_JWT_AUDIENCE_MISMATCH", () => {
+    test("throws NotAuthorizedError when the code is ERROR_JWT_AUDIENCE_MISMATCH", () => {
         expect(() => throwIfCrossmintApiAuthError({ error: true, code: "ERROR_JWT_AUDIENCE_MISMATCH" })).toThrow(
             NotAuthorizedError
         );
     });
 
-    it("does not throw for non-auth error bodies", () => {
+    test("does not throw for non-auth error bodies", () => {
         expect(() => throwIfCrossmintApiAuthError({ error: true, message: "Transaction not found" })).not.toThrow();
         expect(() => throwIfCrossmintApiAuthError({ error: true, code: "SOME_OTHER_ERROR" })).not.toThrow();
         expect(() => throwIfCrossmintApiAuthError(null)).not.toThrow();

--- a/packages/wallets/src/utils/errors.test.ts
+++ b/packages/wallets/src/utils/errors.test.ts
@@ -1,0 +1,61 @@
+import { CrossmintErrors } from "@crossmint/common-sdk-base";
+import { describe, expect, it } from "vitest";
+
+import {
+    JWTDecryptionError,
+    JWTExpiredError,
+    JWTIdentifierError,
+    JWTInvalidError,
+    NotAuthorizedError,
+    throwIfCrossmintApiAuthError,
+} from "./errors";
+
+describe("throwIfCrossmintApiAuthError", () => {
+    it("throws JWTExpiredError with the reported expiry when the code is ERROR_JWT_EXPIRED", () => {
+        const expiredAt = "2026-07-07T21:28:41.000Z";
+        const body = { error: true, message: "expired", code: "ERROR_JWT_EXPIRED", expiredAt };
+
+        try {
+            throwIfCrossmintApiAuthError(body);
+            expect.fail("Expected throwIfCrossmintApiAuthError to throw");
+        } catch (error) {
+            expect(error).toBeInstanceOf(JWTExpiredError);
+            const jwtError = error as JWTExpiredError;
+            expect(jwtError.code).toBe(CrossmintErrors.JWT_EXPIRED);
+            expect(jwtError.expiredAt).toBe(expiredAt);
+        }
+    });
+
+    it("throws JWTInvalidError when the code is ERROR_JWT_INVALID", () => {
+        expect(() => throwIfCrossmintApiAuthError({ error: true, code: "ERROR_JWT_INVALID" })).toThrow(JWTInvalidError);
+    });
+
+    it("throws JWTDecryptionError when the code is ERROR_JWT_DECRYPTION", () => {
+        expect(() => throwIfCrossmintApiAuthError({ error: true, code: "ERROR_JWT_DECRYPTION" })).toThrow(
+            JWTDecryptionError
+        );
+    });
+
+    it("throws JWTIdentifierError with the identifier key when the code is ERROR_JWT_IDENTIFIER_ERROR", () => {
+        try {
+            throwIfCrossmintApiAuthError({ error: true, code: "ERROR_JWT_IDENTIFIER_ERROR", identifierKey: "sub" });
+            expect.fail("Expected throwIfCrossmintApiAuthError to throw");
+        } catch (error) {
+            expect(error).toBeInstanceOf(JWTIdentifierError);
+            expect((error as JWTIdentifierError).identifierKey).toBe("sub");
+        }
+    });
+
+    it("throws NotAuthorizedError when the code is ERROR_JWT_AUDIENCE_MISMATCH", () => {
+        expect(() => throwIfCrossmintApiAuthError({ error: true, code: "ERROR_JWT_AUDIENCE_MISMATCH" })).toThrow(
+            NotAuthorizedError
+        );
+    });
+
+    it("does not throw for non-auth error bodies", () => {
+        expect(() => throwIfCrossmintApiAuthError({ error: true, message: "Transaction not found" })).not.toThrow();
+        expect(() => throwIfCrossmintApiAuthError({ error: true, code: "SOME_OTHER_ERROR" })).not.toThrow();
+        expect(() => throwIfCrossmintApiAuthError(null)).not.toThrow();
+        expect(() => throwIfCrossmintApiAuthError("string")).not.toThrow();
+    });
+});

--- a/packages/wallets/src/utils/errors.ts
+++ b/packages/wallets/src/utils/errors.ts
@@ -1,4 +1,20 @@
-import { CrossmintErrors, CrossmintSDKError, WalletErrorCode } from "@crossmint/common-sdk-base";
+import {
+    CrossmintSDKError,
+    JWTDecryptionError,
+    JWTExpiredError,
+    JWTIdentifierError,
+    JWTInvalidError,
+    NotAuthorizedError,
+    WalletErrorCode,
+} from "@crossmint/common-sdk-base";
+
+export {
+    NotAuthorizedError,
+    JWTExpiredError,
+    JWTInvalidError,
+    JWTDecryptionError,
+    JWTIdentifierError,
+} from "@crossmint/common-sdk-base";
 
 export class InvalidApiKeyError extends CrossmintSDKError {
     constructor(message: string, details?: string) {
@@ -204,53 +220,6 @@ export class PendingApprovalsError extends CrossmintSDKError {
 export class InvalidAddressError extends CrossmintSDKError {
     constructor(message: string, details?: string) {
         super(message, WalletErrorCode.RECIPIENT_ADDRESS_INVALID, details);
-    }
-}
-
-export class NotAuthorizedError extends CrossmintSDKError {
-    constructor(message: string, details?: string) {
-        super(message, CrossmintErrors.NOT_AUTHORIZED, details);
-    }
-}
-
-export class JWTExpiredError extends CrossmintSDKError {
-    /** The expiry time of the JWT as an ISO 8601 timestamp, when reported by the API. */
-    public readonly expiredAt?: string;
-
-    constructor(expiredAt?: string, details?: string) {
-        super(
-            expiredAt != null ? `JWT provided expired at timestamp ${expiredAt}` : "JWT provided has expired",
-            CrossmintErrors.JWT_EXPIRED,
-            details
-        );
-        this.expiredAt = expiredAt;
-    }
-}
-
-export class JWTInvalidError extends CrossmintSDKError {
-    constructor(details?: string) {
-        super("Invalid JWT provided", CrossmintErrors.JWT_INVALID, details);
-    }
-}
-
-export class JWTDecryptionError extends CrossmintSDKError {
-    constructor(details?: string) {
-        super("Error decrypting JWT", CrossmintErrors.JWT_DECRYPTION, details);
-    }
-}
-
-export class JWTIdentifierError extends CrossmintSDKError {
-    public readonly identifierKey?: string;
-
-    constructor(identifierKey?: string, details?: string) {
-        super(
-            identifierKey != null
-                ? `Missing required identifier '${identifierKey}' in the JWT`
-                : "Missing required identifier in the JWT",
-            CrossmintErrors.JWT_IDENTIFIER,
-            details
-        );
-        this.identifierKey = identifierKey;
     }
 }
 

--- a/packages/wallets/src/utils/errors.ts
+++ b/packages/wallets/src/utils/errors.ts
@@ -1,4 +1,4 @@
-import { CrossmintSDKError, WalletErrorCode } from "@crossmint/common-sdk-base";
+import { CrossmintErrors, CrossmintSDKError, WalletErrorCode } from "@crossmint/common-sdk-base";
 
 export class InvalidApiKeyError extends CrossmintSDKError {
     constructor(message: string, details?: string) {
@@ -207,6 +207,96 @@ export class InvalidAddressError extends CrossmintSDKError {
     }
 }
 
+export class NotAuthorizedError extends CrossmintSDKError {
+    constructor(message: string, details?: string) {
+        super(message, CrossmintErrors.NOT_AUTHORIZED, details);
+    }
+}
+
+export class JWTExpiredError extends CrossmintSDKError {
+    /** The expiry time of the JWT as an ISO 8601 timestamp, when reported by the API. */
+    public readonly expiredAt?: string;
+
+    constructor(expiredAt?: string, details?: string) {
+        super(
+            expiredAt != null ? `JWT provided expired at timestamp ${expiredAt}` : "JWT provided has expired",
+            CrossmintErrors.JWT_EXPIRED,
+            details
+        );
+        this.expiredAt = expiredAt;
+    }
+}
+
+export class JWTInvalidError extends CrossmintSDKError {
+    constructor(details?: string) {
+        super("Invalid JWT provided", CrossmintErrors.JWT_INVALID, details);
+    }
+}
+
+export class JWTDecryptionError extends CrossmintSDKError {
+    constructor(details?: string) {
+        super("Error decrypting JWT", CrossmintErrors.JWT_DECRYPTION, details);
+    }
+}
+
+export class JWTIdentifierError extends CrossmintSDKError {
+    public readonly identifierKey?: string;
+
+    constructor(identifierKey?: string, details?: string) {
+        super(
+            identifierKey != null
+                ? `Missing required identifier '${identifierKey}' in the JWT`
+                : "Missing required identifier in the JWT",
+            CrossmintErrors.JWT_IDENTIFIER,
+            details
+        );
+        this.identifierKey = identifierKey;
+    }
+}
+
+/**
+ * Shape of the structured error body returned by the Crossmint wallets API. `code` carries a
+ * stable identifier for the failure and, for auth failures, extra fields (e.g. `expiredAt`) are
+ * spread onto the top level of the response by the backend exception filter.
+ */
+type CrossmintApiErrorBody = {
+    error?: boolean;
+    message?: string;
+    code?: string;
+    expiredAt?: string;
+    identifierKey?: string;
+};
+
+function isCrossmintApiErrorBody(response: unknown): response is CrossmintApiErrorBody {
+    return typeof response === "object" && response != null;
+}
+
+/**
+ * Inspects a Crossmint wallets API error response and, when it carries a recognized auth error
+ * code, throws the corresponding typed error so callers surface the real failure (e.g. an expired
+ * JWT) instead of masking it behind a generic wallet error. Returns without throwing when the
+ * response is not a recognized auth error, letting callers throw their own contextual error.
+ */
+export function throwIfCrossmintApiAuthError(response: unknown): void {
+    if (!isCrossmintApiErrorBody(response) || response.code == null) {
+        return;
+    }
+
+    const details = JSON.stringify(response);
+    switch (response.code) {
+        case "ERROR_JWT_EXPIRED":
+            throw new JWTExpiredError(response.expiredAt, details);
+        case "ERROR_JWT_INVALID":
+            throw new JWTInvalidError(details);
+        case "ERROR_JWT_DECRYPTION":
+            throw new JWTDecryptionError(details);
+        case "ERROR_JWT_IDENTIFIER_ERROR":
+            throw new JWTIdentifierError(response.identifierKey, details);
+        case "ERROR_JWT_AUDIENCE_MISMATCH":
+            throw new NotAuthorizedError(response.message ?? "JWT audience mismatch", details);
+    }
+}
+
 export type WalletError =
     | InvalidTransferAmountError
     | InvalidApiKeyError
@@ -238,4 +328,9 @@ export type WalletError =
     | TransactionFailedError
     | PendingApprovalsError
     | InvalidAddressError
-    | UnsupportedBrowserError;
+    | UnsupportedBrowserError
+    | NotAuthorizedError
+    | JWTExpiredError
+    | JWTInvalidError
+    | JWTDecryptionError
+    | JWTIdentifierError;

--- a/packages/wallets/src/wallets/services/operation-poller.ts
+++ b/packages/wallets/src/wallets/services/operation-poller.ts
@@ -9,6 +9,7 @@ import {
     TransactionHashNotFoundError,
     TransactionNotAvailableError,
     TransactionSendingFailedError,
+    throwIfCrossmintApiAuthError,
 } from "../../utils/errors";
 import { STATUS_POLLING_INTERVAL_MS } from "../../utils/constants";
 import { walletsLogger } from "../../logger";
@@ -41,6 +42,7 @@ export async function waitForTransactionCompletion(
 
         transactionResponse = await apiClient.getTransaction(walletLocator, transactionId);
         if (transactionResponse.error) {
+            throwIfCrossmintApiAuthError(transactionResponse);
             throw new TransactionNotAvailableError(JSON.stringify(transactionResponse));
         }
         await sleep(initialBackoffMs);
@@ -95,6 +97,7 @@ export async function waitForSignatureCompletion(
         await new Promise((resolve) => setTimeout(resolve, STATUS_POLLING_INTERVAL_MS));
         signatureResponse = await apiClient.getSignature(walletLocator, signatureId);
         if ("error" in signatureResponse) {
+            throwIfCrossmintApiAuthError(signatureResponse);
             throw new SignatureNotAvailableError(JSON.stringify(signatureResponse));
         }
     } while (signatureResponse === null || signatureResponse.status === "pending");

--- a/packages/wallets/src/wallets/wallet.test.ts
+++ b/packages/wallets/src/wallets/wallet.test.ts
@@ -12,6 +12,7 @@ import {
     WalletNotAvailableError,
     WalletTypeNotSupportedError,
     SignatureNotAvailableError,
+    JWTExpiredError,
 } from "../utils/errors";
 import { createMockWallet, createMockApiClient, type MockedApiClient } from "./__tests__/test-helpers";
 import { walletsLogger } from "../logger";
@@ -622,6 +623,25 @@ describe("Wallet - approve()", () => {
             mockApiClient.getTransaction.mockResolvedValue(errorResponse as any);
 
             await expect(wallet.approve({ transactionId: "txn-123" })).rejects.toThrow(TransactionNotAvailableError);
+        });
+
+        it("surfaces the JWT expiry instead of a generic transaction error", async () => {
+            const expiredAt = "2026-07-07T21:28:41.000Z";
+            const errorResponse = {
+                error: true,
+                message: `JWT provided expired at timestamp ${expiredAt}`,
+                code: "ERROR_JWT_EXPIRED",
+                expiredAt,
+            };
+
+            mockApiClient.getTransaction.mockResolvedValue(errorResponse as any);
+
+            const approvePromise = wallet.approve({ transactionId: "txn-123" });
+            await expect(approvePromise).rejects.toBeInstanceOf(JWTExpiredError);
+            await expect(approvePromise).rejects.toMatchObject({
+                code: "not-authorized.jwt-expired",
+                expiredAt,
+            });
         });
     });
 

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -40,6 +40,7 @@ import {
     TransactionNotCreatedError,
     WalletNotAvailableError,
     WalletTypeNotSupportedError,
+    throwIfCrossmintApiAuthError,
 } from "../utils/errors";
 import { STATUS_POLLING_INTERVAL_MS } from "../utils/constants";
 import { validateChainForEnvironment, type Chain } from "../chains/chains";
@@ -1141,6 +1142,7 @@ export class Wallet<C extends Chain> {
         const signature = await this.#apiClient.getSignature(this.walletLocator, signatureId);
 
         if ("error" in signature) {
+            throwIfCrossmintApiAuthError(signature);
             throw new SignatureNotAvailableError(JSON.stringify(signature));
         }
 
@@ -1188,6 +1190,7 @@ export class Wallet<C extends Chain> {
         const transaction = await this.#apiClient.getTransaction(this.walletLocator, transactionId);
 
         if ("error" in transaction) {
+            throwIfCrossmintApiAuthError(transaction);
             throw new TransactionNotAvailableError(JSON.stringify(transaction));
         }
 
@@ -1251,6 +1254,7 @@ export class Wallet<C extends Chain> {
         });
 
         if (approvedTransaction.error) {
+            throwIfCrossmintApiAuthError(approvedTransaction);
             throw new TransactionFailedError(JSON.stringify(approvedTransaction));
         }
 
@@ -1263,6 +1267,7 @@ export class Wallet<C extends Chain> {
         });
 
         if (approvedSignature.error) {
+            throwIfCrossmintApiAuthError(approvedSignature);
             throw new SignatureFailedError(JSON.stringify(approvedSignature));
         }
 


### PR DESCRIPTION
## Description

When a caller's JWT expires, `wallet.approve({ transactionId })` was rejecting with a generic `{"code":"wallet:no-transaction"}` (`TransactionNotAvailableError`) instead of the real auth failure. The wallets API returns the true cause — e.g. `{"error":true,"code":"ERROR_JWT_EXPIRED","expiredAt":"..."}` — but the SDK blindly wrapped any error body into `TransactionNotAvailableError` / `SignatureNotAvailableError`, discarding the `code`. This is what MoneyGram hit: the backend logged `ERROR_JWT_EXPIRED` while the SDK surfaced `wallet:no-transaction`.

This adds a `throwIfCrossmintApiAuthError(body)` helper that inspects the API error `code` and throws a typed auth error, mapping the backend codes (see `apps/crossmint-nextjs/src/api/global/jwt-errors.ts` in crossbit-main) to `common-sdk-base` `CrossmintErrors`:

```
ERROR_JWT_EXPIRED          -> JWTExpiredError    (not-authorized.jwt-expired, carries expiredAt)
ERROR_JWT_INVALID          -> JWTInvalidError    (not-authorized.jwt-invalid)
ERROR_JWT_DECRYPTION       -> JWTDecryptionError (not-authorized.jwt-decryption)
ERROR_JWT_IDENTIFIER_ERROR -> JWTIdentifierError (not-authorized.jwt-identifier, carries identifierKey)
ERROR_JWT_AUDIENCE_MISMATCH-> NotAuthorizedError (not-authorized)
```

The helper is called at every point in the approve/poll paths that previously masked the error (`approveTransactionInternal`, `approveSignatureInternal`, `waitForTransactionCompletion`, `waitForSignatureCompletion`, and the two execute-approval handlers). It only throws for recognized auth codes and otherwise returns, so the existing contextual errors are preserved for all other failures.

Note the backend spreads `responseFields` (e.g. `expiredAt`) onto the top level of the error body via its exception filter, so the fields are read from the top level of the response.

### Canonical error classes in `@crossmint/common-sdk-base`

The auth error classes (`NotAuthorizedError`, `JWTExpiredError`, `JWTInvalidError`, `JWTDecryptionError`, `JWTIdentifierError`) were previously duplicated in `client-sdk-base`. Duplicate class objects break cross-package `instanceof` checks (a consumer catching a wallets-thrown error with `client-base`'s `JWTExpiredError` would see `instanceof === false`). They now live canonically in `@crossmint/common-sdk-base` (alongside `CrossmintSDKError`) and are re-exported from both `client-sdk-base` and `wallets-sdk`, so there is a single class per error type. `JWTExpiredError` accepts `string | Date` for `expiredAt` to serve both the wallets layer (string from the API body) and `APIErrorService` (Date).

`client-sdk-base`'s `APIErrorService` is also aligned to the code the backend actually emits (`ERROR_JWT_IDENTIFIER_ERROR`, previously `ERROR_JWT_IDENTIFIER`) and now maps `ERROR_JWT_AUDIENCE_MISMATCH`.

## Test plan

* New unit tests in `packages/wallets/src/utils/errors.test.ts` covering each auth code mapping and the non-auth pass-through (no throw), using the `test()` BDD convention.
* New case in `packages/wallets/src/wallets/wallet.test.ts` asserting `wallet.approve({ transactionId })` rejects with `JWTExpiredError` (`code === "not-authorized.jwt-expired"`, correct `expiredAt`) instead of `TransactionNotAvailableError`.
* Full wallets vitest suite (714 tests) and client-base vitest suite pass; `@crossmint/wallets-sdk...` and `@crossmint/client-sdk-base` build cleanly; `pnpm lint` is clean.

## Package updates

Changeset added at `.changeset/jwt-expired-approve-surfacing.md`:

* `@crossmint/common-sdk-base` (minor) — adds the canonical auth error classes.
* `@crossmint/wallets-sdk` (minor) — surfaces auth errors from approve/poll; re-exports the auth error classes.
* `@crossmint/client-sdk-base` (patch) — re-exports canonical classes; fixes identifier code and adds audience-mismatch mapping.


Link to Devin session: https://crossmint.devinenterprise.com/sessions/706d7fd7c63f48ff841f623238f7d30c
Requested by: @albertoelias-crossmint
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/crossmint-sdk/pull/1973" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->