### PR TITLE
Bump device signer error changeset to minor

### DIFF
--- a/.changeset/device-signer-error-code.md
+++ b/.changeset/device-signer-error-code.md
@@ -1,5 +1,5 @@
 ---
-"@crossmint/client-sdk-react-native-ui": patch
+"@crossmint/client-sdk-react-native-ui": minor
 ---
 
 Surface the device signer error code and underlying reason from the native module, so a failed sign is diagnosable from its logs instead of a generic `SignMessageFailed`.


### PR DESCRIPTION
The device signer error changeset landed as a `patch`, but it includes changes to our native module/code which can't be shipped OTA as a patch, so it should ship as a `minor`

This flips it to `minor` so the open Release packages PR (#1985) bumps `@crossmint/client-sdk-react-native-ui` from `1.4.4` to `1.5.0` instead of `1.4.5`