### PR TITLE
fix(react-native-ui): surface the real device signer error reason to JS

### DIFF
--- a/.changeset/device-signer-error-reason.md
+++ b/.changeset/device-signer-error-reason.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-native-ui": patch
+---
+
+Fixed device signer native errors reaching JS as "undefined reason" instead of the actual failure message, by overriding `reason` on the thrown Expo `Exception` instead of relying on `description`.

--- a/packages/client/ui/react-native/ios/DeviceSignerModule.swift
+++ b/packages/client/ui/react-native/ios/DeviceSignerModule.swift
@@ -11,6 +11,20 @@ import Security
 ///
 /// The module is registered as `"CrossmintDeviceSigner"` and consumed on the JS side by
 /// `NativeDeviceSignerKeyStorage` from `@crossmint/client-sdk-react-native-ui`.
+
+// Expo's JS bridge reads `reason`, not the `description` passed to `Exception.init`, so a plain
+// `Exception(description:)` reaches JS as "undefined reason". Overriding `reason` fixes that.
+private final class MessageException: Exception {
+    private let reasonMessage: String
+
+    init(name: String, message: String, code: String? = nil) {
+        self.reasonMessage = message
+        super.init(name: name, description: message, code: code)
+    }
+
+    override var reason: String { reasonMessage }
+}
+
 public class DeviceSignerModule: Module {
 
     // MARK: - Module definition
@@ -29,10 +43,7 @@ public class DeviceSignerModule: Module {
             do {
                 return try await DeviceSignerModule.defaultStorage().generateKey(address: address)
             } catch {
-                throw Exception(
-                    name: "GenerateKeyFailed",
-                    description: "generateKey failed: \(error)"
-                )
+                throw MessageException(name: "GenerateKeyFailed", message: "generateKey failed: \(error)")
             }
         }
 
@@ -41,7 +52,7 @@ public class DeviceSignerModule: Module {
             do {
                 try await DeviceSignerModule.defaultStorage().mapAddressToKey(address: address, publicKeyBase64: publicKeyBase64)
             } catch {
-                throw Exception(name: "MapAddressToKeyFailed", description: "mapAddressToKey failed: \(error)")
+                throw MessageException(name: "MapAddressToKeyFailed", message: "mapAddressToKey failed: \(error)")
             }
         }
 
@@ -61,9 +72,9 @@ public class DeviceSignerModule: Module {
                 let sig = try await DeviceSignerModule.defaultStorage().signMessage(address: address, message: message)
                 return ["r": sig.r, "s": sig.s]
             } catch let error as DeviceSignerError {
-                throw Exception(name: error.code, description: error.message, code: error.code)
+                throw MessageException(name: error.code, message: error.message, code: error.code)
             } catch {
-                throw Exception(name: "SignMessageFailed", description: "signMessage failed: \(error)")
+                throw MessageException(name: "SignMessageFailed", message: "signMessage failed: \(error)")
             }
         }
 

--- a/packages/client/ui/react-native/ios/DeviceSignerModule.swift
+++ b/packages/client/ui/react-native/ios/DeviceSignerModule.swift
@@ -98,8 +98,6 @@ public class DeviceSignerModule: Module {
     }
 }
 
-// Expo's JS bridge reads `reason`, not the `description` passed to `Exception.init`, so a plain
-// `Exception(description:)` reaches JS as "undefined reason". Overriding `reason` fixes that.
 private final class MessageException: Exception {
     private let reasonMessage: String
 

--- a/packages/client/ui/react-native/ios/DeviceSignerModule.swift
+++ b/packages/client/ui/react-native/ios/DeviceSignerModule.swift
@@ -12,19 +12,6 @@ import Security
 /// The module is registered as `"CrossmintDeviceSigner"` and consumed on the JS side by
 /// `NativeDeviceSignerKeyStorage` from `@crossmint/client-sdk-react-native-ui`.
 
-// Expo's JS bridge reads `reason`, not the `description` passed to `Exception.init`, so a plain
-// `Exception(description:)` reaches JS as "undefined reason". Overriding `reason` fixes that.
-private final class MessageException: Exception {
-    private let reasonMessage: String
-
-    init(name: String, message: String, code: String? = nil) {
-        self.reasonMessage = message
-        super.init(name: name, description: message, code: code)
-    }
-
-    override var reason: String { reasonMessage }
-}
-
 public class DeviceSignerModule: Module {
 
     // MARK: - Module definition
@@ -109,4 +96,17 @@ public class DeviceSignerModule: Module {
         }
         #endif
     }
+}
+
+// Expo's JS bridge reads `reason`, not the `description` passed to `Exception.init`, so a plain
+// `Exception(description:)` reaches JS as "undefined reason". Overriding `reason` fixes that.
+private final class MessageException: Exception {
+    private let reasonMessage: String
+
+    init(name: String, message: String, code: String? = nil) {
+        self.reasonMessage = message
+        super.init(name: name, description: message, code: code)
+    }
+
+    override var reason: String { reasonMessage }
 }


### PR DESCRIPTION
## Summary

Split out of this PR's original scope — the recovery-fix half now lives in #1995, so this one is just the diagnostics fix and can go through its own native build cycle.

Expo's JS bridge builds the JS `Error.message` from `Exception.reason`, not the `description` passed to `Exception.init`, so every native throw in `DeviceSignerModule.swift` was reaching JS as "undefined reason" regardless of the actual failure. A `MessageException` subclass overrides `reason` so the real message gets through. Reproduced with a real corrupted-key repro on device, producing the actual CryptoTokenKit error instead of "undefined reason".

This is a native iOS change, not OTA-safe — requires a new app build.

## Test plan

- [x] Verified on a real physical device via a reversible key-corruption repro (not a destructive erase)