### PR TITLE
feat(wallets): quorum-aware recovery identity — useSigner selects the held member (M4-4 part 4/4)

### DIFF
--- a/.changeset/quorum-member-signing.md
+++ b/.changeset/quorum-member-signing.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": minor
+---
+
+Quorum-aware recovery identity: `useSigner` now selects the quorum member the caller holds — matched against the member configs by type (email/phone normalized, passkey by id or name, server by derived address including legacy derivations, external-wallet by address) — and assembles it as an admin signer, so approvals are submitted under the member's locator. `useSigner` gains an optional second `options` argument with `quorumLocator` to force the member interpretation for a key that exists both inside the quorum and as a delegated signer. Admin operations (`addSigner`/`removeSigner`) run with the active member when it belongs to the quorum, and device-signer recovery reuses a member previously selected via `useSigner` in the same session. The wallet factory now preserves member runtime config (server `secret`, external-wallet `onSign`, passkey callbacks) across the API round-trip, and server member secrets are stripped after resolution. The former `QuorumSignerNotSupportedError` guards are replaced by these working flows or actionable errors listing the member locators.

--- a/packages/wallets/src/index.ts
+++ b/packages/wallets/src/index.ts
@@ -44,6 +44,7 @@ export type {
     ApproveOptions,
     AddSignerOptions,
     RemoveSignerOptions,
+    UseSignerOptions,
 } from "./wallets/types";
 export type { Chain, EVMChain, SolanaChain, StellarChain } from "./chains/chains";
 

--- a/packages/wallets/src/wallets/services/device-recovery-service.test.ts
+++ b/packages/wallets/src/wallets/services/device-recovery-service.test.ts
@@ -40,6 +40,8 @@ function makeSignerManager(overrides: Record<string, unknown> = {}) {
             active = signer;
         }),
         recovery: overrides.recovery ?? { type: "api-key" },
+        adoptedAssemblableQuorumMember: overrides.adoptedAssemblableQuorumMember ?? vi.fn(() => null),
+        quorumMemberLocators: overrides.quorumMemberLocators ?? vi.fn(() => null),
         descriptorContext: vi.fn(() => ({ walletAddress: WALLET_ADDRESS })),
         isApprovedSignerStatus: (status: unknown) => status === "success" || status === "active",
         getSignerState: overrides.getSignerState ?? vi.fn().mockResolvedValue(NULL_STATE),
@@ -262,6 +264,51 @@ describe("DeviceRecoveryService", () => {
             });
             await expect(service.recover()).rejects.toThrow(expected);
             expect(signerManager.setActiveSigner).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("recover() quorum resume", () => {
+        const quorumRecovery = {
+            type: "quorum",
+            locator: "quorum:abc",
+            signers: [{ type: "email", email: "alice@gmail.com", locator: "email:alice@gmail.com" }],
+        };
+
+        function quorumSetup(overrides: { adoptedMember?: unknown; approveSignature?: ReturnType<typeof vi.fn> } = {}) {
+            return setup({
+                approveSignature: overrides.approveSignature,
+                signerManager: {
+                    activeSigner: makeSigner("device", "device:active"),
+                    recovery: quorumRecovery,
+                    adoptedAssemblableQuorumMember: vi.fn(() => overrides.adoptedMember ?? null),
+                    quorumMemberLocators: vi.fn(() => ["email:alice@gmail.com"]),
+                    getSignerState: vi.fn().mockResolvedValue(pendingState("signature", "sig-1")),
+                },
+            });
+        }
+
+        it("throws an actionable error when no quorum member was selected this session", async () => {
+            const { service, signerManager } = quorumSetup();
+            await expect(service.recover()).rejects.toThrow(
+                /quorum admin signer \[email:alice@gmail\.com\].*wallet\.useSigner\(\)/s
+            );
+            expect(signerManager.setActiveSigner).not.toHaveBeenCalled();
+        });
+
+        it("approves the pending operation with the adopted member and restores the device signer", async () => {
+            const memberAdapter = makeSigner("email", "email:alice@gmail.com");
+            mockedAssembleSigner.mockReturnValue(memberAdapter);
+            const approveSignature = vi.fn().mockResolvedValue(undefined);
+            const { service, signerManager } = quorumSetup({
+                adoptedMember: { type: "email", email: "alice@gmail.com", locator: "email:alice@gmail.com" },
+                approveSignature,
+            });
+
+            await service.recover();
+
+            expect(approveSignature).toHaveBeenCalledWith("sig-1");
+            expect(signerManager.setActiveSigner).toHaveBeenNthCalledWith(1, memberAdapter);
+            expect(signerManager.setActiveSigner).toHaveBeenLastCalledWith(expect.objectContaining({ type: "device" }));
         });
     });
 

--- a/packages/wallets/src/wallets/services/device-recovery-service.ts
+++ b/packages/wallets/src/wallets/services/device-recovery-service.ts
@@ -8,11 +8,12 @@ import {
     type InternalSignerConfig,
     isApiSourcedServerSignerConfig,
     OtpValidationError,
+    type RecoverySignerConfigForChain,
     type SignerAdapter,
     type SignerConfigForChain,
     type SignerLocator,
 } from "../../signers/types";
