### PR TITLE
playground(rn): mock passkey signer for CI e2e flows (WAL-11271)

### DIFF
--- a/apps/wallets/expo/snippets/07-permissions.tsx
+++ b/apps/wallets/expo/snippets/07-permissions.tsx
@@ -3,15 +3,18 @@ import { Permissions as PermissionsShared } from "@crossmint/wallets-playground-
 import { createMockPasskeySigner } from "../src/mockPasskey";
 
 export function Permissions() {
-    const { wallet, createDeviceSigner } = useWallet();
-    // The RN provider guards real passkeys (no WebAuthn on native) — its
-    // createPasskeySigner always throws. The playground passes a mock instead so
-    // e2e flows can exercise the add-signer path, mirroring the Flutter sample.
+    const { wallet, createDeviceSigner, createPasskeySigner } = useWallet();
+    // Mock passkeys are for CI e2e only: the Maestro flows in
+    // crossmint-mobile-e2e-tests set EXPO_PUBLIC_MOCK_PASSKEY=true at build time
+    // so they can exercise the add-signer path (the RN provider's real
+    // createPasskeySigner always throws — no WebAuthn on native). The real path
+    // is preserved by default for local/manual testing.
+    const useMockPasskey = process.env.EXPO_PUBLIC_MOCK_PASSKEY === "true";
     return (
         <PermissionsShared
             wallet={wallet}
             createDeviceSigner={createDeviceSigner}
-            createPasskeySigner={createMockPasskeySigner}
+            createPasskeySigner={useMockPasskey ? createMockPasskeySigner : createPasskeySigner}
         />
     );
 }

--- a/apps/wallets/expo/snippets/07-permissions.tsx
+++ b/apps/wallets/expo/snippets/07-permissions.tsx
@@ -1,13 +1,17 @@
 import { useWallet } from "@crossmint/client-sdk-react-native-ui";
 import { Permissions as PermissionsShared } from "@crossmint/wallets-playground-shared";
+import { createMockPasskeySigner } from "../src/mockPasskey";
 
 export function Permissions() {
-    const { wallet, createDeviceSigner, createPasskeySigner } = useWallet();
+    const { wallet, createDeviceSigner } = useWallet();
+    // The RN provider guards real passkeys (no WebAuthn on native) — its
+    // createPasskeySigner always throws. The playground passes a mock instead so
+    // e2e flows can exercise the add-signer path, mirroring the Flutter sample.
     return (
         <PermissionsShared
             wallet={wallet}
             createDeviceSigner={createDeviceSigner}
-            createPasskeySigner={createPasskeySigner}
+            createPasskeySigner={createMockPasskeySigner}
         />
     );
 }

--- a/apps/wallets/expo/src/mockPasskey.ts
+++ b/apps/wallets/expo/src/mockPasskey.ts
@@ -16,7 +16,9 @@ function randomHex(byteLength: number): string {
 }
 
 /**
- * MOCK passkey creator for the playground app only.
+ * MOCK passkey creator for the playground app only. Only injected when
+ * EXPO_PUBLIC_MOCK_PASSKEY=true (CI e2e test mode) — see snippets/07-permissions.tsx;
+ * default builds keep the real provider path for local/manual testing.
  *
  * The React Native provider guards real passkey creation (`createPasskeySigner`
  * throws — there is no WebAuthn on native), but `wallet.addSigner` accepts a

--- a/apps/wallets/expo/src/mockPasskey.ts
+++ b/apps/wallets/expo/src/mockPasskey.ts
@@ -1,0 +1,60 @@
+import { Alert } from "react-native";
+import type { CrossmintWalletBaseContext } from "@crossmint/client-sdk-react-native-ui";
+
+// The descriptor shape expected by `wallet.addSigner` for passkeys
+// (RegisterSignerPasskeyParams from @crossmint/wallets-sdk), derived from the
+// provider context so it stays in sync with the SDK.
+type PasskeySignerDescriptor = Awaited<ReturnType<CrossmintWalletBaseContext["createPasskeySigner"]>>;
+
+function randomHex(byteLength: number): string {
+    const bytes = new Uint8Array(byteLength);
+    // Polyfilled by react-native-get-random-values (see utils/polyfills.ts).
+    crypto.getRandomValues(bytes);
+    return Array.from(bytes)
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("");
+}
+
+/**
+ * MOCK passkey creator for the playground app only.
+ *
+ * The React Native provider guards real passkey creation (`createPasskeySigner`
+ * throws — there is no WebAuthn on native), but `wallet.addSigner` accepts a
+ * passkey descriptor, and the register-signer API does not validate the WebAuthn
+ * attestation. This mock lets Maestro e2e flows exercise the "add passkey signer"
+ * path on CI, mirroring the Flutter sample's mock passkey dialog
+ * (example/lib/wallets_v1_playground/views/dialogs/passkey_dialog.dart).
+ *
+ * Note: publicKey.x/y must be valid positive BigInt decimal or hex strings —
+ * the API rejects bare hex without the 0x prefix with HTTP 400.
+ */
+export function createMockPasskeySigner(name: string): Promise<PasskeySignerDescriptor> {
+    return new Promise((resolve, reject) => {
+        Alert.alert(
+            "Create Passkey (Mock)",
+            "This playground simulates passkey creation with random credentials. No real WebAuthn ceremony takes place.",
+            [
+                {
+                    text: "Cancel",
+                    style: "cancel",
+                    onPress: () => reject(new Error("Passkey creation cancelled")),
+                },
+                {
+                    text: "Simulate",
+                    onPress: () =>
+                        resolve({
+                            type: "passkey",
+                            id: `mock-credential-${randomHex(8)}`,
+                            name,
+                            publicKey: {
+                                x: `0x${randomHex(32)}`,
+                                y: `0x${randomHex(32)}`,
+                            },
+                        }),
+                },
+            ],
+            // Treat dismissing the alert (tap outside / back button) as cancel.
+            { cancelable: true, onDismiss: () => reject(new Error("Passkey creation cancelled")) }
+        );
+    });
+}


