### PR TITLE
Surface the device signer error code and underlying cause in logs

### DIFF
--- a/.changeset/device-signer-error-code.md
+++ b/.changeset/device-signer-error-code.md
@@ -1,0 +1,7 @@
+---
+"@crossmint/client-sdk-react-native-ui": patch
+---
+
+Surface the device signer error code and underlying reason from the native module, so a failed sign is diagnosable from its logs instead of a generic `SignMessageFailed`.
+
+`DeviceSignerModule.signMessage` now throws the Expo exception with the SDK error code passed explicitly through `code:` (Expo otherwise derives the code from the exception name, which garbles an `UPPER_SNAKE` value like `DEVICE_SIGNER_SIGNING_FAILED`), and with the underlying error in the message. Also bumps the `CrossmintDeviceSigner` pod to `~> 1.1.2`, which carries that underlying detail.

--- a/packages/client/ui/react-native/ios/CrossmintReactNativeUI.podspec
+++ b/packages/client/ui/react-native/ios/CrossmintReactNativeUI.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.swift_version  = '6.0'
 
   s.dependency 'ExpoModulesCore'
-  s.dependency 'CrossmintDeviceSigner', '~> 0.12'
+  s.dependency 'CrossmintDeviceSigner', '~> 1.1.2'
 end

--- a/packages/client/ui/react-native/ios/DeviceSignerModule.swift
+++ b/packages/client/ui/react-native/ios/DeviceSignerModule.swift
@@ -61,12 +61,7 @@ public class DeviceSignerModule: Module {
                 let sig = try await DeviceSignerModule.defaultStorage().signMessage(address: address, message: message)
                 return ["r": sig.r, "s": sig.s]
             } catch let error as DeviceSignerError {
-                // Surface the SDK error code as the exception name so JS can branch on it
-                // (e.g. re-register the device signer on DEVICE_SIGNER_SIGNING_FAILED or
-                // DEVICE_SIGNER_KEY_NOT_FOUND). The description carries the underlying reason;
-                // Expo already prefixes "Calling the 'signMessage' function has failed", so we
-                // do not add our own redundant prefix.
-                throw Exception(name: error.code, description: error.message)
+                throw Exception(name: error.code, description: error.message, code: error.code)
             } catch {
                 throw Exception(name: "SignMessageFailed", description: "signMessage failed: \(error)")
             }