-import { DeviceSignerNotSupportedError, QuorumSignerNotSupportedError } from "../../utils/errors";
+import { DeviceSignerNotSupportedError } from "../../utils/errors";
 import { createDeviceSigner } from "@/utils/device-signers";
 import type { DeviceSignerKeyStorage } from "@/utils/device-signers/DeviceSignerKeyStorage";
 import { walletsLogger } from "../../logger";
@@ -272,31 +273,13 @@ export class DeviceRecoveryService<C extends Chain> {
         pendingOperation: PendingSignerOperation
     ): Promise<void> {
         const originalSigner = this.#signerManager.activeSigner;
-        const recovery = this.#signerManager.recovery;
-        if (recovery.type === "quorum") {
-            throw new QuorumSignerNotSupportedError(
-                "Cannot resume pending approval with a quorum recovery signer. " +
-                    "Quorum signing is not yet supported by this SDK version."
-            );
-        }
-        if (isApiSourcedServerSignerConfig(recovery) && !this.#serverSignerResolver.hasRecoveryResolution) {
-            throw new Error(
-                "Cannot resume pending approval: no secret available. " +
-                    'Call wallet.useSigner({ type: "server", secret: ... }) first with the recovery server secret.'
-            );
-        }
-        const signerDescriptor = getSignerDescriptor<C>(recovery.type);
+        const recoveryConfig = this.#resolveResumeRecoveryConfig();
+        const signerDescriptor = getSignerDescriptor<C>(recoveryConfig.type as SignerConfigForChain<C>["type"]);
         const signerDescriptorContext = this.#signerManager.descriptorContext();
-        if (
-            recovery.type === "external-wallet" &&
-            !signerDescriptor.canAutoAssemble(recovery, signerDescriptorContext)
-        ) {
-            throw new Error(
-                "Cannot resume pending approval: no onSign callback available. " +
-                    'Call wallet.useSigner({ type: "external-wallet", address: "0x...", onSign: async (tx) => ... }) first.'
-            );
-        }
-        const recoveryInternalConfig = signerDescriptor.buildInternalConfig(recovery, signerDescriptorContext);
+        const recoveryInternalConfig = signerDescriptor.buildInternalConfig(
+            recoveryConfig as SignerConfigForChain<C>,
+            signerDescriptorContext
+        );
         this.#signerManager.setActiveSigner(
             assembleSigner(this.#chain, recoveryInternalConfig, this.#options?.deviceSignerKeyStorage)
         );
@@ -320,6 +303,43 @@ export class DeviceRecoveryService<C extends Chain> {
             signerLocator: deviceSigner.locator(),
             resumed: true,
         });
+    }
+
+    /**
+     * The recovery-side config to assemble for approving a pending device-signer operation.
+     * For a quorum, only a member the caller already selected via useSigner() this session may
+     * be reused — never one picked silently on their behalf.
+     */
+    #resolveResumeRecoveryConfig(): RecoverySignerConfigForChain<C> {
+        const recovery = this.#signerManager.recovery;
+        if (recovery.type === "quorum") {
+            const member = this.#signerManager.adoptedAssemblableQuorumMember();
+            if (member == null) {
+                throw new Error(
+                    "This device signer has a pending approval that must be signed by a member of this wallet's " +
+                        `quorum admin signer [${(this.#signerManager.quorumMemberLocators() ?? []).join(", ")}]. ` +
+                        "Call wallet.useSigner() with the config of the member you hold, then select the device " +
+                        'again with wallet.useSigner({ type: "device" }) and retry.'
+                );
+            }
+            return member as RecoverySignerConfigForChain<C>;
+        }
+        if (isApiSourcedServerSignerConfig(recovery) && !this.#serverSignerResolver.hasRecoveryResolution) {
+            throw new Error(
+                "Cannot resume pending approval: no secret available. " +
+                    'Call wallet.useSigner({ type: "server", secret: ... }) first with the recovery server secret.'
+            );
+        }
+        if (
+            recovery.type === "external-wallet" &&
+            !getSignerDescriptor<C>(recovery.type).canAutoAssemble(recovery, this.#signerManager.descriptorContext())
+        ) {
+            throw new Error(
+                "Cannot resume pending approval: no onSign callback available. " +
+                    'Call wallet.useSigner({ type: "external-wallet", address: "0x...", onSign: async (tx) => ... }) first.'
+            );
+        }
+        return recovery;
     }
 
     async #findLocalDeviceSigner(deviceSignerKeyStorage: DeviceSignerKeyStorage): Promise<SignerAdapter | null> {

