### PR TITLE
fix(wallets): surface transactionId and status on 5xx transaction API failures

### DIFF
--- a/.changeset/quiet-wombats-reconcile-transaction-5xx.md
+++ b/.changeset/quiet-wombats-reconcile-transaction-5xx.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+Expose transaction IDs and HTTP status codes when transaction API requests fail with a 5xx response, so callers can check transaction status before retrying.

--- a/packages/wallets/src/api/client.ts
+++ b/packages/wallets/src/api/client.ts
@@ -6,7 +6,7 @@ import {
 } from "@crossmint/common-sdk-base";
 
 import { SDK_NAME, SDK_VERSION } from "../utils/constants";
-import { InvalidApiKeyError } from "../utils/errors";
+import { InvalidApiKeyError, wrapTransactionApiError } from "../utils/errors";
 import { walletsLogger } from "../logger/init";
 
 import type {
@@ -101,11 +101,15 @@ class ApiClient extends CrossmintApiClient {
         walletLocator: WalletLocator,
         params: CreateTransactionParams
     ): Promise<CreateTransactionResponse> {
-        const response = await this.post(`${this.apiPrefix}/${walletLocator}/transactions`, {
-            body: JSON.stringify(params),
-            headers: this.headers,
-        });
-        return response.json();
+        try {
+            const response = await this.post(`${this.apiPrefix}/${walletLocator}/transactions`, {
+                body: JSON.stringify(params),
+                headers: this.headers,
+            });
+            return response.json();
+        } catch (error) {
+            throw wrapTransactionApiError(error) ?? error;
+        }
     }
 
     async approveTransaction(

--- a/packages/wallets/src/index.ts
+++ b/packages/wallets/src/index.ts
@@ -11,6 +11,7 @@ export {
     JWTInvalidError,
     JWTDecryptionError,
     JWTIdentifierError,
+    TransactionApiError,
 } from "./utils/errors";
 
 // API

--- a/packages/wallets/src/utils/errors.ts
+++ b/packages/wallets/src/utils/errors.ts
@@ -1,4 +1,5 @@
 import {
+    ApiClientError,
     CrossmintSDKError,
     JWTDecryptionError,
     JWTExpiredError,
@@ -211,6 +212,21 @@ export class TransactionFailedError extends CrossmintSDKError {
     }
 }
 
+export class TransactionApiError extends CrossmintSDKError {
+    public readonly transactionId?: string;
+    public readonly status?: number;
+
+    constructor(message: string, options: { transactionId?: string; status?: number; details?: string } = {}) {
+        const transactionMessage =
+            options.transactionId == null
+                ? `${message} The transaction outcome is indeterminate; check its status before retrying if possible.`
+                : `${message} (transactionId: ${options.transactionId}). The transaction may have succeeded; check its status before retrying.`;
+        super(transactionMessage, WalletErrorCode.TRANSACTION_FAILED, options.details);
+        this.transactionId = options.transactionId;
+        this.status = options.status;
+    }
+}
+
 export class PendingApprovalsError extends CrossmintSDKError {
     constructor(message: string, details?: string) {
         super(message, WalletErrorCode.TRANSACTION_FAILED, details);
@@ -266,6 +282,37 @@ export function throwIfCrossmintApiAuthError(response: unknown): void {
     }
 }
 
+function extractTransactionId(responseBody: string | null): string | undefined {
+    if (responseBody == null) {
+        return undefined;
+    }
+
+    try {
+        const parsed = JSON.parse(responseBody);
+        return typeof parsed?.id === "string" ? parsed.id : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+export function wrapTransactionApiError(error: unknown, transactionId?: string): TransactionApiError | undefined {
+    if (!(error instanceof ApiClientError)) {
+        return undefined;
+    }
+
+    const resolvedTransactionId = transactionId ?? extractTransactionId(error.responseBody);
+    const details = JSON.stringify({
+        status: error.status,
+        transactionId: resolvedTransactionId,
+        responseBody: error.responseBody,
+    });
+    return new TransactionApiError(error.message, {
+        transactionId: resolvedTransactionId,
+        status: error.status,
+        details,
+    });
+}
+
 export type WalletError =
     | InvalidTransferAmountError
     | InvalidApiKeyError
@@ -295,6 +342,7 @@ export type WalletError =
     | TransactionAwaitingApprovalError
     | TransactionHashNotFoundError
     | TransactionFailedError
+    | TransactionApiError
     | PendingApprovalsError
     | InvalidAddressError
     | UnsupportedBrowserError

--- a/packages/wallets/src/wallets/services/operation-poller.test.ts
+++ b/packages/wallets/src/wallets/services/operation-poller.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiClientError } from "@crossmint/common-sdk-base";
 import type { ApiClient, WalletLocator } from "../../api";
 import {
     SignatureConfirmationTimeoutError,
@@ -9,6 +10,7 @@ import {
     TransactionHashNotFoundError,
     TransactionNotAvailableError,
     TransactionSendingFailedError,
+    TransactionApiError,
 } from "../../utils/errors";
 import { walletsLogger } from "../../logger";
 import { waitForSignatureCompletion, waitForTransactionCompletion } from "./operation-poller";
@@ -174,6 +176,18 @@ describe("operation-poller", () => {
             expect(error).toBeInstanceOf(TransactionNotAvailableError);
             expect(error.message).toBe(JSON.stringify(errorResponse));
             expect(mockApiClient.getTransaction).toHaveBeenCalledTimes(2);
+        });
+
+        it("attaches the transaction ID and status when polling returns a 5xx", async () => {
+            mockApiClient.getTransaction.mockRejectedValue(
+                new ApiClientError("API request failed: 502 Bad Gateway", 502, "Bad Gateway", "Bad Gateway")
+            );
+
+            const error = await settleError(pollTx("txn-poll-500"));
+
+            expect(error).toBeInstanceOf(TransactionApiError);
+            expect(error).toMatchObject({ transactionId: "txn-poll-500", status: 502 });
+            expect(error.message).toContain("(transactionId: txn-poll-500)");
         });
 
         it.each([

--- a/packages/wallets/src/wallets/services/operation-poller.ts
+++ b/packages/wallets/src/wallets/services/operation-poller.ts
@@ -10,6 +10,7 @@ import {
     TransactionNotAvailableError,
     TransactionSendingFailedError,
     throwIfCrossmintApiAuthError,
+    wrapTransactionApiError,
 } from "../../utils/errors";
 import { STATUS_POLLING_INTERVAL_MS } from "../../utils/constants";
 import { walletsLogger } from "../../logger";
@@ -48,7 +49,11 @@ export async function waitForTransactionCompletion(
         }
 
         const pollStartedAt = Date.now();
-        transactionResponse = await apiClient.getTransaction(walletLocator, transactionId);
+        try {
+            transactionResponse = await apiClient.getTransaction(walletLocator, transactionId);
+        } catch (error) {
+            throw wrapTransactionApiError(error, transactionId) ?? error;
+        }
         if (transactionResponse.error) {
             throwIfCrossmintApiAuthError(transactionResponse);
             throw new TransactionNotAvailableError(JSON.stringify(transactionResponse));

--- a/packages/wallets/src/wallets/solana.test.ts
+++ b/packages/wallets/src/wallets/solana.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiClientError } from "@crossmint/common-sdk-base";
 import { SolanaWallet } from "./solana";
 import type { CreateTransactionSuccessResponse } from "../api";
-import { TransactionNotCreatedError } from "../utils/errors";
+import { TransactionApiError, TransactionNotCreatedError } from "../utils/errors";
 import {
     createMockWallet,
     createMockApiClient,
@@ -222,6 +223,41 @@ describe("SolanaWallet - sendTransaction()", () => {
     });
 
     describe("error cases", () => {
+        it("surfaces the transaction ID from a 5xx create response", async () => {
+            const serializedTx = createMockSolanaSerializedTransaction();
+            mockApiClient.createTransaction.mockRejectedValue(
+                new ApiClientError(
+                    "API request failed: 500 Internal Server Error",
+                    500,
+                    "Internal Server Error",
+                    '{"id":"txn-500"}'
+                )
+            );
+
+            const error = await solanaWallet
+                .sendTransaction({ serializedTransaction: serializedTx })
+                .catch((caught) => caught);
+
+            expect(error).toBeInstanceOf(TransactionApiError);
+            expect(error).toMatchObject({ transactionId: "txn-500", status: 500 });
+            expect(error.message).toContain("(transactionId: txn-500)");
+        });
+
+        it("surfaces an indeterminate transaction error for an opaque 5xx create response", async () => {
+            const serializedTx = createMockSolanaSerializedTransaction();
+            mockApiClient.createTransaction.mockRejectedValue(
+                new ApiClientError("API request failed: 500", 500, "", "<html>Internal Server Error</html>")
+            );
+
+            const error = await solanaWallet
+                .sendTransaction({ serializedTransaction: serializedTx })
+                .catch((caught) => caught);
+
+            expect(error).toBeInstanceOf(TransactionApiError);
+            expect(error).toMatchObject({ transactionId: undefined, status: 500 });
+            expect(error.message).toContain("outcome is indeterminate");
+        });
+
         it("throws TransactionNotCreatedError when API returns error", async () => {
             const serializedTx = createMockSolanaSerializedTransaction();
             const errorResponse = {

--- a/packages/wallets/src/wallets/solana.ts
+++ b/packages/wallets/src/wallets/solana.ts
@@ -9,7 +9,7 @@ import type {
     TransactionInputOptions,
 } from "./types";
 import { Wallet } from "./wallet";
-import { TransactionNotCreatedError } from "../utils/errors";
+import { TransactionNotCreatedError, wrapTransactionApiError } from "../utils/errors";
 import { SolanaExternalWalletSigner } from "@/signers/solana-external-wallet";
 import type { CreateTransactionSuccessResponse } from "@/api";
 import { walletsLogger } from "../logger";
@@ -115,12 +115,17 @@ export class SolanaWallet extends Wallet<SolanaChain> {
             serializedTransaction = bs58.encode(params.transaction.serialize());
         }
 
-        const transactionCreationResponse = await this.apiClient.createTransaction(this.walletLocator, {
-            params: {
-                transaction: serializedTransaction,
-                signer,
-            },
-        });
+        let transactionCreationResponse: Awaited<ReturnType<typeof this.apiClient.createTransaction>>;
+        try {
+            transactionCreationResponse = await this.apiClient.createTransaction(this.walletLocator, {
+                params: {
+                    transaction: serializedTransaction,
+                    signer,
+                },
+            });
+        } catch (error) {
+            throw wrapTransactionApiError(error) ?? error;
+        }
 
         if ("error" in transactionCreationResponse) {
             throw new TransactionNotCreatedError(JSON.stringify(transactionCreationResponse));

--- a/packages/wallets/src/wallets/wallet.test.ts
+++ b/packages/wallets/src/wallets/wallet.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiClientError } from "@crossmint/common-sdk-base";
 import { Wallet } from "./wallet";
 import { WalletFactory } from "./wallet-factory";
 import type { ApiClient, GetBalanceSuccessResponse, SendResponse, GetWalletSuccessResponse } from "../api";
@@ -13,6 +14,7 @@ import {
     WalletTypeNotSupportedError,
     SignatureNotAvailableError,
     JWTExpiredError,
+    TransactionApiError,
 } from "../utils/errors";
 import { createMockWallet, createMockApiClient, type MockedApiClient } from "./__tests__/test-helpers";
 import { walletsLogger } from "../logger";
@@ -623,6 +625,18 @@ describe("Wallet - approve()", () => {
             mockApiClient.getTransaction.mockResolvedValue(errorResponse as any);
 
             await expect(wallet.approve({ transactionId: "txn-123" })).rejects.toThrow(TransactionNotAvailableError);
+        });
+
+        it("attaches the transaction ID and status when approval lookup returns a 5xx", async () => {
+            mockApiClient.getTransaction.mockRejectedValue(
+                new ApiClientError("API request failed: 500 Internal Server Error", 500, "Internal Server Error", null)
+            );
+
+            const error = await wallet.approve({ transactionId: "txn-123" }).catch((caught) => caught);
+
+            expect(error).toBeInstanceOf(TransactionApiError);
+            expect(error).toMatchObject({ transactionId: "txn-123", status: 500 });
+            expect(error.message).toContain("(transactionId: txn-123)");
         });
 
         it("surfaces the JWT expiry instead of a generic transaction error", async () => {

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -4,6 +4,8 @@ import type {
     ApiClient,
     WalletLocator,
     RegisterSignerParams,
+    ApproveTransactionResponse,
+    GetTransactionResponse,
     GetTransactionSuccessResponse,
     GetTransactionsResponse,
     GetWalletSuccessResponse,
@@ -41,6 +43,7 @@ import {
     WalletNotAvailableError,
     WalletTypeNotSupportedError,
     throwIfCrossmintApiAuthError,
+    wrapTransactionApiError,
 } from "../utils/errors";
 import { validateChainForEnvironment, type Chain } from "../chains/chains";
 import { type ChainAdapter, type ChainType, getChainAdapter, isSupportedChainType } from "../chains/chain-adapter";
@@ -1190,7 +1193,12 @@ export class Wallet<C extends Chain> {
     }
 
     protected async approveTransactionInternal(transactionId: string, options?: ApproveOptions) {
-        const transaction = await this.#apiClient.getTransaction(this.walletLocator, transactionId);
+        let transaction: GetTransactionResponse;
+        try {
+            transaction = await this.#apiClient.getTransaction(this.walletLocator, transactionId);
+        } catch (error) {
+            throw wrapTransactionApiError(error, transactionId) ?? error;
+        }
 
         if ("error" in transaction) {
             throwIfCrossmintApiAuthError(transaction);
@@ -1252,9 +1260,14 @@ export class Wallet<C extends Chain> {
 
     private async executeApproveTransactionWithErrorHandling(transactionId: string, approvals: Approval[]) {
         walletsLogger.info("wallet.approve: submitting approval to API", { transactionId });
-        const approvedTransaction = await this.#apiClient.approveTransaction(this.walletLocator, transactionId, {
-            approvals,
-        });
+        let approvedTransaction: ApproveTransactionResponse;
+        try {
+            approvedTransaction = await this.#apiClient.approveTransaction(this.walletLocator, transactionId, {
+                approvals,
+            });
+        } catch (error) {
+            throw wrapTransactionApiError(error, transactionId) ?? error;
+        }
 
         if (approvedTransaction.error) {
             throwIfCrossmintApiAuthError(approvedTransaction);


### PR DESCRIPTION
## Description

A customer reported that their first `sendTransaction` on a Solana smart wallet (which triggers the on-chain `AddSigner` bootstrap) landed successfully on-chain, but the SDK raised a bare `"API request failed: 500"` to the client. An unrecoverable-looking error on an operation that actually succeeded invites a naive retry — in a trading context that means **double-buy risk**.

Root cause: `ApiClient.makeRequest` (common base) throws `ApiClientError` on any 5xx regardless of the operation's actual outcome, and no layer of the create/approve/poll pipeline attaches the `transactionId` before the error reaches the caller — even at approve/poll sites where the ID is already known locally. (PR #1966's polling rework did not change error propagation.)

This PR keeps the pipeline unchanged and adds the smallest reconciliation path: a new exported `TransactionApiError extends CrossmintSDKError` carrying `transactionId?` and `status?`, plus a `wrapTransactionApiError(error, transactionId?)` helper applied at each throw site:

```
// create (solana.ts, api/client.ts): id best-effort parsed from 5xx responseBody
catch (error) { throw wrapTransactionApiError(error) ?? error; }

// approve lookup, approve submission (wallet.ts), polling (operation-poller.ts): id known locally
catch (error) { throw wrapTransactionApiError(error, transactionId) ?? error; }
```

Behavioral change: a 5xx during create/approve/poll now throws `TransactionApiError` instead of a raw `ApiClientError`. When the transaction ID is known, the message includes `(transactionId: ...)` and guidance to check status before retrying; when unknown (opaque create 5xx), the message states the outcome is indeterminate. Clients can catch `TransactionApiError`, read `error.transactionId`, and reconcile (e.g. fetch transaction status) instead of blindly retrying `sendTransaction`.

**Open product question:** this PR deliberately re-throws (does not swallow) 5xx even when the transaction may have succeeded — swallowing vs. polling-through on create-5xx is a product decision. The safe minimal change here only makes the error reconcilable.

## Test plan

* New vitest cases in `@crossmint/wallets-sdk`:
  * create 5xx with `{"id": ...}` body → `TransactionApiError` with `transactionId` set
  * create 5xx with opaque body → `TransactionApiError` with `status` set, `transactionId` undefined, "indeterminate" message
  * poll 5xx → `transactionId` attached
  * approve lookup 5xx → `transactionId` attached
* `pnpm lint`, `pnpm --filter @crossmint/wallets-sdk... build && pnpm --filter @crossmint/wallets-sdk test:vitest` (653 passed, 68 skipped integration)

## Package updates

* `@crossmint/wallets-sdk` — patch changeset added (`.changeset/quiet-wombats-reconcile-transaction-5xx.md`)

Link to Devin session: https://crossmint.devinenterprise.com/sessions/57c0d09399aa4688aaef9347747ff79d
Requested by: @alfonso-paella