### PR TITLE
feat(wallets): auto-inject a device signer on Solana wallet creation

### DIFF
--- a/.changeset/wallets-sdk-solana-eager-device-signer.md
+++ b/.changeset/wallets-sdk-solana-eager-device-signer.md
@@ -1,0 +1,9 @@
+---
+"@crossmint/wallets-sdk": minor
+---
+
+Solana wallets now inject a device signer at creation time by default, reaching parity with EVM and Stellar. When `deviceSignerKeyStorage` is configured, `WalletFactory.createWallet` includes a `device` signer in the creation payload for every chain.
+
+Because a Solana wallet's provider is only known server-side and some providers (e.g. Squads) reject device signers at creation with the stable `DEVICE_SIGNER_NOT_SUPPORTED` error code, creation is retried once without the device signer when that specific rejection occurs. Wallet creation therefore succeeds regardless of the backing provider; for providers without device-signer support, a device signer is registered post-creation via the wallet's existing recovery flow (or falls back to the recovery signer).
+
+A device signer that the caller supplies explicitly is never stripped — a `DEVICE_SIGNER_NOT_SUPPORTED` rejection for an explicit signer surfaces as before. Behavior for EVM and Stellar is unchanged.

--- a/packages/wallets/src/wallets/wallet-factory.test.ts
+++ b/packages/wallets/src/wallets/wallet-factory.test.ts
@@ -140,8 +140,7 @@ describe("WalletFactory - OnCreateConfig Support", () => {
 
             await walletFactory.createWallet(args);
 
-            // Solana now reaches parity with EVM/Stellar: the device signer is sent in the
-            // creation payload rather than being deferred to a post-creation flow.
+            // Parity with EVM/Stellar: the device signer is in the creation payload.
             const call = mockApiClient.createWallet.mock.calls[0]?.[0];
             expect(call?.config?.delegatedSigners).toHaveLength(1);
             expect(call?.config?.delegatedSigners?.[0]).toEqual(
@@ -153,8 +152,7 @@ describe("WalletFactory - OnCreateConfig Support", () => {
         });
 
         it("retries Solana creation without the device signer when the backend rejects it with DEVICE_SIGNER_NOT_SUPPORTED", async () => {
-            // First attempt (with device signer) is rejected by a provider that doesn't support
-            // device signers (e.g. Squads); the retry (without device signer) succeeds.
+            // First attempt (with device signer) is rejected; the retry (without it) succeeds.
             mockApiClient.createWallet
                 .mockResolvedValueOnce({
                     error: true,
@@ -179,13 +177,12 @@ describe("WalletFactory - OnCreateConfig Support", () => {
             await expect(walletFactory.createWallet(args)).resolves.toBeDefined();
 
             expect(mockApiClient.createWallet).toHaveBeenCalledTimes(2);
-            // First call includes the device signer.
             const firstCall = mockApiClient.createWallet.mock.calls[0]?.[0];
             expect(firstCall?.config?.delegatedSigners).toHaveLength(1);
             expect(firstCall?.config?.delegatedSigners?.[0]).toEqual(
                 expect.objectContaining({ signer: expect.objectContaining({ type: "device" }) })
             );
-            // Retry strips the auto-injected device signer so creation succeeds on Squads.
+            // Retry strips the auto-injected device signer.
             const secondCall = mockApiClient.createWallet.mock.calls[1]?.[0];
             expect(secondCall?.config?.delegatedSigners ?? []).toHaveLength(0);
         });
@@ -215,8 +212,7 @@ describe("WalletFactory - OnCreateConfig Support", () => {
         });
 
         it("does not strip an explicitly-provided device signer on rejection", async () => {
-            // When the caller explicitly supplies a device signer, a DEVICE_SIGNER_NOT_SUPPORTED
-            // rejection is a genuine error the caller should see — not something to silently drop.
+            // A rejection for a caller-supplied signer is a genuine error, not something to drop.
             mockApiClient.createWallet.mockResolvedValue({
                 error: true,
                 message: "Device signers are not currently supported for this Solana wallet.",

--- a/packages/wallets/src/wallets/wallet-factory.test.ts
+++ b/packages/wallets/src/wallets/wallet-factory.test.ts
@@ -91,8 +91,22 @@ describe("WalletFactory - OnCreateConfig Support", () => {
     });
 
     describe("createWallet with device signer", () => {
-        it("does not inject device signer for Solana wallets at creation time (deferred to try-and-fallback post-creation flow)", async () => {
-            const solanaWallet = {
+        // A valid uncompressed P-256 public key in base64: 0x04 + 32-byte x + 32-byte y = 65 bytes.
+        const validDevicePublicKeyBase64 = Buffer.concat([
+            Buffer.from([0x04]),
+            Buffer.alloc(32, 1),
+            Buffer.alloc(32, 2),
+        ]).toString("base64");
+
+        const createMockDeviceSignerKeyStorage = () => ({
+            getKey: vi.fn().mockResolvedValue(null),
+            saveKey: vi.fn().mockResolvedValue(undefined),
+            generateKey: vi.fn().mockResolvedValue(validDevicePublicKeyBase64),
+            getDeviceName: vi.fn().mockReturnValue("Chrome on Mac"),
+        });
+
+        const solanaWalletResponse = (delegatedSigners: unknown[] = []) =>
+            ({
                 chainType: "solana" as const,
                 type: "smart" as const,
                 address: "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
@@ -103,19 +117,15 @@ describe("WalletFactory - OnCreateConfig Support", () => {
                         address: "AdminSignerAddress123",
                         locator: "external-wallet:AdminSignerAddress123",
                     },
-                    delegatedSigners: [],
+                    delegatedSigners,
                 },
                 createdAt: Date.now(),
-            } as GetWalletSuccessResponse;
+            }) as GetWalletSuccessResponse;
 
-            mockApiClient.createWallet.mockResolvedValue(solanaWallet);
+        it("injects device signer for Solana wallets at creation time when deviceSignerKeyStorage is provided", async () => {
+            mockApiClient.createWallet.mockResolvedValue(solanaWalletResponse());
 
-            const mockDeviceSignerKeyStorage = {
-                getKey: vi.fn().mockResolvedValue(null),
-                saveKey: vi.fn().mockResolvedValue(undefined),
-                generateKey: vi.fn(),
-                getDeviceName: vi.fn().mockReturnValue("Unknown Device"),
-            };
+            const mockDeviceSignerKeyStorage = createMockDeviceSignerKeyStorage();
 
             const args: WalletCreateArgs<"solana"> = {
                 chain: "solana",
@@ -130,13 +140,105 @@ describe("WalletFactory - OnCreateConfig Support", () => {
 
             await walletFactory.createWallet(args);
 
-            // Device signers must not be sent in the Solana createWallet call: some underlying
-            // providers reject device signers and the SDK cannot tell which provider backs the
-            // wallet upfront. The post-creation flow registers device signers and falls back
-            // to the recovery signer when the backend returns DEVICE_SIGNER_NOT_SUPPORTED.
+            // Solana now reaches parity with EVM/Stellar: the device signer is sent in the
+            // creation payload rather than being deferred to a post-creation flow.
             const call = mockApiClient.createWallet.mock.calls[0]?.[0];
-            expect(call?.config?.delegatedSigners ?? []).toHaveLength(0);
-            expect(mockDeviceSignerKeyStorage.generateKey).not.toHaveBeenCalled();
+            expect(call?.config?.delegatedSigners).toHaveLength(1);
+            expect(call?.config?.delegatedSigners?.[0]).toEqual(
+                expect.objectContaining({
+                    signer: expect.objectContaining({ type: "device" }),
+                })
+            );
+            expect(mockDeviceSignerKeyStorage.generateKey).toHaveBeenCalled();
+        });
+
+        it("retries Solana creation without the device signer when the backend rejects it with DEVICE_SIGNER_NOT_SUPPORTED", async () => {
+            // First attempt (with device signer) is rejected by a provider that doesn't support
+            // device signers (e.g. Squads); the retry (without device signer) succeeds.
+            mockApiClient.createWallet
+                .mockResolvedValueOnce({
+                    error: true,
+                    message: "Device signers are not currently supported for this Solana wallet.",
+                    code: "DEVICE_SIGNER_NOT_SUPPORTED",
+                } as any)
+                .mockResolvedValueOnce(solanaWalletResponse());
+
+            const mockDeviceSignerKeyStorage = createMockDeviceSignerKeyStorage();
+
+            const args: WalletCreateArgs<"solana"> = {
+                chain: "solana",
+                recovery: {
+                    type: "external-wallet",
+                    address: "AdminSignerAddress123",
+                },
+                options: {
+                    deviceSignerKeyStorage: mockDeviceSignerKeyStorage as unknown as any,
+                },
+            };
+
+            await expect(walletFactory.createWallet(args)).resolves.toBeDefined();
+
+            expect(mockApiClient.createWallet).toHaveBeenCalledTimes(2);
+            // First call includes the device signer.
+            const firstCall = mockApiClient.createWallet.mock.calls[0]?.[0];
+            expect(firstCall?.config?.delegatedSigners).toHaveLength(1);
+            expect(firstCall?.config?.delegatedSigners?.[0]).toEqual(
+                expect.objectContaining({ signer: expect.objectContaining({ type: "device" }) })
+            );
+            // Retry strips the auto-injected device signer so creation succeeds on Squads.
+            const secondCall = mockApiClient.createWallet.mock.calls[1]?.[0];
+            expect(secondCall?.config?.delegatedSigners ?? []).toHaveLength(0);
+        });
+
+        it("does not retry when a non-device-signer error is returned", async () => {
+            mockApiClient.createWallet.mockResolvedValue({
+                error: true,
+                message: "Some unrelated creation failure",
+            } as any);
+
+            const mockDeviceSignerKeyStorage = createMockDeviceSignerKeyStorage();
+
+            const args: WalletCreateArgs<"solana"> = {
+                chain: "solana",
+                recovery: {
+                    type: "external-wallet",
+                    address: "AdminSignerAddress123",
+                },
+                options: {
+                    deviceSignerKeyStorage: mockDeviceSignerKeyStorage as unknown as any,
+                },
+            };
+
+            await expect(walletFactory.createWallet(args)).rejects.toThrow(WalletCreationError);
+            // A generic error must surface as-is, without a silent retry that could mask it.
+            expect(mockApiClient.createWallet).toHaveBeenCalledTimes(1);
+        });
+
+        it("does not strip an explicitly-provided device signer on rejection", async () => {
+            // When the caller explicitly supplies a device signer, a DEVICE_SIGNER_NOT_SUPPORTED
+            // rejection is a genuine error the caller should see — not something to silently drop.
+            mockApiClient.createWallet.mockResolvedValue({
+                error: true,
+                message: "Device signers are not currently supported for this Solana wallet.",
+                code: "DEVICE_SIGNER_NOT_SUPPORTED",
+            } as any);
+
+            const mockDeviceSignerKeyStorage = createMockDeviceSignerKeyStorage();
+
+            const args: WalletCreateArgs<"solana"> = {
+                chain: "solana",
+                recovery: {
+                    type: "external-wallet",
+                    address: "AdminSignerAddress123",
+                },
+                signers: [{ type: "device", locator: `device:${validDevicePublicKeyBase64}` }],
+                options: {
+                    deviceSignerKeyStorage: mockDeviceSignerKeyStorage as unknown as any,
+                },
+            };
+
+            await expect(walletFactory.createWallet(args)).rejects.toThrow(WalletCreationError);
+            expect(mockApiClient.createWallet).toHaveBeenCalledTimes(1);
         });
 
         it("injects device signer for EVM wallets when deviceSignerKeyStorage is provided", async () => {

--- a/packages/wallets/src/wallets/wallet-factory.ts
+++ b/packages/wallets/src/wallets/wallet-factory.ts
@@ -126,15 +126,8 @@ export class WalletFactory {
             );
         }
 
-        // Include a device signer in the wallet's initial signer set when a device-key storage is
-        // available (client-side). This is done uniformly across EVM, Stellar and Solana so the
-        // device signer is the default across chains. Solana providers without device-signer support
-        // (e.g. Squads, the current production default) reject a device signer at creation with the
-        // stable DEVICE_SIGNER_NOT_SUPPORTED error code, and the SDK cannot tell which provider backs
-        // the wallet before it is created. We therefore attempt eager registration and, if the backend
-        // rejects it, transparently retry creation without the device signer (see createSmartWallet).
-        // The wallet's post-creation flow then registers a device signer for supported providers or
-        // falls back to the recovery signer for those that don't.
+        // Inject a device signer as the default on every chain when key storage is available.
+        // Some providers reject it at creation; createSmartWallet retries without it in that case.
         const eagerlyAddDeviceSigner = validatedArgs.options?.deviceSignerKeyStorage != null;
         const explicitSigners = validatedArgs.signers ?? [];
         const didAutoInjectDeviceSigner = eagerlyAddDeviceSigner && !explicitSigners.some((s) => s.type === "device");
@@ -183,14 +176,7 @@ export class WalletFactory {
         return await this.createWalletInstance(walletResponse, validatedArgs);
     }
 
-    /**
-     * Sends the smart-wallet creation request, with a defensive fallback for Solana providers that
-     * reject device signers (e.g. Squads). When the SDK auto-injected a device signer and the backend
-     * rejects creation with the stable DEVICE_SIGNER_NOT_SUPPORTED error code, the device signer is
-     * stripped from the delegated-signer set and creation is retried once. This keeps wallet creation
-     * working regardless of the server-side provider (which the client cannot know upfront); a device
-     * signer is registered post-creation for supported providers via the wallet's recovery flow.
-     */
+    /** Creates the smart wallet, retrying once without the auto-injected device signer if the provider rejects it. */
     private async createSmartWallet<C extends Chain>(
         args: WalletCreateArgs<C>,
         adminSigner: unknown,
@@ -227,11 +213,7 @@ export class WalletFactory {
         return await this.apiClient.createWallet(buildParams(signersWithoutDeviceSigner));
     }
 
-    /**
-     * Identifies the eagerly-injected device signer within a built delegated-signer set. Only the
-     * auto-injected device signer takes this object shape ({ signer: { type: "device", ... } });
-     * user-provided device signers with a locator are serialized as string locators.
-     */
+    /** Matches the auto-injected device signer (object form); locator-based device signers are strings. */
     private isBuiltDeviceSigner(
         builtSigner: { signer: string } | RegisterSignerParams | { signer: PasskeySignerConfig }
     ): boolean {

--- a/packages/wallets/src/wallets/wallet-factory.ts
+++ b/packages/wallets/src/wallets/wallet-factory.ts
@@ -6,12 +6,13 @@ import type {
     RecoverySignerConfig,
     ApiClient,
     CreateWalletParams,
+    CreateWalletResponse,
     GetWalletSuccessResponse,
     RegisterSignerPasskeyParams,
     Signer as SignerResponse,
     RegisterSignerParams,
 } from "../api";
-import { WalletCreationError, WalletNotAvailableError } from "../utils/errors";
+import { DEVICE_SIGNER_NOT_SUPPORTED_ERROR_CODE, WalletCreationError, WalletNotAvailableError } from "../utils/errors";
 import { type Chain, validateChainForEnvironment } from "../chains/chains";
 import type {
     ExternalWalletRegistrationConfig,
@@ -125,16 +126,21 @@ export class WalletFactory {
             );
         }
 
-        // Include device signer in the signers array when deviceSignerKeyStorage is available (client-side).
-        // Solana smart wallets are excluded: some underlying providers reject device signers and
-        // the SDK cannot tell which provider backs the wallet upfront. We defer device-signer
-        // registration to the wallet's post-creation flow, where a rejection with the stable
-        // DEVICE_SIGNER_NOT_SUPPORTED error code is caught and falls back to the recovery signer.
-        const shouldEagerlyAddDeviceSigner =
-            validatedArgs.options?.deviceSignerKeyStorage != null && validatedArgs.chain !== "solana";
-        const signersWithDevice = shouldEagerlyAddDeviceSigner
+        // Include a device signer in the wallet's initial signer set when a device-key storage is
+        // available (client-side). This is done uniformly across EVM, Stellar and Solana so the
+        // device signer is the default across chains. Solana providers without device-signer support
+        // (e.g. Squads, the current production default) reject a device signer at creation with the
+        // stable DEVICE_SIGNER_NOT_SUPPORTED error code, and the SDK cannot tell which provider backs
+        // the wallet before it is created. We therefore attempt eager registration and, if the backend
+        // rejects it, transparently retry creation without the device signer (see createSmartWallet).
+        // The wallet's post-creation flow then registers a device signer for supported providers or
+        // falls back to the recovery signer for those that don't.
+        const eagerlyAddDeviceSigner = validatedArgs.options?.deviceSignerKeyStorage != null;
+        const explicitSigners = validatedArgs.signers ?? [];
+        const didAutoInjectDeviceSigner = eagerlyAddDeviceSigner && !explicitSigners.some((s) => s.type === "device");
+        const signersWithDevice = eagerlyAddDeviceSigner
             ? this.ensureDeviceSignerInSigners(validatedArgs)
-            : validatedArgs.signers ?? [];
+            : explicitSigners;
         const builtSigners = await this.registerSigners(
             signersWithDevice,
             validatedArgs.chain,
@@ -156,17 +162,12 @@ export class WalletFactory {
             adminSigner = validatedArgs.recovery;
         }
 
-        const walletResponse = await this.apiClient.createWallet({
-            type: "smart",
-            chainType: this.getChainType(validatedArgs.chain),
-            config: {
-                adminSigner,
-                ...(validatedArgs.plugins ? { plugins: validatedArgs.plugins } : {}),
-                ...(builtSigners != null ? { delegatedSigners: builtSigners } : {}),
-            },
-            owner: validatedArgs.owner ?? undefined,
-            alias: validatedArgs.alias ?? undefined,
-        } as CreateWalletParams);
+        const walletResponse = await this.createSmartWallet(
+            validatedArgs,
+            adminSigner,
+            builtSigners,
+            didAutoInjectDeviceSigner
+        );
 
         if ("error" in walletResponse) {
             walletsLogger.error("walletFactory.createWallet.error", {
@@ -180,6 +181,62 @@ export class WalletFactory {
         });
 
         return await this.createWalletInstance(walletResponse, validatedArgs);
+    }
+
+    /**
+     * Sends the smart-wallet creation request, with a defensive fallback for Solana providers that
+     * reject device signers (e.g. Squads). When the SDK auto-injected a device signer and the backend
+     * rejects creation with the stable DEVICE_SIGNER_NOT_SUPPORTED error code, the device signer is
+     * stripped from the delegated-signer set and creation is retried once. This keeps wallet creation
+     * working regardless of the server-side provider (which the client cannot know upfront); a device
+     * signer is registered post-creation for supported providers via the wallet's recovery flow.
+     */
+    private async createSmartWallet<C extends Chain>(
+        args: WalletCreateArgs<C>,
+        adminSigner: unknown,
+        builtSigners: Array<{ signer: string } | RegisterSignerParams | { signer: PasskeySignerConfig }>,
+        didAutoInjectDeviceSigner: boolean
+    ): Promise<CreateWalletResponse> {
+        const buildParams = (delegatedSigners: typeof builtSigners): CreateWalletParams =>
+            ({
+                type: "smart",
+                chainType: this.getChainType(args.chain),
+                config: {
+                    adminSigner,
+                    ...(args.plugins ? { plugins: args.plugins } : {}),
+                    ...(delegatedSigners != null ? { delegatedSigners } : {}),
+                },
+                owner: args.owner ?? undefined,
+                alias: args.alias ?? undefined,
+            }) as CreateWalletParams;
+
+        const walletResponse = await this.apiClient.createWallet(buildParams(builtSigners));
+
+        const rejectedDeviceSigner =
+            didAutoInjectDeviceSigner &&
+            "error" in walletResponse &&
+            (walletResponse as { code?: string }).code === DEVICE_SIGNER_NOT_SUPPORTED_ERROR_CODE;
+        if (!rejectedDeviceSigner) {
+            return walletResponse;
+        }
+
+        walletsLogger.info("walletFactory.createWallet.deviceSignerUnsupported.retryWithoutDeviceSigner", {
+            chain: args.chain,
+        });
+        const signersWithoutDeviceSigner = builtSigners.filter((s) => !this.isBuiltDeviceSigner(s));
+        return await this.apiClient.createWallet(buildParams(signersWithoutDeviceSigner));
+    }
+
+    /**
+     * Identifies the eagerly-injected device signer within a built delegated-signer set. Only the
+     * auto-injected device signer takes this object shape ({ signer: { type: "device", ... } });
+     * user-provided device signers with a locator are serialized as string locators.
+     */
+    private isBuiltDeviceSigner(
+        builtSigner: { signer: string } | RegisterSignerParams | { signer: PasskeySignerConfig }
+    ): boolean {
+        const signer = builtSigner.signer;
+        return typeof signer === "object" && signer != null && "type" in signer && signer.type === "device";
     }
 
     private async createWalletInstance<C extends Chain>(

--- a/packages/wallets/src/wallets/wallet-factory.ts
+++ b/packages/wallets/src/wallets/wallet-factory.ts
@@ -213,12 +213,13 @@ export class WalletFactory {
         return await this.apiClient.createWallet(buildParams(signersWithoutDeviceSigner));
     }
 
-    /** Matches the auto-injected device signer (object form); locator-based device signers are strings. */
+    // Matches a device signer in object form. Callers only run this when didAutoInjectDeviceSigner is
+    // true (no caller-supplied device signer), so the sole match is the one we injected.
     private isBuiltDeviceSigner(
         builtSigner: { signer: string } | RegisterSignerParams | { signer: PasskeySignerConfig }
     ): boolean {
         const signer = builtSigner.signer;
-        return typeof signer === "object" && signer != null && "type" in signer && signer.type === "device";
+        return typeof signer === "object" && signer != null && signer.type === "device";
     }
 
     private async createWalletInstance<C extends Chain>(

--- a/packages/wallets/src/wallets/wallet-factory.ts
+++ b/packages/wallets/src/wallets/wallet-factory.ts
@@ -126,16 +126,16 @@ export class WalletFactory {
             );
         }
 
-        // Inject a device signer as the default on every chain when key storage is available.
-        // Some providers reject it at creation; createSmartWallet retries without it in that case.
-        const eagerlyAddDeviceSigner = validatedArgs.options?.deviceSignerKeyStorage != null;
+        // Inject a device signer as the default when key storage is available and the caller supplied none.
+        // Some providers reject it at creation; createSmartWallet retries without it, gated on this same flag.
         const explicitSigners = validatedArgs.signers ?? [];
-        const didAutoInjectDeviceSigner = eagerlyAddDeviceSigner && !explicitSigners.some((s) => s.type === "device");
-        const signersWithDevice = eagerlyAddDeviceSigner
-            ? this.ensureDeviceSignerInSigners(validatedArgs)
+        const didAutoInjectDeviceSigner =
+            validatedArgs.options?.deviceSignerKeyStorage != null && !explicitSigners.some((s) => s.type === "device");
+        const signersToRegister = didAutoInjectDeviceSigner
+            ? [...explicitSigners, { type: "device" } as SignerConfigForChain<C>]
             : explicitSigners;
         const builtSigners = await this.registerSigners(
-            signersWithDevice,
+            signersToRegister,
             validatedArgs.chain,
             validatedArgs.options?.deviceSignerKeyStorage
         );
@@ -307,22 +307,6 @@ export class WalletFactory {
                 y: passkeyCredential.publicKey.y.toString(),
             },
         };
-    }
-
-    /**
-     * Ensures device signer is included in the signers array for wallet creation.
-     * If no device signer is present in args.signers, adds one.
-     * Device signer support depends on the wallet provider; validation is handled server-side.
-     */
-    private ensureDeviceSignerInSigners<C extends Chain>(
-        args: WalletCreateArgs<C>
-    ): Array<SignerConfigForChain<C> | ExternalWalletRegistrationConfig> {
-        const signers = args.signers ?? [];
-        const hasDeviceSigner = signers.some((s) => s.type === "device");
-        if (!hasDeviceSigner) {
-            return [...signers, { type: "device" } as SignerConfigForChain<C>];
-        }
-        return signers;
     }
 
     private validateExistingWalletConfig<C extends Chain>(


### PR DESCRIPTION
## What

Makes Solana `createWallet()` auto-inject a device signer by default (when `deviceSignerKeyStorage` is configured), reaching parity with EVM and Stellar. Previously a `chain !== "solana"` guard in `WalletFactory.createWallet` excluded Solana, so the recovery signer ended up as the default for Solana transactions.

## Why the guard existed — and why it's now safe to remove

The guard was added in #1830 because a Solana wallet's provider isn't known until after the wallet is created, and not every provider supports device signers — those that don't reject a device signer at creation time. Naively removing the guard would break wallet creation for those wallets.

This PR removes the guard **with a defensive retry**: when creation is rejected with the stable `DEVICE_SIGNER_NOT_SUPPORTED` error code — and only when the SDK auto-injected the device signer — creation is retried once without it. This reuses the same error code the SDK already handles in `addSigner` / `recover()`.

## How

- Removed the `&& chain !== "solana"` guard; the device signer is injected for all chains when `deviceSignerKeyStorage` is set.
- New `createSmartWallet()` helper: attempts creation with the device signer; on a `DEVICE_SIGNER_NOT_SUPPORTED` response for an auto-injected signer, strips it and retries once. The wallet's existing post-creation `recover()` flow then handles the recovery-signer fallback, as before.
- Guardrails: a generic error surfaces **without** retry (never masks unrelated failures); an **explicitly-supplied** device signer is never silently stripped.

## Tests

`wallet-factory.test.ts` (32 → 35 passing):
- Solana now injects a device signer at creation.
- Retries without the device signer on `DEVICE_SIGNER_NOT_SUPPORTED`.
- Non-device errors are not retried.
- An explicit device signer is not stripped on rejection.

## Notes

- On the retry path, the rejected eager attempt leaves one orphaned temporary device key (unmapped, since the wallet doesn't exist yet) — this mirrors existing EVM-on-failure behavior; there's no `deleteKey`-by-temp-id API, so no cleanup complexity was added.