### PR TITLE
PAY-12564: add GlobalMessage display rule to EmbeddedCheckoutV3AppearanceRules

### DIFF
--- a/.changeset/global-message-appearance-rule.md
+++ b/.changeset/global-message-appearance-rule.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-base": minor
+---
+
+Added `GlobalMessage` display rule to `EmbeddedCheckoutV3AppearanceRules`.

--- a/packages/client/base/src/types/embed/v3/CrossmintEmbeddedCheckoutV3Props.ts
+++ b/packages/client/base/src/types/embed/v3/CrossmintEmbeddedCheckoutV3Props.ts
@@ -100,6 +100,9 @@ export type EmbeddedCheckoutV3AppearanceRules = {
     ReceiptEmailInput?: {
         display?: "hidden";
     };
+    GlobalMessage?: {
+        display?: "hidden" | "visible";
+    };
     Label?: {
         font?: {
             family?: string;


### PR DESCRIPTION
## Description

Mirrors the new appearance rule introduced in [Paella-Labs/crossbit-main#27986](https://github.com/Paella-Labs/crossbit-main/pull/27986) into the public `@crossmint/client-sdk-base` types.

Adds `GlobalMessage` to `EmbeddedCheckoutV3AppearanceRules` so integrators can opt in/out of global-message banners in the embedded checkout:

```ts
appearance: {
  rules: {
    GlobalMessage: {
      display: "visible", // or "hidden"
    },
  },
}
```

This is the SDK-side type that backs the runtime `GlobalMessage` behavior in the web checkout (Express Checkout now uses `defaultVisible={false}` and only renders the banner when `rules.GlobalMessage.display === "visible"`).

## Test plan

- `pnpm --filter @crossmint/client-sdk-base build` passes (after building workspace deps).
- `pnpm exec biome check --diagnostic-level=error --max-diagnostics=200 packages/client/base/src/types/embed/v3/CrossmintEmbeddedCheckoutV3Props.ts` passes.
- Added a changeset for `@crossmint/client-sdk-base`.

## Package updates

- `@crossmint/client-sdk-base`: minor bump (new optional `GlobalMessage` rule in `EmbeddedCheckoutV3AppearanceRules`).


Link to Devin session: https://crossmint.devinenterprise.com/sessions/52f46c7183fa4e76a894c8d6c4b71f1a
Requested by: @pabloe-crossmint