--- a/packages/client/ui/react-native/ios/DeviceSignerModule.swift
+++ b/packages/client/ui/react-native/ios/DeviceSignerModule.swift
@@ -60,6 +60,13 @@ public class DeviceSignerModule: Module {
             do {
                 let sig = try await DeviceSignerModule.defaultStorage().signMessage(address: address, message: message)
                 return ["r": sig.r, "s": sig.s]
+            } catch let error as DeviceSignerError {
+                // Surface the SDK error code as the exception name so JS can branch on it
+                // (e.g. re-register the device signer on DEVICE_SIGNER_SIGNING_FAILED or
+                // DEVICE_SIGNER_KEY_NOT_FOUND). The description carries the underlying reason;
+                // Expo already prefixes "Calling the 'signMessage' function has failed", so we
+                // do not add our own redundant prefix.
+                throw Exception(name: error.code, description: error.message)
             } catch {
                 throw Exception(name: "SignMessageFailed", description: "signMessage failed: \(error)")
             }

--- a/packages/client/ui/react-native/src/native/NativeDeviceSignerKeyStorage.ts
+++ b/packages/client/ui/react-native/src/native/NativeDeviceSignerKeyStorage.ts
@@ -2,6 +2,35 @@ import { requireNativeModule } from "expo-modules-core";
 import * as Device from "expo-device";
 import { DeviceSignerKeyStorage } from "@crossmint/wallets-sdk";
 
+/**
+ * Error thrown when a native device signer operation fails.
+ *
+ * `code` is the stable machine code surfaced by the native module (for example
+ * `DEVICE_SIGNER_SIGNING_FAILED` or `DEVICE_SIGNER_KEY_NOT_FOUND`) so callers and
+ * error reporters can branch and group on it without parsing the message. The
+ * original native error is preserved on `cause` for the full underlying detail.
+ */
+export class DeviceSignerNativeError extends Error {
+    readonly code: string;
+    readonly cause?: unknown;
+
+    constructor(code: string, message: string, options?: { cause?: unknown }) {
+        super(message);
+        this.name = "DeviceSignerNativeError";
+        this.code = code;
+        this.cause = options?.cause;
+    }
+}
+
+function toDeviceSignerNativeError(error: unknown): DeviceSignerNativeError {
+    const nativeCode = (error as { code?: unknown } | null | undefined)?.code;
+    const code = typeof nativeCode === "string" && nativeCode.length > 0 ? nativeCode : "DEVICE_SIGNER_NATIVE_ERROR";
+    // The native message already names the operation (Expo prefixes "Calling the '<fn>'
+    // function has failed"), so pass it through as-is and keep code + cause structured.
+    const message = error instanceof Error ? error.message : String(error);
+    return new DeviceSignerNativeError(code, message, { cause: error });
+}
+
 interface CrossmintDeviceSignerModule {
     isAvailable(): Promise<boolean>;
     generateKey(address: string | null): Promise<string>;
@@ -36,12 +65,20 @@ export class NativeDeviceSignerKeyStorage extends DeviceSignerKeyStorage {
         super("");
     }
 
-    generateKey(params: { address?: string }): Promise<string> {
-        return getNativeModule().generateKey(params.address ?? null);
+    async generateKey(params: { address?: string }): Promise<string> {
+        try {
+            return await getNativeModule().generateKey(params.address ?? null);
+        } catch (error) {
+            throw toDeviceSignerNativeError(error);
+        }
     }
 
-    mapAddressToKey(address: string, publicKeyBase64: string): Promise<void> {
-        return getNativeModule().mapAddressToKey(address, publicKeyBase64);
+    async mapAddressToKey(address: string, publicKeyBase64: string): Promise<void> {
+        try {
+            return await getNativeModule().mapAddressToKey(address, publicKeyBase64);
+        } catch (error) {
+            throw toDeviceSignerNativeError(error);
+        }
     }
 
     getKey(address: string): Promise<string | null> {
@@ -52,16 +89,28 @@ export class NativeDeviceSignerKeyStorage extends DeviceSignerKeyStorage {
         return getNativeModule().hasKey(publicKeyBase64);
     }
 
-    signMessage(address: string, message: string): Promise<{ r: string; s: string }> {
-        return getNativeModule().signMessage(address, message);
+    async signMessage(address: string, message: string): Promise<{ r: string; s: string }> {
+        try {
+            return await getNativeModule().signMessage(address, message);
+        } catch (error) {
+            throw toDeviceSignerNativeError(error);
+        }
     }
 
-    deleteKey(address: string): Promise<void> {
-        return getNativeModule().deleteKey(address);
+    async deleteKey(address: string): Promise<void> {
+        try {
+            return await getNativeModule().deleteKey(address);
+        } catch (error) {
+            throw toDeviceSignerNativeError(error);
+        }
     }
 
-    deletePendingKey(publicKeyBase64: string): Promise<void> {
-        return getNativeModule().deletePendingKey(publicKeyBase64);
+    async deletePendingKey(publicKeyBase64: string): Promise<void> {
+        try {
+            return await getNativeModule().deletePendingKey(publicKeyBase64);
+        } catch (error) {
+            throw toDeviceSignerNativeError(error);
+        }
     }
 
     getDeviceName(): string {

--- a/packages/client/ui/react-native/src/native/NativeDeviceSignerKeyStorage.ts
+++ b/packages/client/ui/react-native/src/native/NativeDeviceSignerKeyStorage.ts
@@ -2,35 +2,6 @@ import { requireNativeModule } from "expo-modules-core";
 import * as Device from "expo-device";
 import { DeviceSignerKeyStorage } from "@crossmint/wallets-sdk";
 
-/**
- * Error thrown when a native device signer operation fails.
- *
- * `code` is the stable machine code surfaced by the native module (for example
- * `DEVICE_SIGNER_SIGNING_FAILED` or `DEVICE_SIGNER_KEY_NOT_FOUND`) so callers and
- * error reporters can branch and group on it without parsing the message. The
- * original native error is preserved on `cause` for the full underlying detail.
- */
-export class DeviceSignerNativeError extends Error {
-    readonly code: string;
-    readonly cause?: unknown;
-
-    constructor(code: string, message: string, options?: { cause?: unknown }) {
-        super(message);
-        this.name = "DeviceSignerNativeError";
-        this.code = code;
-        this.cause = options?.cause;
-    }
-}
-
-function toDeviceSignerNativeError(error: unknown): DeviceSignerNativeError {
-    const nativeCode = (error as { code?: unknown } | null | undefined)?.code;
-    const code = typeof nativeCode === "string" && nativeCode.length > 0 ? nativeCode : "DEVICE_SIGNER_NATIVE_ERROR";
-    // The native message already names the operation (Expo prefixes "Calling the '<fn>'
-    // function has failed"), so pass it through as-is and keep code + cause structured.
-    const message = error instanceof Error ? error.message : String(error);
-    return new DeviceSignerNativeError(code, message, { cause: error });
-}
-
 interface CrossmintDeviceSignerModule {
     isAvailable(): Promise<boolean>;
     generateKey(address: string | null): Promise<string>;
@@ -65,20 +36,12 @@ export class NativeDeviceSignerKeyStorage extends DeviceSignerKeyStorage {
         super("");
     }
 
-    async generateKey(params: { address?: string }): Promise<string> {
-        try {
-            return await getNativeModule().generateKey(params.address ?? null);
-        } catch (error) {
-            throw toDeviceSignerNativeError(error);
-        }
+    generateKey(params: { address?: string }): Promise<string> {
+        return getNativeModule().generateKey(params.address ?? null);
     }
 
-    async mapAddressToKey(address: string, publicKeyBase64: string): Promise<void> {
-        try {
-            return await getNativeModule().mapAddressToKey(address, publicKeyBase64);
-        } catch (error) {
-            throw toDeviceSignerNativeError(error);
-        }
+    mapAddressToKey(address: string, publicKeyBase64: string): Promise<void> {
+        return getNativeModule().mapAddressToKey(address, publicKeyBase64);
     }
 
     getKey(address: string): Promise<string | null> {
@@ -89,28 +52,16 @@ export class NativeDeviceSignerKeyStorage extends DeviceSignerKeyStorage {
         return getNativeModule().hasKey(publicKeyBase64);
     }
 
-    async signMessage(address: string, message: string): Promise<{ r: string; s: string }> {
-        try {
-            return await getNativeModule().signMessage(address, message);
-        } catch (error) {
-            throw toDeviceSignerNativeError(error);
-        }
+    signMessage(address: string, message: string): Promise<{ r: string; s: string }> {
+        return getNativeModule().signMessage(address, message);
     }
 
-    async deleteKey(address: string): Promise<void> {
-        try {
-            return await getNativeModule().deleteKey(address);
-        } catch (error) {
-            throw toDeviceSignerNativeError(error);
-        }
+    deleteKey(address: string): Promise<void> {
+        return getNativeModule().deleteKey(address);
     }
 
-    async deletePendingKey(publicKeyBase64: string): Promise<void> {
-        try {
-            return await getNativeModule().deletePendingKey(publicKeyBase64);
-        } catch (error) {
-            throw toDeviceSignerNativeError(error);
-        }
+    deletePendingKey(publicKeyBase64: string): Promise<void> {
+        return getNativeModule().deletePendingKey(publicKeyBase64);
     }
 
     getDeviceName(): string {


### PR DESCRIPTION
When a device signer failed, the bridge sent the same generic `SignMessageFailed` error every time. You could not see why it failed, or tell `signingFailed` from `keyNotFound`. This passes the real error code and the underlying reason through, so each failure is clear in the logs.

The error code now travels on the Expo exception's `code` field, and the message includes the underlying error. Expo already passes both to JavaScript, so the JS side stays a plain passthrough.

## Changes
- `DeviceSignerModule.signMessage` now throws the Expo error with the real message and passes the code through the `code:` argument. Without the explicit `code:`, Expo builds the code from the exception name and garbles a value like `DEVICE_SIGNER_SIGNING_FAILED`
- Bumps the `CrossmintDeviceSigner` pod to `~> 1.1.2`, which carries the underlying error
