### PR TITLE
fix(wallets): expose SDK error details for geo-blocked requests

### DIFF
--- a/.changeset/geo-blocked-wallet-error-details.md
+++ b/.changeset/geo-blocked-wallet-error-details.md
@@ -1,0 +1,16 @@
+---
+"@crossmint/common-sdk-base": patch
+"@crossmint/client-sdk-react-base": minor
+---
+
+Expose structured error details for failed wallet loads/creations so integrators can distinguish a permanent geo-block from a transient network failure.
+
+`ApiClient.makeRequest` now throws a typed `ApiClientError` (carrying HTTP `status` and body) for any non-`ok` response whose body is not JSON — e.g. a Cloudflare 403 geo-block returning HTML — instead of letting callers hit an opaque `SyntaxError` from `.json()`. JSON 4xx responses are still passed through unchanged.
+
+The wallet context now exposes an `error` field alongside `status`:
+
+```ts
+error: { code: "region-blocked" | "network" | "unknown"; status?: number; message: string } | null
+```
+
+403 maps to `region-blocked` (permanent, don't retry), while fetch rejects/timeouts, 5xx, and 429 map to `network` (transient, retryable). `getOrCreateWallet`'s auto-retry loop is gated so it no longer hammers a permanently region-blocked endpoint.

--- a/.changeset/geo-blocked-wallet-error-details.md
+++ b/.changeset/geo-blocked-wallet-error-details.md
@@ -13,4 +13,4 @@ The wallet context now exposes an `error` field alongside `status`:
 error: { code: "region-blocked" | "network" | "unknown"; status?: number; message: string } | null
 ```
 
-403 maps to `region-blocked` (permanent, don't retry), while fetch rejects/timeouts, 5xx, and 429 map to `network` (transient, retryable). `getOrCreateWallet`'s auto-retry loop is gated so it no longer hammers a permanently region-blocked endpoint.
+A 403 whose body carries the Cloudflare country/region-ban signature (error 1009) maps to `region-blocked` (permanent, don't retry); fetch rejects/timeouts, 5xx, and 429 map to `network` (transient, retryable); everything else (including other 403s) is `unknown`. `getOrCreateWallet`'s auto-retry loop is gated on `region-blocked` so it no longer hammers a permanently region-blocked endpoint.

--- a/packages/client/react-base/src/providers/CrossmintWalletBaseProvider.tsx
+++ b/packages/client/react-base/src/providers/CrossmintWalletBaseProvider.tsx
@@ -277,8 +277,6 @@ export function CrossmintWalletBaseProvider({
             if (wallet != null) {
                 return wallet;
             }
-            // Don't hammer a permanently-blocked endpoint: this callback is re-fired by the
-            // createOnLogin effect whenever status flips to "error", so stop retrying region blocks.
             if (walletError?.code === "region-blocked") {
                 return undefined;
             }

--- a/packages/client/react-base/src/providers/CrossmintWalletBaseProvider.tsx
+++ b/packages/client/react-base/src/providers/CrossmintWalletBaseProvider.tsx
@@ -16,7 +16,7 @@ import {
 } from "@crossmint/wallets-sdk";
 import type { HandshakeParent } from "@crossmint/client-sdk-window";
 import type { signerInboundEvents, signerOutboundEvents } from "@crossmint/client-signers";
-import type { UIConfig } from "@crossmint/common-sdk-base";
+import { ApiClientError, type UIConfig } from "@crossmint/common-sdk-base";
 import { useCrossmint, useSignerAuth } from "@/hooks";
 import type { CreateOnLogin } from "@/types";
 import cloneDeep from "lodash.clonedeep";
@@ -25,11 +25,26 @@ import { LoggerContext } from "./CrossmintProvider";
 import { CrossmintWalletUIBaseProvider, type UIRenderProps } from "./CrossmintWalletUIBaseProvider";
 import { CrossmintAuthBaseContext } from "./CrossmintAuthBaseProvider";
 
+/**
+ * Structured detail about the last wallet load/creation failure, exposed alongside `status`
+ * so integrators can render an actionable message and decide whether to retry.
+ * - `region-blocked`: request was blocked (e.g. Cloudflare 403 from a restricted region). Permanent — do not retry.
+ * - `network`: transient failure (fetch reject/timeout, 5xx, or 429). Retryable.
+ * - `unknown`: anything else.
+ */
+export type WalletContextError = {
+    code: "region-blocked" | "network" | "unknown";
+    status?: number;
+    message: string;
+};
+
 export type CrossmintWalletBaseContext = {
     /** The current wallet instance, or undefined if no wallet is loaded. */
     wallet: Wallet<Chain> | undefined;
     /** Current wallet status. */
     status: "not-loaded" | "in-progress" | "loaded" | "error";
+    /** Detail about the last failure, or null when there is no error. */
+    error: WalletContextError | null;
     /** Retrieves an existing wallet. */
     getWallet: <C extends Chain>(
         props: Pick<ClientSideWalletArgsFor<C>, "chain" | "alias">
@@ -54,6 +69,7 @@ export type CrossmintWalletBaseContext = {
 export const CrossmintWalletBaseContext = createContext<CrossmintWalletBaseContext>({
     wallet: undefined,
     status: "not-loaded",
+    error: null,
     getWallet: () => Promise.resolve(undefined),
     createWallet: () => Promise.resolve(undefined),
     clientTEEConnection: undefined,
@@ -116,6 +132,28 @@ export type PasskeyPromptState = {
     secondaryActionOnClick?: () => void;
 };
 
+/**
+ * Maps a thrown wallet load/creation error to the structured shape exposed on the context.
+ * A 403 is treated as a permanent region block; fetch rejects/timeouts, 5xx, and 429 are
+ * treated as transient network failures; everything else is unknown.
+ */
+function mapWalletError(error: unknown): WalletContextError {
+    if (error instanceof ApiClientError) {
+        if (error.status === 403) {
+            return { code: "region-blocked", status: error.status, message: error.message };
+        }
+        if (error.status >= 500 || error.status === 429) {
+            return { code: "network", status: error.status, message: error.message };
+        }
+        return { code: "unknown", status: error.status, message: error.message };
+    }
+    // A rejected fetch (no response) surfaces as a TypeError; treat as transient network failure.
+    if (error instanceof TypeError) {
+        return { code: "network", message: error.message };
+    }
+    return { code: "unknown", message: error instanceof Error ? error.message : String(error) };
+}
+
 export function CrossmintWalletBaseProvider({
     children,
     createOnLogin,
@@ -134,6 +172,7 @@ export function CrossmintWalletBaseProvider({
     const { crossmint } = useCrossmint("CrossmintWalletBaseProvider must be used within CrossmintProvider");
     const [wallet, setWallet] = useState<Wallet<Chain> | undefined>(undefined);
     const [walletStatus, setWalletStatus] = useState<"not-loaded" | "in-progress" | "loaded" | "error">("not-loaded");
+    const [walletError, setWalletError] = useState<WalletContextError | null>(null);
     const [passkeyPromptState, setPasskeyPromptState] = useState<PasskeyPromptState>({ open: false });
     const signerAuth = useSignerAuth();
     const { onAuthRequired: signerOnAuthRequired } = signerAuth;
@@ -238,9 +277,15 @@ export function CrossmintWalletBaseProvider({
             if (wallet != null) {
                 return wallet;
             }
+            // Don't hammer a permanently-blocked endpoint: this callback is re-fired by the
+            // createOnLogin effect whenever status flips to "error", so stop retrying region blocks.
+            if (walletError?.code === "region-blocked") {
+                return undefined;
+            }
 
             try {
                 setWalletStatus("in-progress");
+                setWalletError(null);
                 const wallets = CrossmintWallets.from(crossmint);
 
                 await initializeWebViewIfNeeded(args.recovery);
@@ -279,11 +324,12 @@ export function CrossmintWalletBaseProvider({
             } catch (error) {
                 logger.error("react.wallet.getOrCreateWallet.error", { error });
                 setWallet(undefined);
+                setWalletError(mapWalletError(error));
                 setWalletStatus("error");
                 return undefined;
             }
         },
-        [crossmint, crossmint.jwt, walletStatus, wallet, initializeWebViewIfNeeded, buildWalletOptions]
+        [crossmint, crossmint.jwt, walletStatus, wallet, walletError, initializeWebViewIfNeeded, buildWalletOptions]
     );
 
     const getWallet = useCallback(
@@ -294,6 +340,7 @@ export function CrossmintWalletBaseProvider({
 
             try {
                 setWalletStatus("in-progress");
+                setWalletError(null);
                 const wallets = CrossmintWallets.from(crossmint);
 
                 // Initialize WebView before building options. Unlike getOrCreateWallet/createWallet,
@@ -316,6 +363,7 @@ export function CrossmintWalletBaseProvider({
                 return wallet;
             } catch (error) {
                 logger.error("react.wallet.getWallet.error", { error });
+                setWalletError(mapWalletError(error));
                 setWalletStatus("error");
                 return undefined;
             }
@@ -331,6 +379,7 @@ export function CrossmintWalletBaseProvider({
 
             try {
                 setWalletStatus("in-progress");
+                setWalletError(null);
                 const wallets = CrossmintWallets.from(crossmint);
 
                 await initializeWebViewIfNeeded(args.recovery);
@@ -345,6 +394,7 @@ export function CrossmintWalletBaseProvider({
             } catch (error) {
                 logger.error("react.wallet.createWallet.error", { error });
                 setWallet(undefined);
+                setWalletError(mapWalletError(error));
                 setWalletStatus("error");
                 return undefined;
             }
@@ -443,6 +493,7 @@ export function CrossmintWalletBaseProvider({
         if (crossmint.jwt == null && walletStatus !== "not-loaded") {
             setWalletStatus("not-loaded");
             setWallet(undefined);
+            setWalletError(null);
         }
     }, [crossmint.jwt, walletStatus]);
 
@@ -450,6 +501,7 @@ export function CrossmintWalletBaseProvider({
         () => ({
             wallet,
             status: walletStatus,
+            error: walletError,
             getWallet,
             createWallet,
             clientTEEConnection,
@@ -462,6 +514,7 @@ export function CrossmintWalletBaseProvider({
             createWallet,
             wallet,
             walletStatus,
+            walletError,
             clientTEEConnection,
             otpSignerState,
             createDeviceSigner,

--- a/packages/client/react-base/src/providers/CrossmintWalletBaseProvider.tsx
+++ b/packages/client/react-base/src/providers/CrossmintWalletBaseProvider.tsx
@@ -133,13 +133,26 @@ export type PasskeyPromptState = {
 };
 
 /**
- * Maps a thrown wallet load/creation error to the structured shape exposed on the context.
- * A 403 is treated as a permanent region block; fetch rejects/timeouts, 5xx, and 429 are
- * treated as transient network failures; everything else is unknown.
+ * Cloudflare serves an HTTP 403 with an HTML body when it bans the requester's country/region.
+ * Its error code 1009 ("Access denied: ... has banned the country or region your IP address is
+ * in") is the distinguishing signal — it lets us treat a genuine geo-block as permanent without
+ * also labelling every other non-JSON 403 (nginx access controls, a CDN/reverse-proxy rule) as
+ * `region-blocked` and permanently suppressing the auto-retry loop.
  */
-function mapWalletError(error: unknown): WalletContextError {
+const CLOUDFLARE_REGION_BLOCK_PATTERN = /error\s*1009|banned\s+(?:the\s+)?(?:country|region)/i;
+
+export function isCloudflareRegionBlock(responseBody: string | null): boolean {
+    return responseBody != null && CLOUDFLARE_REGION_BLOCK_PATTERN.test(responseBody);
+}
+
+/**
+ * Maps a thrown wallet load/creation error to the structured shape exposed on the context.
+ * A Cloudflare region-ban 403 is treated as a permanent block; fetch rejects/timeouts, 5xx, and
+ * 429 are treated as transient network failures; everything else (incl. other 403s) is unknown.
+ */
+export function mapWalletError(error: unknown): WalletContextError {
     if (error instanceof ApiClientError) {
-        if (error.status === 403) {
+        if (error.status === 403 && isCloudflareRegionBlock(error.responseBody)) {
             return { code: "region-blocked", status: error.status, message: error.message };
         }
         if (error.status >= 500 || error.status === 429) {

--- a/packages/client/react-base/src/providers/map-wallet-error.test.ts
+++ b/packages/client/react-base/src/providers/map-wallet-error.test.ts
@@ -1,0 +1,52 @@
+import { ApiClientError } from "@crossmint/common-sdk-base";
+import { describe, expect, test } from "vitest";
+
+import { mapWalletError } from "./CrossmintWalletBaseProvider";
+
+const CLOUDFLARE_1009_BODY = `<!DOCTYPE html><html><head><title>Access denied</title></head><body>
+Error 1009 Ray ID: abc123
+Access denied: The owner of this website (crossmint.com) has banned the country or region your IP address is in (MM) from accessing this website.
+</body></html>`;
+
+function apiClientError(status: number, body: string | null): ApiClientError {
+    return new ApiClientError(`API request failed: ${status}`, status, "Forbidden", body);
+}
+
+describe("mapWalletError", () => {
+    describe("when a 403 body carries the Cloudflare region-ban signature", () => {
+        test("maps to region-blocked", () => {
+            expect(mapWalletError(apiClientError(403, CLOUDFLARE_1009_BODY))).toEqual({
+                code: "region-blocked",
+                status: 403,
+                message: "API request failed: 403",
+            });
+        });
+    });
+
+    describe("when a 403 body is a generic non-Cloudflare block", () => {
+        test("maps to unknown so the auto-retry loop is not permanently suppressed", () => {
+            const nginxBody =
+                "<html><head><title>403 Forbidden</title></head><body><center><h1>403 Forbidden</h1></center></body></html>";
+            expect(mapWalletError(apiClientError(403, nginxBody)).code).toBe("unknown");
+        });
+    });
+
+    describe("when the error is a 5xx or 429", () => {
+        test("maps to network", () => {
+            expect(mapWalletError(apiClientError(502, "Bad Gateway")).code).toBe("network");
+            expect(mapWalletError(apiClientError(429, "Too Many Requests")).code).toBe("network");
+        });
+    });
+
+    describe("when the error is a rejected fetch (TypeError)", () => {
+        test("maps to network", () => {
+            expect(mapWalletError(new TypeError("Failed to fetch")).code).toBe("network");
+        });
+    });
+
+    describe("when the error is anything else", () => {
+        test("maps to unknown", () => {
+            expect(mapWalletError(new Error("boom")).code).toBe("unknown");
+        });
+    });
+});

--- a/packages/common/base/src/apiClient/ApiClient.ts
+++ b/packages/common/base/src/apiClient/ApiClient.ts
@@ -20,10 +20,13 @@ export abstract class ApiClient {
             headers: { ...this.commonHeaders, ...init.headers }, // commonHeaders intentionally first, in case sub class wants to override
         });
 
-        // Only throw on server errors (5xx) where the response body is likely
-        // non-JSON (e.g. HTML 502 from load balancer). 4xx responses are passed
-        // through so callers can inspect the JSON error body as before.
-        if (response.status >= 500) {
+        // Throw on server errors (5xx) and on any non-ok response whose body is not JSON
+        // (e.g. an HTML 502 from a load balancer, or a Cloudflare 403 geo-block). Calling
+        // `.json()` on those bodies would otherwise raise an opaque SyntaxError. JSON 4xx
+        // responses are still passed through so callers can inspect the structured error body.
+        const contentType = response.headers.get("content-type") ?? "";
+        const isJsonResponse = contentType.includes("application/json");
+        if (response.status >= 500 || (!response.ok && !isJsonResponse)) {
             let responseBody: string | null = null;
             try {
                 responseBody = await response.text();

--- a/packages/common/base/src/apiClient/api-client.test.ts
+++ b/packages/common/base/src/apiClient/api-client.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { ApiClient, ApiClientError } from "./ApiClient";
+
+class TestApiClient extends ApiClient {
+    get commonHeaders(): HeadersInit {
+        return {};
+    }
+    get baseUrl(): string {
+        return "https://example.com";
+    }
+}
+
+function mockResponse(status: number, body: string, contentType: string): Response {
+    return new Response(body, {
+        status,
+        headers: { "content-type": contentType },
+    });
+}
+
+describe("ApiClient makeRequest", () => {
+    const client = new TestApiClient();
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe("when the response is a non-ok status with a non-JSON body", () => {
+        test("throws a typed ApiClientError carrying the status and body", async () => {
+            const htmlBody = "<html><body>Access denied (region blocked)</body></html>";
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(mockResponse(403, htmlBody, "text/html"));
+
+            const error = await client.get("wallets/me", {}).catch((e) => e);
+
+            expect(error).toBeInstanceOf(ApiClientError);
+            expect(error.status).toBe(403);
+            expect(error.responseBody).toBe(htmlBody);
+        });
+    });
+
+    describe("when the response is a 5xx server error", () => {
+        test("throws an ApiClientError regardless of content type", async () => {
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(mockResponse(502, "Bad Gateway", "text/plain"));
+
+            const error = await client.get("wallets/me", {}).catch((e) => e);
+
+            expect(error).toBeInstanceOf(ApiClientError);
+            expect(error.status).toBe(502);
+        });
+    });
+
+    describe("when the response is a non-ok status with a JSON error body", () => {
+        test("passes the response through so callers can inspect the structured body", async () => {
+            const jsonBody = JSON.stringify({ error: true, message: "not found" });
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(mockResponse(404, jsonBody, "application/json"));
+
+            const response = await client.get("wallets/me", {});
+
+            expect(response.status).toBe(404);
+            await expect(response.json()).resolves.toEqual({ error: true, message: "not found" });
+        });
+    });
+
+    describe("when the response is ok", () => {
+        test("returns the response without throwing", async () => {
+            const jsonBody = JSON.stringify({ address: "0x123" });
+            vi.spyOn(globalThis, "fetch").mockResolvedValue(mockResponse(200, jsonBody, "application/json"));
+
+            const response = await client.get("wallets/me", {});
+
+            expect(response.status).toBe(200);
+        });
+    });
+});


### PR DESCRIPTION
## Description

Fixes [WAL-11049](https://linear.app/crossmint/issue/WAL-11049/expose-sdk-error-details-for-geo-blocked-requests). When a user's requests are geo-blocked by Cloudflare (403 with an HTML body), the SDK previously surfaced only a generic `status: "error"` — integrators (e.g. SpotPay in Myanmar) couldn't tell a permanent block from a transient network blip, and the underlying failure was an opaque `SyntaxError` from calling `.json()` on HTML.

This is the **minimal** version of the fix. Rather than the ticket's "throw a typed error for all non-`ok` responses", which would break the ~20 call sites that rely on 4xx returning a JSON error body (`if ("error" in result)`), the `throwIfCrossmintApiAuthError` JWT mapping, and the 422 idempotency path in `approveSignature`, this only newly throws for non-`ok` responses whose body **isn't JSON** — which is exactly the Cloudflare-HTML case that was producing the `SyntaxError`.

Two changes:

1. **`ApiClient.makeRequest`** (`packages/common/base`) — keep the existing `>= 500` throw, and additionally throw a typed `ApiClientError` (carrying HTTP `status` + body) when `!response.ok` **and** the response content-type is not `application/json`. JSON 4xx responses still pass through unchanged.

2. **`CrossmintWalletBaseProvider`** (`packages/client/react-base`) — add an `error` field to the wallet context beside `status`:
   ```ts
   error: { code: "region-blocked" | "network" | "unknown"; status?: number; message: string } | null
   ```
   A `mapWalletError()` helper classifies the thrown error: `403 → region-blocked` (permanent, don't retry); fetch reject/`TypeError` / `5xx` / `429 → network` (transient, retryable); else `unknown`. It's set in the `getWallet`/`getOrCreateWallet`/`createWallet` catch blocks and cleared on start/success/logout. Because `getOrCreateWallet` auto-retries via the `createOnLogin` effect when `status` flips to `"error"`, the loop is now gated to bail out on a `region-blocked` code so it stops hammering a permanently-blocked endpoint.

`error` flows through `useWallet()` automatically, so react-ui and react-native consumers get it with no further changes.

## Test plan

* New unit tests in `packages/common/base/src/apiClient/api-client.test.ts` cover `makeRequest`: non-ok + non-JSON body → throws `ApiClientError` with status/body; 5xx → throws; non-ok + JSON body → passes through; ok → passes through.
* `pnpm --filter @crossmint/common-sdk-base test:vitest` and `pnpm --filter @crossmint/client-sdk-react-base test:vitest` both pass.
* Build (`pnpm --filter @crossmint/client-sdk-react-base... build`) and lint pass with no new warnings.

## Package updates

* `@crossmint/common-sdk-base`: patch
* `@crossmint/client-sdk-react-base`: minor (new `error` context field)

Changeset added: `.changeset/geo-blocked-wallet-error-details.md`.


Link to Devin session: https://crossmint.devinenterprise.com/sessions/6eb653772dbe4a10bdaff1435299a166
Requested by: @albertoelias-crossmint