--- a/packages/wallets/src/wallets/types.ts
+++ b/packages/wallets/src/wallets/types.ts
@@ -43,6 +43,16 @@ export type AddSignerOptions = PrepareOnly & {
 
 export type RemoveSignerOptions = PrepareOnly;
 
+export type UseSignerOptions = {
+    /**
+     * Locator of the wallet's quorum admin signer (`quorum:<id>`). Forces the signer config to be
+     * interpreted as a member of that quorum, skipping delegated-signer resolution — only needed
+     * to disambiguate a key that exists both inside the quorum and elsewhere in the wallet's
+     * signer hierarchy.
+     */
+    quorumLocator?: string;
+};
+
 export type UpgradeOptions = Partial<PrepareOnly> & {
     signer?: string | ServerSignerConfig;
 };

--- a/packages/wallets/src/wallets/wallet.quorum-recovery.test.ts
+++ b/packages/wallets/src/wallets/wallet.quorum-recovery.test.ts
@@ -1,10 +1,10 @@
-import { afterEach, beforeEach, describe, expect, it, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { Wallet } from "./wallet";
 import { WalletFactory } from "./wallet-factory";
-import { QuorumSignerNotSupportedError } from "../utils/errors";
 import type { ApiClient, GetWalletSuccessResponse } from "../api";
 import type { Chain } from "../chains/chains";
-import type { SignerAdapter } from "../signers/types";
+import type { SignerAdapter, SignerConfigForChain } from "../signers/types";
+import { deriveServerSignerDetails } from "../signers/server";
 import { APIKeyEnvironmentPrefix } from "@crossmint/common-sdk-base";
 import { createMockApiClient, type MockedApiClient } from "./__tests__/test-helpers";
 
@@ -42,47 +42,295 @@ const singleAdminWallet = {
     createdAt: Date.now(),
 } as GetWalletSuccessResponse;
 
-describe("Wallet - quorum recovery signing guards", () => {
-    let mockApiClient: {
-        isServerSide: boolean;
-        crossmint: { projectId: string };
-        projectId: string;
-        environment: string;
-        getWallet: ReturnType<typeof vi.fn>;
-        createWallet: ReturnType<typeof vi.fn>;
-    };
+const evmQuorumWallet = {
+    chainType: "evm" as const,
+    type: "smart" as const,
+    address: "0x1234567890123456789012345678901234567890",
+    owner: "test-owner",
+    config: {
+        adminSigner: {
+            type: "quorum",
+            threshold: 1,
+            locator: "quorum:9f2c0000",
+            signers: [
+                { type: "external-wallet", address: "0xMemberAAA", locator: "external-wallet:0xMemberAAA" },
+                { type: "email", email: "bob@gmail.com", locator: "email:bob@gmail.com" },
+            ],
+        },
+    },
+    createdAt: Date.now(),
+} as unknown as GetWalletSuccessResponse;
+
+const passkeyQuorumWallet = {
+    chainType: "evm" as const,
+    type: "smart" as const,
+    address: "0x1234567890123456789012345678901234567890",
+    owner: "test-owner",
+    config: {
+        adminSigner: {
+            type: "quorum",
+            threshold: 1,
+            locator: "quorum:9f2c0000",
+            signers: [
+                { type: "passkey", id: "pk-1", name: "primary", locator: "passkey:pk-1" },
+                { type: "passkey", id: "pk-2", name: "backup", locator: "passkey:pk-2" },
+            ],
+        },
+    },
+    createdAt: Date.now(),
+} as unknown as GetWalletSuccessResponse;
+
+describe("Wallet - quorum member selection", () => {
+    const TEST_SECRET = "b".repeat(64);
+    const PROJECT_ID = "test-project";
+
+    let mockApiClient: MockedApiClient & { crossmint: { projectId: string }; projectId: string };
     let walletFactory: WalletFactory;
+    let onSign: ReturnType<typeof vi.fn>;
 
     beforeEach(() => {
+        vi.clearAllMocks();
         mockApiClient = {
-            isServerSide: false,
-            crossmint: { projectId: "test-project" },
-            projectId: "test-project",
+            ...createMockApiClient(),
+            crossmint: { projectId: PROJECT_ID },
+            projectId: PROJECT_ID,
             environment: APIKeyEnvironmentPrefix.STAGING,
-            getWallet: vi.fn().mockResolvedValue(quorumWallet),
-            createWallet: vi.fn().mockResolvedValue(quorumWallet),
         };
+        mockApiClient.getWallet.mockResolvedValue(quorumWallet);
         walletFactory = new WalletFactory(mockApiClient as unknown as ApiClient);
+        onSign = vi.fn().mockResolvedValue("0xmembersig");
     });
 
-    describe("useSigner with a quorum member", () => {
-        it("explains that quorum signing is unsupported instead of claiming the member is unregistered", async () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    describe("when the caller holds an external-wallet member", () => {
+        test("useSigner selects it as an admin signer under the member locator", async () => {
             const wallet = await walletFactory.getWallet({ chain: "solana" });
 
-            const attempt = wallet.useSigner({ type: "email", email: "alice@gmail.com" });
-            await expect(attempt).rejects.toThrow(QuorumSignerNotSupportedError);
-            await expect(wallet.useSigner({ type: "email", email: "alice@gmail.com" })).rejects.toThrow(
-                "signing with a quorum member is not yet supported by this SDK version"
+            await wallet.useSigner({ type: "external-wallet", address: "MemberWallet111", onSign } as Parameters<
+                Wallet<Chain>["useSigner"]
+            >[0]);
+
+            expect(wallet.signer?.locator()).toBe("external-wallet:MemberWallet111");
+            expect(wallet.signer?.status).toBe("active");
+            expect(mockApiClient.getSigner).not.toHaveBeenCalled();
+        });
+
+        test("a subsequent approve submits the member's signature under its locator", async () => {
+            mockApiClient.getWallet.mockResolvedValue(evmQuorumWallet);
+            const wallet = await walletFactory.getWallet({ chain: "base-sepolia" });
+            await wallet.useSigner({ type: "external-wallet", address: "0xMemberAAA", onSign } as Parameters<
+                Wallet<Chain>["useSigner"]
+            >[0]);
+            mockApiClient.getTransaction.mockResolvedValue({
+                id: "txn-1",
+                status: "success",
+                chainType: "evm",
+                approvals: {
+                    pending: [
+                        {
+                            signer: { type: "quorum", locator: "quorum:9f2c0000" },
+                            quorumApprovals: {
+                                threshold: 1,
+                                remaining: 1,
+                                pending: [
+                                    {
+                                        signer: {
+                                            type: "external-wallet",
+                                            address: "0xMemberAAA",
+                                            locator: "external-wallet:0xMemberAAA",
+                                        },
+                                        message: "member-message",
+                                    },
+                                    {
+                                        signer: {
+                                            type: "email",
+                                            email: "bob@gmail.com",
+                                            locator: "email:bob@gmail.com",
+                                        },
+                                        message: "member-message-bob",
+                                    },
+                                ],
+                                submitted: [],
+                            },
+                        },
+                    ],
+                    submitted: [],
+                },
+                onChain: { txId: "0xabcdef", explorerLink: "https://explorer.example.com/tx/0xabcdef" },
+            } as Awaited<ReturnType<ApiClient["getTransaction"]>>);
+            mockApiClient.approveTransaction.mockResolvedValue({ id: "txn-1", status: "success" } as Awaited<
+                ReturnType<ApiClient["approveTransaction"]>
+            >);
+
+            vi.useFakeTimers();
+            const approvePromise = wallet.approve({ transactionId: "txn-1" });
+            await vi.runAllTimersAsync();
+            const result = await approvePromise;
+
+            expect(result.hash).toBe("0xabcdef");
+            expect(onSign).toHaveBeenCalledWith("member-message");
+            expect(mockApiClient.approveTransaction).toHaveBeenCalledWith(expect.anything(), "txn-1", {
+                approvals: [{ signer: "external-wallet:0xMemberAAA", signature: "0xmembersig" }],
+            });
+        });
+    });
+
+    describe("when the caller holds the email member", () => {
+        test("a denormalized email input still selects the member", async () => {
+            const wallet = await walletFactory.getWallet({ chain: "solana" });
+
+            await wallet.useSigner({ type: "email", email: "Alice@GMAIL.com" });
+
+            expect(wallet.signer?.locator()).toBe("email:alice@gmail.com");
+            expect(wallet.signer?.status).toBe("active");
+        });
+    });
+
+    describe("when the caller holds the server member", () => {
+        test("useSigner with the secret resolves the member derivation and strips the secret", async () => {
+            const { derivedAddress } = deriveServerSignerDetails(
+                { type: "server", secret: TEST_SECRET },
+                "solana",
+                PROJECT_ID,
+                APIKeyEnvironmentPrefix.STAGING
+            );
+            mockApiClient.getWallet.mockResolvedValue({
+                ...(quorumWallet as unknown as Record<string, unknown>),
+                config: {
+                    adminSigner: {
+                        type: "quorum",
+                        threshold: 1,
+                        locator: "quorum:9f2c0000",
+                        signers: [
+                            { type: "server", address: derivedAddress, locator: `server:${derivedAddress}` },
+                            { type: "email", email: "alice@gmail.com", locator: "email:alice@gmail.com" },
+                        ],
+                    },
+                },
+            } as unknown as GetWalletSuccessResponse);
+            const wallet = await walletFactory.getWallet({ chain: "solana" });
+
+            await wallet.useSigner({ type: "server", secret: TEST_SECRET });
+
+            expect(wallet.signer?.locator()).toBe(`server:${derivedAddress}`);
+            expect(wallet.signer?.status).toBe("active");
+            const recovery = wallet.recovery as unknown as { signers: Array<Record<string, unknown>> };
+            const serverMember = recovery.signers.find((member) => member.type === "server");
+            expect(serverMember).toEqual({
+                type: "server",
+                address: derivedAddress,
+                locator: `server:${derivedAddress}`,
+            });
+        });
+    });
+
+    describe("when the config matches no member", () => {
+        test("the error lists the member locators and points at useSigner", async () => {
+            const wallet = await walletFactory.getWallet({ chain: "solana" });
+
+            await expect(wallet.useSigner({ type: "email", email: "mallory@example.com" })).rejects.toThrow(
+                'Signer "email:mallory@example.com" is not a registered delegated signer and does not match any member ' +
+                    "of this wallet's quorum admin signer [external-wallet:MemberWallet111, email:alice@gmail.com]. " +
+                    "Call wallet.useSigner() with the config of the quorum member you hold."
             );
         });
 
-        it("keeps the unregistered-signer error for wallets with a single admin signer", async () => {
+        test("keeps the unregistered-signer error for wallets with a single admin signer", async () => {
             mockApiClient.getWallet.mockResolvedValue(singleAdminWallet);
             const wallet = await walletFactory.getWallet({ chain: "solana" });
 
             await expect(wallet.useSigner({ type: "email", email: "not-a-signer@example.com" })).rejects.toThrow(
                 'Signer "email:not-a-signer@example.com" is not registered in this wallet.'
             );
+        });
+    });
+
+    describe("when quorumLocator is provided", () => {
+        test("forces the member interpretation without a registration lookup", async () => {
+            const wallet = await walletFactory.getWallet({ chain: "solana" });
+            const getWalletCallsAfterInit = mockApiClient.getWallet.mock.calls.length;
+
+            await wallet.useSigner(
+                { type: "external-wallet", address: "MemberWallet111", onSign } as Parameters<
+                    Wallet<Chain>["useSigner"]
+                >[0],
+                { quorumLocator: "quorum:9f2c0000" }
+            );
+
+            expect(wallet.signer?.locator()).toBe("external-wallet:MemberWallet111");
+            expect(wallet.signer?.status).toBe("active");
+            expect(mockApiClient.getWallet.mock.calls.length).toBe(getWalletCallsAfterInit);
+            expect(mockApiClient.getSigner).not.toHaveBeenCalled();
+        });
+
+        test("rejects a locator that names a different quorum", async () => {
+            const wallet = await walletFactory.getWallet({ chain: "solana" });
+
+            await expect(
+                wallet.useSigner({ type: "email", email: "alice@gmail.com" }, { quorumLocator: "quorum:deadbeef" })
+            ).rejects.toThrow(
+                'Quorum locator "quorum:deadbeef" does not match this wallet\'s quorum admin signer ("quorum:9f2c0000").'
+            );
+        });
+
+        test("rejects a config that matches no member", async () => {
+            const wallet = await walletFactory.getWallet({ chain: "solana" });
+
+            await expect(
+                wallet.useSigner({ type: "email", email: "mallory@example.com" }, { quorumLocator: "quorum:9f2c0000" })
+            ).rejects.toThrow(/does not match any member of this wallet's quorum admin signer/);
+        });
+
+        test("rejects device configs", async () => {
+            const wallet = await walletFactory.getWallet({ chain: "solana" });
+
+            await expect(wallet.useSigner({ type: "device" }, { quorumLocator: "quorum:9f2c0000" })).rejects.toThrow(
+                "Device signers cannot be quorum members — quorumLocator does not apply."
+            );
+        });
+
+        test("rejects wallets whose admin signer is not a quorum", async () => {
+            mockApiClient.getWallet.mockResolvedValue(singleAdminWallet);
+            const wallet = await walletFactory.getWallet({ chain: "solana" });
+
+            await expect(
+                wallet.useSigner({ type: "email", email: "alice@gmail.com" }, { quorumLocator: "quorum:9f2c0000" })
+            ).rejects.toThrow("A quorumLocator was provided, but this wallet's admin signer is not a quorum.");
+        });
+    });
+
+    describe("when the quorum has multiple passkey members", () => {
+        beforeEach(() => {
+            mockApiClient.getWallet.mockResolvedValue(passkeyQuorumWallet);
+        });
+
+        test("an id-less, name-less config is rejected as ambiguous", async () => {
+            const wallet = await walletFactory.getWallet({ chain: "base-sepolia" });
+
+            await expect(wallet.useSigner({ type: "passkey" } as SignerConfigForChain<"base-sepolia">)).rejects.toThrow(
+                /Multiple passkey members are in this wallet's quorum admin signer/
+            );
+        });
+
+        test("selecting by name adopts the stored credential id", async () => {
+            const wallet = await walletFactory.getWallet({ chain: "base-sepolia" });
+
+            await wallet.useSigner({ type: "passkey", name: "backup" } as SignerConfigForChain<"base-sepolia">);
+
+            expect(wallet.signer?.locator()).toBe("passkey:pk-2");
+            expect(wallet.signer?.status).toBe("active");
+        });
+
+        test("selecting by credential id works even though the passkey is not a registered signer", async () => {
+            const wallet = await walletFactory.getWallet({ chain: "base-sepolia" });
+
+            await wallet.useSigner({ type: "passkey", id: "pk-1" } as SignerConfigForChain<"base-sepolia">);
+
+            expect(wallet.signer?.locator()).toBe("passkey:pk-1");
+            expect(wallet.signer?.status).toBe("active");
         });
     });
 });

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -26,6 +26,7 @@ import type {
     ApproveResult,
     PrepareOnly,
     SendTokenTransactionOptions,
+    UseSignerOptions,
 } from "./types";
 import { mapApiSignerToSigner } from "../utils/signer-mapping";
 import {
@@ -33,7 +34,6 @@ import {
     DeviceSignerNotSupportedError,
     InvalidSignerError,
     InvalidTransferAmountError,
-    QuorumSignerNotSupportedError,
     SignatureFailedError,
     SignatureNotAvailableError,
     TransactionFailedError,
@@ -49,6 +49,7 @@ import type {
     ExternalWalletRegistrationConfig,
     PasskeySignerConfig,
     RecoverySignerConfigForChain,
+    ResolvedQuorumMember,
     ServerSignerConfig,
     SignerAdapter,
     SignerConfigForChain,
@@ -62,6 +63,7 @@ import { getSignerDescriptor } from "../signers/descriptors";
 import { walletsLogger } from "../logger";
 
 import { getSignerLocator } from "../utils/signer-locator";
+import { getQuorumMemberLocator } from "../utils/quorum-members";
 import { toRecipientLocator, toTokenLocator } from "../utils/locators";
 import { formatBalanceResponse } from "./services/balance-formatter";
 import { SignerManager } from "./services/signer-manager";
@@ -843,7 +845,14 @@ export class Wallet<C extends Chain> {
      * For external-wallet signers: the config object must include an onSign callback
      * (applies to both registered and recovery signers).
      *
+     * For quorum admin signers: pass the config of the member you hold — a member is selected
+     * like any other signer, and approvals are submitted under that member's locator. Members
+     * are matched before registered delegated signers (email/phone/external-wallet) or after
+     * them (passkey/server); pass `options.quorumLocator` to force the member interpretation
+     * for a key that exists both inside the quorum and as a delegated signer.
+     *
      * @param signer - The signer config object to use
+     * @param options - Optional selection modifiers (see {@link UseSignerOptions})
      */
     @WithLoggerContext({
         logger: walletsLogger,
@@ -852,7 +861,7 @@ export class Wallet<C extends Chain> {
             return { chain: thisArg.chain, address: thisArg.address };
         },
     })
-    public async useSigner(signer: SignerConfigForChain<C>): Promise<void> {
+    public async useSigner(signer: SignerConfigForChain<C>, options?: UseSignerOptions): Promise<void> {
         walletsLogger.info("wallet.useSigner.start");
         // Reset the delegated signer cache when processing a fresh server signer.
         // The recovery resolution is intentionally preserved — it's set once during
@@ -863,27 +872,45 @@ export class Wallet<C extends Chain> {
         getSignerDescriptor<C>(signer.type).validateConfig(signer);
 
         let isAdminSigner = false;
+        // A matched quorum member replaces the caller's config with the API-merged one, so the
+        // assembled adapter's locator equals the API's member locator (what the approval loop
+        // matches `quorumApprovals.pending` entries against).
+        let effectiveConfig = signer;
         if (signer.type === "device") {
+            if (options?.quorumLocator != null) {
+                throw new Error("Device signers cannot be quorum members — quorumLocator does not apply.");
+            }
             await this.#deviceRecovery.resolveAvailability(signer);
         } else {
-            isAdminSigner = await this.resolveNonDeviceSigner(signer);
+            ({ isAdminSigner, effectiveConfig } = await this.resolveNonDeviceSigner(signer, options));
         }
 
-        const internalConfig = getSignerDescriptor<C>(signer.type).buildInternalConfig(
-            signer,
+        const internalConfig = getSignerDescriptor<C>(effectiveConfig.type).buildInternalConfig(
+            effectiveConfig,
             this.#signerManager.descriptorContext()
         );
-        const signerLocator = getSignerLocator(signer);
+        const signerLocator = getSignerLocator(effectiveConfig);
         this.#signerManager.setActiveSigner(await this.#signerManager.assemble(internalConfig, { isAdminSigner }));
         walletsLogger.info("wallet.useSigner.success", { signerLocator });
     }
 
     /**
-     * Resolve a non-device signer: check registration first, then fall back to recovery.
+     * Resolve a non-device signer: check registration first, then fall back to recovery —
+     * either the single admin signer or, for quorum wallets, the member the config identifies.
      * For passkeys without an explicit credential id, auto-selects from registered signers.
-     * Returns true if the signer is an admin (recovery) signer.
+     * Returns whether the signer is admin-side and the config to assemble it from (the caller's
+     * config, or the API-merged member config for quorum members).
      */
-    private async resolveNonDeviceSigner(signer: SignerConfigForChain<C>): Promise<boolean> {
+    private async resolveNonDeviceSigner(
+        signer: SignerConfigForChain<C>,
+        options?: UseSignerOptions
+    ): Promise<{ isAdminSigner: boolean; effectiveConfig: SignerConfigForChain<C> }> {
+        // quorumLocator forces the member interpretation and skips delegated-signer resolution —
+        // it disambiguates a key that is both a quorum member and a registered delegated signer.
+        if (options?.quorumLocator != null) {
+            return this.resolveForcedQuorumMember(signer, options.quorumLocator);
+        }
+
         // For non-passkey, non-server signers, check if this is the recovery (admin) signer first.
         // Admin signers are always approved — skip the registration check and getSigner API call
         // which only works for delegated signers (returns 404/400 for admin signers).
@@ -891,9 +918,18 @@ export class Wallet<C extends Chain> {
         // incorrectly match a delegated passkey.
         // Server signers are excluded so they always flow through the server signer block below,
         // which resolves the correct (primary or legacy) derivation.
-        if (signer.type !== "passkey" && signer.type !== "server" && this.isRecoverySigner(signer)) {
-            this.#deviceRecovery.onSignerSelected();
-            return true;
+        if (signer.type !== "passkey" && signer.type !== "server") {
+            if (this.isRecoverySigner(signer)) {
+                this.#deviceRecovery.onSignerSelected();
+                return { isAdminSigner: true, effectiveConfig: signer };
+            }
+            // Same admin-first precedence for quorum members: a config identifying a member
+            // selects it without a registration round-trip.
+            const member = this.tryResolveQuorumMember(signer);
+            if (member != null) {
+                this.#deviceRecovery.onSignerSelected();
+                return { isAdminSigner: true, effectiveConfig: member };
+            }
         }
 
         // Passkey without id: try to auto-select from registered signers
@@ -903,39 +939,127 @@ export class Wallet<C extends Chain> {
                 // No registered passkeys — use recovery if this is the recovery signer
                 if (this.isRecoverySigner(signer)) {
                     this.#deviceRecovery.onSignerSelected();
-                    return true;
+                    return { isAdminSigner: true, effectiveConfig: signer };
+                }
+                // ... or the quorum member it identifies (by name, or the only passkey member).
+                const member = this.tryResolveQuorumMember(signer);
+                if (member != null) {
+                    this.#deviceRecovery.onSignerSelected();
+                    return { isAdminSigner: true, effectiveConfig: member };
                 }
                 throw new Error("No passkey signer is registered on this wallet.");
             }
         }
 
         if (signer.type === "server") {
-            return this.resolveServerSigner(signer);
+            return { isAdminSigner: await this.resolveServerSigner(signer), effectiveConfig: signer };
         }
 
         // Check if this is a registered signer
         const locator = this.resolveSignerLocator(signer);
         if (await this.signerIsRegistered(locator)) {
             this.#deviceRecovery.onSignerSelected();
-            return false;
+            return { isAdminSigner: false, effectiveConfig: signer };
         }
 
         // Not a registered signer — fall back to recovery
         if (this.isRecoverySigner(signer)) {
             this.#deviceRecovery.onSignerSelected();
-            return true;
+            return { isAdminSigner: true, effectiveConfig: signer };
+        }
+
+        // Passkey with an explicit id that isn't registered may still be a quorum member.
+        if (signer.type === "passkey") {
+            const member = this.tryResolveQuorumMember(signer);
+            if (member != null) {
+                this.#deviceRecovery.onSignerSelected();
+                return { isAdminSigner: true, effectiveConfig: member };
+            }
         }
 
         // A quorum member is part of the admin signer, not a delegated signer, so it can never
         // pass the registration check above — "not registered" would be misleading for it.
-        if (this.#signerManager.recovery.type === "quorum") {
-            throw new QuorumSignerNotSupportedError(
-                `Signer "${locator}" is not a registered delegated signer, and this wallet uses a quorum recovery signer — ` +
-                    "signing with a quorum member is not yet supported by this SDK version."
+        const memberLocators = this.#signerManager.quorumMemberLocators();
+        if (memberLocators != null) {
+            throw new Error(
+                `Signer "${locator}" is not a registered delegated signer and does not match any member ` +
+                    `of this wallet's quorum admin signer [${memberLocators.join(", ")}]. ` +
+                    "Call wallet.useSigner() with the config of the quorum member you hold."
             );
         }
 
         throw new Error(`Signer "${locator}" is not registered in this wallet.`);
+    }
+
+    /**
+     * Resolve a candidate config against the wallet's quorum members. On a unique match, the
+     * member is adopted (API identity fields merged over the caller's config, runtime callbacks
+     * preserved) and the merged config returned; null when nothing matches.
+     */
+    private tryResolveQuorumMember(signer: SignerConfigForChain<C>): SignerConfigForChain<C> | null {
+        const matches = this.#signerManager.matchQuorumMembers(signer);
+        if (matches.length === 0) {
+            return null;
+        }
+        if (matches.length > 1) {
+            // Only passkeys can match several members: id-less, name-less configs match permissively.
+            throw new Error(
+                "Multiple passkey members are in this wallet's quorum admin signer. " +
+                    'Specify the credential id or name: wallet.useSigner({ type: "passkey", id: "<credential-id>" })'
+            );
+        }
+        const member = matches[0];
+        const merged = { ...signer, ...member } as SignerConfigForChain<C> & ResolvedQuorumMember;
+        this.#signerManager.adoptQuorumMemberConfig(getQuorumMemberLocator(member), merged);
+        return merged;
+    }
+
+    /**
+     * quorumLocator path of useSigner: validate the locator and match the config strictly
+     * against the quorum's members, bypassing delegated-signer resolution.
+     */
+    private resolveForcedQuorumMember(
+        signer: SignerConfigForChain<C>,
+        quorumLocator: string
+    ): { isAdminSigner: boolean; effectiveConfig: SignerConfigForChain<C> } {
+        const recovery = this.#signerManager.recovery;
+        if (recovery.type !== "quorum") {
+            throw new Error("A quorumLocator was provided, but this wallet's admin signer is not a quorum.");
+        }
+        if (recovery.locator != null && recovery.locator !== quorumLocator) {
+            throw new Error(
+                `Quorum locator "${quorumLocator}" does not match this wallet's quorum admin signer ("${recovery.locator}").`
+            );
+        }
+
+        if (signer.type === "server") {
+            const matches = this.#signerManager.matchQuorumMembers(signer);
+            if (matches.length === 0) {
+                throw this.quorumNonMemberError(signer);
+            }
+            // Force the recovery resolution (no registered-signer preference) so the resolver
+            // caches the member-matching derivation, then drop the now-redundant secret.
+            this.#serverSignerResolver.resolveForUseSigner(signer as ServerSignerConfig, [], () => true);
+            this.#signerManager.adoptQuorumMemberConfig(getQuorumMemberLocator(matches[0]), matches[0]);
+            this.#signerManager.stripSecretFromRecovery();
+            this.#deviceRecovery.onSignerSelected();
+            return { isAdminSigner: true, effectiveConfig: signer };
+        }
+
+        const member = this.tryResolveQuorumMember(signer);
+        if (member == null) {
+            throw this.quorumNonMemberError(signer);
+        }
+        this.#deviceRecovery.onSignerSelected();
+        return { isAdminSigner: true, effectiveConfig: member };
+    }
+
+    private quorumNonMemberError(signer: SignerConfigForChain<C>): Error {
+        const memberLocators = this.#signerManager.quorumMemberLocators() ?? [];
+        return new Error(
+            `Signer "${getSignerLocator(signer)}" does not match any member of this wallet's quorum admin signer ` +
+                `[${memberLocators.join(", ")}]. Call wallet.useSigner() with the config of the quorum member you hold.`
+        );
     }
 
     /**
@@ -945,17 +1069,29 @@ export class Wallet<C extends Chain> {
     private async resolveServerSigner(signer: ServerSignerConfig): Promise<boolean> {
         const existingSigners = await this.signers();
         const registeredLocators = existingSigners.map((s) => s.locator);
+        const isQuorum = this.#signerManager.recovery.type === "quorum";
         const resolution = this.#serverSignerResolver.resolveForUseSigner(signer, registeredLocators, () =>
-            this.isRecoverySigner(signer as SignerConfigForChain<C>)
+            isQuorum
+                ? this.#signerManager.matchQuorumMembers(signer).length > 0
+                : this.isRecoverySigner(signer as SignerConfigForChain<C>)
         );
         switch (resolution.kind) {
             case "delegated":
                 this.#deviceRecovery.onSignerSelected();
                 return false;
-            case "recovery":
+            case "recovery": {
+                if (isQuorum) {
+                    // Record which member this secret resolved to; the derivation itself is
+                    // cached in the resolver, so only the member's API identity is stored.
+                    const matches = this.#signerManager.matchQuorumMembers(signer);
+                    if (matches.length === 1) {
+                        this.#signerManager.adoptQuorumMemberConfig(getQuorumMemberLocator(matches[0]), matches[0]);
+                    }
+                }
                 this.#signerManager.stripSecretFromRecovery();
                 this.#deviceRecovery.onSignerSelected();
                 return true;
+            }
             case "unregistered":
                 throw new Error(resolution.message);
         }


### PR DESCRIPTION
Linear: [WAL-11292](https://linear.app/crossmint/issue/WAL-11292/m4-4-sdk-quorum-aware-recovery-identity-usesigner-disambiguation) · EDD §6.5 · **Part 4/4 of the M4-4 stack** — split for reviewability into #1997 (shared member matcher), #1998 (SignerManager/resolver plumbing), #1999 (factory runtime-config preservation), and this PR (the user-facing flows). The stack's union is byte-identical to this PR's original single-commit form.

## Summary

Per EDD §6.5, the caller never selects "the quorum" — it selects, via `useSigner`, the member it holds. This PR makes that real on top of the stack's plumbing: the remaining `QuorumSignerNotSupportedError` guards are replaced with working flows or actionable errors. Launch scope is 1-of-n, but nothing here counts thresholds — the same code path serves m-of-n when the API gate lifts.

- **`useSigner(signer, options?)`** matches the config against the quorum's members (via the #1997 matcher) and assembles the member as an admin signer from the *API-merged* config (`adoptQuorumMemberConfig`, #1998), so the adapter's locator equals the API member locator the approval loop matches on. Precedence: member-first for email/phone/external-wallet, registration-first for passkey/server. New optional `options.quorumLocator` (exported `UseSignerOptions`) forces the member interpretation for a key that is both a member and a delegated signer.
- **Server members**: `resolveServerSigner` routes quorum matching through the resolver so the correct (primary or legacy) derivation is cached, then strips the member's secret.
- **Device-signer recovery resume**: `#resolveResumeRecoveryConfig` reuses a member the caller already selected via `useSigner` this session (`adoptedAssemblableQuorumMember`, #1998); never silently picks one — otherwise an actionable error listing the member locators.

## Review guide

1. `src/wallets/wallet.ts` — `useSigner` / `resolveNonDeviceSigner`: the merged-config idea and the precedence rules; `resolveForcedQuorumMember` for the `quorumLocator` path.
2. `src/wallets/services/device-recovery-service.ts` — `#resolveResumeRecoveryConfig` (adopted-member-or-error).
3. `src/wallets/wallet.quorum-recovery.test.ts` — the flipped "quorum member selection" suite is the behavioral spec; the `useSigner → approve` end-to-end test proves the chain joins up.

## Compatibility

Old-vs-new dist `.d.ts` surface diff: one added export (`UseSignerOptions`), one signature change (`useSigner` gains an optional trailing param), nothing removed. `QuorumSignerNotSupportedError` stays exported (M4-6 may reuse it) but is no longer thrown. All new branches are gated on `recovery.type === "quorum"` — single-admin flows are byte-for-byte unchanged (125 pre-existing `wallet.test.ts` tests untouched). Changeset (minor) covers the whole stack and rides here.

## Testing

- Full `packages/wallets` unit suite: 735 passed (29 files) at the top of the stack.
- New/extended here: flipped `wallet.quorum-recovery.test.ts` (21 tests incl. e2e approve under member locator, `quorumLocator` cases, multi-passkey disambiguation, server member secret-strip), `device-recovery-service.test.ts` (resume with/without adopted member).
- `tsc --noEmit` clean; biome clean; dist rebuilt and `react-base` typechecks against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
