### PR TITLE
chore: remove deprecated checkoutcom-flow and stripe-payment-element from CreateOrderInputDTO

### DIFF
--- a/.changeset/remove-deprecated-payment-methods.md
+++ b/.changeset/remove-deprecated-payment-methods.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+chore: remove deprecated checkoutcom-flow and stripe-payment-element from CreateOrderInputDTO

--- a/packages/wallets/src/openapi.json
+++ b/packages/wallets/src/openapi.json
@@ -4950,68 +4950,6 @@
                                             },
                                             "method": {
                                                 "type": "string",
-                                                "enum": ["stripe-payment-element"]
-                                            },
-                                            "currency": {
-                                                "type": "string",
-                                                "enum": [
-                                                    "usd",
-                                                    "eur",
-                                                    "aud",
-                                                    "gbp",
-                                                    "jpy",
-                                                    "sgd",
-                                                    "hkd",
-                                                    "krw",
-                                                    "inr",
-                                                    "vnd"
-                                                ]
-                                            }
-                                        },
-                                        "required": ["method"]
-                                    },
-                                    {
-                                        "type": "object",
-                                        "properties": {
-                                            "receiptEmail": {
-                                                "description": "Email that the receipt will be sent to.",
-                                                "type": "string",
-                                                "format": "email",
-                                                "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$"
-                                            },
-                                            "method": {
-                                                "type": "string",
-                                                "enum": ["checkoutcom-flow"]
-                                            },
-                                            "currency": {
-                                                "type": "string",
-                                                "enum": [
-                                                    "usd",
-                                                    "eur",
-                                                    "aud",
-                                                    "gbp",
-                                                    "jpy",
-                                                    "sgd",
-                                                    "hkd",
-                                                    "krw",
-                                                    "inr",
-                                                    "vnd"
-                                                ]
-                                            }
-                                        },
-                                        "required": ["method"]
-                                    },
-                                    {
-                                        "type": "object",
-                                        "properties": {
-                                            "receiptEmail": {
-                                                "description": "Email that the receipt will be sent to.",
-                                                "type": "string",
-                                                "format": "email",
-                                                "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$"
-                                            },
-                                            "method": {
-                                                "type": "string",
                                                 "enum": ["card-token"]
                                             },
                                             "currency": {
@@ -7035,68 +6973,6 @@
                                             }
                                         },
                                         "required": ["method", "currency"]
-                                    },
-                                    {
-                                        "type": "object",
-                                        "properties": {
-                                            "receiptEmail": {
-                                                "description": "Email that the receipt will be sent to.",
-                                                "type": "string",
-                                                "format": "email",
-                                                "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$"
-                                            },
-                                            "method": {
-                                                "type": "string",
-                                                "enum": ["stripe-payment-element"]
-                                            },
-                                            "currency": {
-                                                "type": "string",
-                                                "enum": [
-                                                    "usd",
-                                                    "eur",
-                                                    "aud",
-                                                    "gbp",
-                                                    "jpy",
-                                                    "sgd",
-                                                    "hkd",
-                                                    "krw",
-                                                    "inr",
-                                                    "vnd"
-                                                ]
-                                            }
-                                        },
-                                        "required": ["method"]
-                                    },
-                                    {
-                                        "type": "object",
-                                        "properties": {
-                                            "receiptEmail": {
-                                                "description": "Email that the receipt will be sent to.",
-                                                "type": "string",
-                                                "format": "email",
-                                                "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$"
-                                            },
-                                            "method": {
-                                                "type": "string",
-                                                "enum": ["checkoutcom-flow"]
-                                            },
-                                            "currency": {
-                                                "type": "string",
-                                                "enum": [
-                                                    "usd",
-                                                    "eur",
-                                                    "aud",
-                                                    "gbp",
-                                                    "jpy",
-                                                    "sgd",
-                                                    "hkd",
-                                                    "krw",
-                                                    "inr",
-                                                    "vnd"
-                                                ]
-                                            }
-                                        },
-                                        "required": ["method"]
                                     },
                                     {
                                         "type": "object",


### PR DESCRIPTION
## Description

Removes the deprecated `checkoutcom-flow` and `stripe-payment-element` `payment.method` enum options from `CreateOrderInputDTO` in `packages/wallets/src/openapi.json`. The existing `card` option covers the same card-payment flows, and this aligns the public SDK spec with the docs deprecation messaging.

Note: `packages/client/base/src/lib/hosted-checkout/Order.ts` still lists these values because it mirrors the order *response* schema, and the API currently still emits processor-specific method values in order objects.

## Test plan

- Verified the file is valid JSON after the change
- Confirmed `card` remains a valid `payment.method` option in both `anyOf` branches of `CreateOrderInputDTO`
- Confirmed `checkoutcom-flow` and `stripe-payment-element` are no longer present in `CreateOrderInputDTO.payment` oneOf entries

## Package updates

- This is a spec-only change in `packages/wallets/src/openapi.json` and does not change runtime code or public package APIs, so no changeset is required.

Link to Devin session: https://crossmint.devinenterprise.com/sessions/0e2ad01383a94c8282aa5dc3493084ca
Requested by: @fedemint