### PR DESCRIPTION
## Summary

The React Native playground (`apps/wallets/expo`) renders the passkey signer UI via the shared `Permissions` component, but the RN provider hard-guards passkeys: `createPasskeySigner` from `useWallet()` always throws "Passkey signers are not supported in React Native..." because there is no WebAuthn ceremony on native. This blocked Maestro e2e flows from exercising the "add passkey signer" path on CI.

This PR adds a **mock** passkey creation path, sample-app-only (no published package is touched):

- `apps/wallets/expo/src/mockPasskey.ts` — `createMockPasskeySigner(name)` shows an `Alert` ("Create Passkey (Mock)") with **Cancel** (rejects with "Passkey creation cancelled", surfaced in the shared component's status label) and **Simulate** (resolves a fake descriptor: `id: mock-credential-<8 random hex bytes>`, `publicKey.x/y: 0x + 32 random hex bytes`). Typed against the SDK's `RegisterSignerPasskeyParams` via the provider context type, so it stays in sync.
- `apps/wallets/expo/snippets/07-permissions.tsx` — passes the mock as the `createPasskeySigner` prop to the shared `Permissions` component instead of the guarded hook value.

### Why this works

- The RN guard (`PasskeyGuard` in `packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx`) only wraps `createWallet`, `createPasskeySigner`, and the `createOnLogin` config — `wallet.addSigner()` accepts a passkey descriptor unguarded, and delegated-signer approval is done by the recovery signer, not the passkey itself.
- The register-signer API does not validate the WebAuthn attestation; it only validates `publicKey.x/y` as positive BigInt decimal/hex strings (bare hex without `0x` is rejected with HTTP 400 — the mock uses the `0x` prefix).
- This mirrors the already-merged, e2e-proven precedent in the Flutter SDK sample (`example/lib/wallets_v1_playground/views/dialogs/passkey_dialog.dart`), where the same mock credentials are accepted and the signer appears with a `passkey:` locator.

### Follow-up

A follow-up PR in `crossmint-mobile-e2e-tests` enables the RN passkey leg of the delegated-signers Maestro flow behind an env flag once this lands.

## Test plan

- [x] `tsc --noEmit` on the expo app — no new errors (one pre-existing error in `snippets/09-chain-switcher.tsx` exists on clean `origin/main`, untouched here)
- [x] `biome check` clean on both touched files
- [ ] Manual/Maestro: add-passkey flow on the Android playground — select passkey chip, enter name, tap `signers-add-button`, tap "Simulate", verify signer appears in `signers-list` with a `passkey:mock-credential-...` locator
- [ ] Cancel path: tapping "Cancel" surfaces "addSigner error: Passkey creation cancelled" in the status label