### PR TITLE
feat(wallets): quorum member plumbing in SignerManager and server resolver (M4-4 part 2/4)

### DIFF
--- a/packages/wallets/src/signers/descriptors/descriptors.test.ts
+++ b/packages/wallets/src/signers/descriptors/descriptors.test.ts
@@ -20,7 +20,7 @@ const cfg = (c: object) => c as unknown as Config;
 function makeCtx(
     overrides: {
         deviceSignerKeyStorage?: DeviceSignerKeyStorage;
-        hasRecoveryResolution?: boolean;
+        resolvedRecoveryAddress?: string | null;
         apiLocator?: ServerSignerResolver["apiLocator"];
         candidateAddresses?: ServerSignerResolver["candidateAddresses"];
     } = {}
@@ -34,7 +34,7 @@ function makeCtx(
         deviceSignerKeyStorage: overrides.deviceSignerKeyStorage,
         serverSigners: {
             keyMaterialForAssembly: vi.fn(() => SERVER_KEY_MATERIAL),
-            hasRecoveryResolution: overrides.hasRecoveryResolution ?? false,
+            resolvedRecoveryAddress: overrides.resolvedRecoveryAddress ?? null,
             apiLocator: overrides.apiLocator ?? vi.fn(() => "server:0xDerivedServer"),
             candidateAddresses: overrides.candidateAddresses ?? vi.fn(() => []),
         } as unknown as ServerSignerResolver,
@@ -161,12 +161,15 @@ it.each<[name: string, config: Config, expected: boolean]>([
     expect(getSignerDescriptor("external-wallet").canAutoAssemble(config as never, makeCtx())).toBe(expected);
 });
 
-it.each<[name: string, config: Config, hasRecoveryResolution: boolean, expected: boolean]>([
-    ["full config", cfg({ type: "server", secret: "s" }), false, true],
-    ["api-sourced without recovery resolution", cfg({ type: "server", address: "0xabc" }), false, false],
-    ["api-sourced with recovery resolution", cfg({ type: "server", address: "0xabc" }), true, true],
-])("canAutoAssemble: server %s", (_name, config, hasRecoveryResolution, expected) => {
-    const ctx = makeCtx({ hasRecoveryResolution });
+it.each<[name: string, config: Config, resolvedRecoveryAddress: string | null, expected: boolean]>([
+    ["full config", cfg({ type: "server", secret: "s" }), null, true],
+    ["api-sourced without recovery resolution", cfg({ type: "server", address: "0xabc" }), null, false],
+    ["api-sourced with its own recovery resolution", cfg({ type: "server", address: "0xabc" }), "0xabc", true],
+    // A resolution cached for another admin identity (e.g. a different quorum server member)
+    // must not report this one assemblable.
+    ["api-sourced with another address's resolution", cfg({ type: "server", address: "0xabc" }), "0xOther", false],
+])("canAutoAssemble: server %s", (_name, config, resolvedRecoveryAddress, expected) => {
+    const ctx = makeCtx({ resolvedRecoveryAddress });
     expect(getSignerDescriptor("server").canAutoAssemble(config as never, ctx)).toBe(expected);
 });
 

--- a/packages/wallets/src/signers/descriptors/server.ts
+++ b/packages/wallets/src/signers/descriptors/server.ts
@@ -39,7 +39,9 @@ export const serverSignerDescriptor: SignerDescriptor = {
         config: SignerConfigForChain<C> | ApiSourcedServerSignerConfig,
         ctx: SignerDescriptorContext<C>
     ): boolean {
-        return !isApiSourcedServerSignerConfig(config) || ctx.serverSigners.hasRecoveryResolution;
+        // Per-address, not a global flag: the resolver caches one admin identity, and with
+        // quorum server members another member's cache must not report this one assemblable.
+        return !isApiSourcedServerSignerConfig(config) || ctx.serverSigners.resolvedRecoveryAddress === config.address;
     },
 
     addSignerPayload<C extends Chain>(

--- a/packages/wallets/src/signers/server/resolver.test.ts
+++ b/packages/wallets/src/signers/server/resolver.test.ts
@@ -39,6 +39,7 @@ const fullConfig = (secret: string): ServerSignerConfig => ({ type: "server", se
 const apiConfig = (address: string): ApiSourcedServerSignerConfig => ({ type: "server", address });
 const makeResolver = (overrides?: {
     apiRecoveryAddress?: string | null;
+    apiQuorumServerMemberAddresses?: string[];
     apiDelegatedAddresses?: string[];
     knownOnChainAddresses?: string[];
 }): ServerSignerResolver =>
@@ -47,6 +48,7 @@ const makeResolver = (overrides?: {
         projectId: "proj_test_123",
         environment: "staging",
         apiRecoveryAddress: overrides?.apiRecoveryAddress ?? null,
+        apiQuorumServerMemberAddresses: overrides?.apiQuorumServerMemberAddresses ?? [],
         apiDelegatedAddresses: overrides?.apiDelegatedAddresses ?? [],
         knownOnChainAddresses: () => overrides?.knownOnChainAddresses ?? [],
     });
@@ -99,10 +101,18 @@ describe("ServerSignerResolver", () => {
         });
         it.each([
             ["legacy matches apiRecoveryAddress", { apiRecoveryAddress: "0xLegacy" }],
+            ["legacy matches a quorum server member address", { apiQuorumServerMemberAddresses: ["0xLegacy"] }],
             ["legacy is a known on-chain address", { knownOnChainAddresses: ["0xLegacy"] }],
         ] as const)("picks legacy and wipes primary when %s", (_t, o) => {
             const recorded = installDual();
             expect(makeResolver(o).resolveDerivation(fullConfig("s")).derivedAddress).toBe("0xLegacy");
+            expectWipedAndKept(recorded[0], "primary", "legacy", 9);
+        });
+        it("caches the legacy derivation as the recovery resolution when it matches a quorum server member", () => {
+            const recorded = installDual();
+            const resolver = makeResolver({ apiQuorumServerMemberAddresses: ["0xLegacy"] });
+            expect(resolver.resolveForUseSigner(fullConfig("s"), [], () => true)).toEqual({ kind: "recovery" });
+            expect(resolver.resolvedRecoveryAddress).toBe("0xLegacy");
             expectWipedAndKept(recorded[0], "primary", "legacy", 9);
         });
         it("picks primary and wipes legacy otherwise", () => {

--- a/packages/wallets/src/signers/server/resolver.test.ts
+++ b/packages/wallets/src/signers/server/resolver.test.ts
@@ -83,9 +83,19 @@ describe("ServerSignerResolver", () => {
         });
         it("throws the exact message when api-sourced config has no cached recovery resolution", () => {
             expect(() => makeResolver().resolveDerivation(apiConfig("0xSome"))).toThrow(
-                "Cannot resolve server signer derivation: no secret available and no cached recovery resolution. " +
+                'Cannot resolve server signer derivation for "server:0xSome": ' +
+                    "no secret available and no cached recovery resolution for that address. " +
                     'Call wallet.useSigner({ type: "server", secret: ... }) first.'
             );
+        });
+        it("refuses to serve the cached recovery resolution for a different member's address", () => {
+            const recorded = installCandidates({ rec: { primary: { address: "0xRec", fill: 5 }, legacy: null } });
+            const resolver = makeResolver({ apiRecoveryAddress: "0xRec" });
+            cacheRecovery(resolver, recorded, "rec");
+            expect(() => resolver.resolveDerivation(apiConfig("0xOtherMember"))).toThrow(
+                /no cached recovery resolution for that address/
+            );
+            expect(resolver.resolveDerivation(apiConfig("0xRec")).derivedAddress).toBe("0xRec");
         });
         it("returns the cache hit and wipes both fresh candidates", () => {
             const resolver = makeResolver({ apiRecoveryAddress: "0xRecPrimary" });

--- a/packages/wallets/src/signers/server/resolver.ts
+++ b/packages/wallets/src/signers/server/resolver.ts
@@ -52,11 +52,16 @@ export class ServerSignerResolver {
 
     resolveDerivation(config: ServerSignerConfig | ApiSourcedServerSignerConfig): DerivedServerSigner {
         if (isApiSourcedServerSignerConfig(config)) {
-            if (this.#resolvedRecoveryServerSigner != null) {
-                return this.#resolvedRecoveryServerSigner;
+            // The cache holds one admin identity; with quorum server members there can be
+            // several, so serve it only for the address it was resolved for — never
+            // substitute another member's key material.
+            const cached = this.#resolvedRecoveryServerSigner;
+            if (cached != null && cached.derivedAddress === config.address) {
+                return cached;
             }
             throw new Error(
-                "Cannot resolve server signer derivation: no secret available and no cached recovery resolution. " +
+                `Cannot resolve server signer derivation for "server:${config.address}": ` +
+                    "no secret available and no cached recovery resolution for that address. " +
                     'Call wallet.useSigner({ type: "server", secret: ... }) first.'
             );
         }

--- a/packages/wallets/src/signers/server/resolver.ts
+++ b/packages/wallets/src/signers/server/resolver.ts
@@ -14,6 +14,7 @@ export class ServerSignerResolver {
     readonly #projectId: string;
     readonly #environment: string;
     readonly #apiRecoveryAddress: string | null;
+    readonly #apiQuorumServerMemberAddresses: string[];
     readonly #apiDelegatedAddresses: string[];
     readonly #knownOnChainAddresses: () => string[];
 
@@ -25,6 +26,7 @@ export class ServerSignerResolver {
         projectId: string;
         environment: string;
         apiRecoveryAddress: string | null;
+        apiQuorumServerMemberAddresses?: string[];
         apiDelegatedAddresses: string[];
         knownOnChainAddresses: () => string[];
     }) {
@@ -32,8 +34,16 @@ export class ServerSignerResolver {
         this.#projectId = params.projectId;
         this.#environment = params.environment;
         this.#apiRecoveryAddress = params.apiRecoveryAddress;
+        this.#apiQuorumServerMemberAddresses = params.apiQuorumServerMemberAddresses ?? [];
         this.#apiDelegatedAddresses = params.apiDelegatedAddresses;
         this.#knownOnChainAddresses = params.knownOnChainAddresses;
+    }
+
+    // The admin identity is either the single recovery signer's address or any quorum
+    // member's — a legacy derivation matching either must win over the primary, so the
+    // assembled adapter's locator lines up with the API's member locator.
+    #isAdminAddress(address: string): boolean {
+        return address === this.#apiRecoveryAddress || this.#apiQuorumServerMemberAddresses.includes(address);
     }
 
     deriveCandidates(config: ServerSignerConfig): { primary: DerivedServerSigner; legacy: DerivedServerSigner | null } {
@@ -62,7 +72,7 @@ export class ServerSignerResolver {
         }
 
         if (legacy != null) {
-            if (legacy.derivedAddress === this.#apiRecoveryAddress) {
+            if (this.#isAdminAddress(legacy.derivedAddress)) {
                 secureWipe(primary.derivedKeyBytes);
                 return legacy;
             }
@@ -129,7 +139,7 @@ export class ServerSignerResolver {
     }
 
     #selectRecovery(primary: DerivedServerSigner, legacy: DerivedServerSigner | null): DerivedServerSigner {
-        if (this.#apiRecoveryAddress != null && legacy != null && legacy.derivedAddress === this.#apiRecoveryAddress) {
+        if (legacy != null && this.#isAdminAddress(legacy.derivedAddress)) {
             this.#resolvedRecoveryServerSigner = legacy;
             this.#wipeNonSelectedCandidate(legacy, primary);
             return legacy;

--- a/packages/wallets/src/wallets/services/signer-manager.test.ts
+++ b/packages/wallets/src/wallets/services/signer-manager.test.ts
@@ -223,12 +223,14 @@ describe("SignerManager", () => {
         expect(manager.recovery).toBe(recovery);
     });
 
-    it("stripSecretFromRecovery() strips resolved server member secrets inside a quorum", () => {
+    it("stripSecretFromRecovery() strips only the resolved server member's secret inside a quorum", () => {
         const manager = makeManager({
+            serverSignerResolver: makeResolver({ resolvedRecoveryAddress: "0xM" }),
             recovery: asRecoveryConfig({
                 type: "quorum",
                 signers: [
                     { type: "server", secret: "topsecret", address: "0xM", locator: "server:0xM" },
+                    { type: "server", secret: "unresolved", address: "0xOther", locator: "server:0xOther" },
                     { type: "server", secret: "no-api-address" },
                     { type: "email", email: "alice@gmail.com", locator: "email:alice@gmail.com" },
                 ],
@@ -239,8 +241,15 @@ describe("SignerManager", () => {
 
         const { signers } = manager.recovery as unknown as { signers: Array<Record<string, unknown>> };
         expect(signers[0]).toEqual({ type: "server", address: "0xM", locator: "server:0xM" });
-        expect(signers[1]).toEqual({ type: "server", secret: "no-api-address" });
-        expect(signers[2]).toEqual({ type: "email", email: "alice@gmail.com", locator: "email:alice@gmail.com" });
+        // The resolver caches a single derivation — a member it never resolved keeps its secret.
+        expect(signers[1]).toEqual({
+            type: "server",
+            secret: "unresolved",
+            address: "0xOther",
+            locator: "server:0xOther",
+        });
+        expect(signers[2]).toEqual({ type: "server", secret: "no-api-address" });
+        expect(signers[3]).toEqual({ type: "email", email: "alice@gmail.com", locator: "email:alice@gmail.com" });
     });
 
     it("adoptQuorumMemberConfig() replaces only the matched member and records the selection", () => {
@@ -273,6 +282,46 @@ describe("SignerManager", () => {
             locator: "external-wallet:0xMember",
         });
         expect(manager.adoptedAssemblableQuorumMember()).toBeNull();
+    });
+
+    it.each([
+        ["another member's derivation is the cached one", "0xOtherMember", null],
+        ["its own derivation is the cached one", "0xM", { type: "server", address: "0xM" }],
+    ])(
+        "adoptedAssemblableQuorumMember() with an adopted secret-less server member when %s",
+        (_name, resolvedRecoveryAddress, expected) => {
+            const serverQuorum = asRecoveryConfig({
+                type: "quorum",
+                signers: [{ type: "server", address: "0xM", locator: "server:0xM" }],
+            });
+            const manager = makeManager({
+                serverSignerResolver: makeResolver({ resolvedRecoveryAddress }),
+                recovery: serverQuorum,
+            });
+            manager.adoptQuorumMemberConfig("server:0xM", { type: "server", address: "0xM", locator: "server:0xM" });
+            if (expected == null) {
+                expect(manager.adoptedAssemblableQuorumMember()).toBeNull();
+            } else {
+                expect(manager.adoptedAssemblableQuorumMember()).toMatchObject(expected);
+            }
+        }
+    );
+
+    it("adoptQuorumMemberConfig() with a locator matching no member records nothing", () => {
+        const manager = makeManager({ recovery: quorumRecovery });
+
+        manager.adoptQuorumMemberConfig("external-wallet:0xNobody", {
+            type: "external-wallet",
+            address: "0xNobody",
+            locator: "external-wallet:0xNobody",
+            onSign: vi.fn(),
+        });
+
+        expect(manager.recovery).toBe(quorumRecovery);
+        expect(manager.adoptedAssemblableQuorumMember()).toBeNull();
+        expect(walletsLogger.warn).toHaveBeenCalledWith("signerManager.adoptQuorumMemberConfig.noSuchMember", {
+            memberLocator: "external-wallet:0xNobody",
+        });
     });
 
     it.each([

--- a/packages/wallets/src/wallets/services/signer-manager.test.ts
+++ b/packages/wallets/src/wallets/services/signer-manager.test.ts
@@ -63,6 +63,16 @@ async function expectThrowsMatching(run: () => unknown, branchKeyword: RegExp): 
 
 const apiKeyConfig = { type: "api-key" } as const;
 
+const quorumRecovery = asRecoveryConfig({
+    type: "quorum",
+    threshold: 1,
+    locator: "quorum:abc",
+    signers: [
+        { type: "external-wallet", address: "0xMember", locator: "external-wallet:0xMember" },
+        { type: "email", email: "alice@gmail.com", locator: "email:alice@gmail.com" },
+    ],
+});
+
 beforeEach(() => {
     vi.clearAllMocks();
     walletsLogger.warn = vi.fn();
@@ -92,8 +102,16 @@ describe("SignerManager", () => {
             /requires calling wallet\.useSigner\(\)/,
         ],
         ["a read-only wallet", { recovery: apiKeyConfig }, /read-only/],
+        ["a quorum recovery signer", { recovery: quorumRecovery }, /quorum member you hold/],
     ] as const)("require() with no active signer reports %s", async (_name, overrides, branchKeyword) => {
         await expectThrowsMatching(() => makeManager(overrides as Overrides).require(), branchKeyword);
+    });
+
+    it("require() with a quorum recovery lists the member locators", async () => {
+        await expectThrowsMatching(
+            () => makeManager({ recovery: quorumRecovery }).require(),
+            /\[external-wallet:0xMember, email:alice@gmail\.com\]/
+        );
     });
 
     it.each([
@@ -151,6 +169,34 @@ describe("SignerManager", () => {
         );
     });
 
+    it("withRecoverySigner() runs the operation with the active quorum member without reassembling", async () => {
+        const member = { locator: () => "external-wallet:0xMember" as SignerLocator } as unknown as SignerAdapter;
+        const manager = makeManager({ signer: member, recovery: quorumRecovery });
+        let signerDuringOperation: SignerAdapter | undefined;
+
+        await expect(
+            manager.withRecoverySigner(() => {
+                signerDuringOperation = manager.activeSigner;
+                return Promise.resolve("ok");
+            })
+        ).resolves.toBe("ok");
+
+        expect(signerDuringOperation).toBe(member);
+        expect(mockedAssembleSigner).not.toHaveBeenCalled();
+        expect(manager.activeSigner).toBe(member);
+    });
+
+    it.each([
+        ["no active signer", undefined],
+        ["an active signer that is not a member", makeSigner("outsider")],
+    ])("withRecoverySigner() with a quorum recovery and %s instructs selecting a member", async (_name, signer) => {
+        await expectThrowsMatching(
+            () => makeManager({ signer, recovery: quorumRecovery }).withRecoverySigner(async () => "unused"),
+            /quorum member you hold/
+        );
+        expect(mockedAssembleSigner).not.toHaveBeenCalled();
+    });
+
     it("stripSecretFromRecovery() replaces a secret-bearing server recovery with an address-only config", () => {
         const manager = makeManager({
             recovery: asRecoveryConfig({ type: "server", secret: "topsecret" }),
@@ -175,6 +221,58 @@ describe("SignerManager", () => {
         const manager = makeManager({ recovery, serverSignerResolver: makeResolver(resolver) });
         manager.stripSecretFromRecovery();
         expect(manager.recovery).toBe(recovery);
+    });
+
+    it("stripSecretFromRecovery() strips resolved server member secrets inside a quorum", () => {
+        const manager = makeManager({
+            recovery: asRecoveryConfig({
+                type: "quorum",
+                signers: [
+                    { type: "server", secret: "topsecret", address: "0xM", locator: "server:0xM" },
+                    { type: "server", secret: "no-api-address" },
+                    { type: "email", email: "alice@gmail.com", locator: "email:alice@gmail.com" },
+                ],
+            }),
+        });
+
+        manager.stripSecretFromRecovery();
+
+        const { signers } = manager.recovery as unknown as { signers: Array<Record<string, unknown>> };
+        expect(signers[0]).toEqual({ type: "server", address: "0xM", locator: "server:0xM" });
+        expect(signers[1]).toEqual({ type: "server", secret: "no-api-address" });
+        expect(signers[2]).toEqual({ type: "email", email: "alice@gmail.com", locator: "email:alice@gmail.com" });
+    });
+
+    it("adoptQuorumMemberConfig() replaces only the matched member and records the selection", () => {
+        const manager = makeManager({ recovery: quorumRecovery });
+        const onSign = vi.fn();
+
+        manager.adoptQuorumMemberConfig("external-wallet:0xMember", {
+            type: "external-wallet",
+            address: "0xMember",
+            locator: "external-wallet:0xMember",
+            onSign,
+        });
+
+        const { signers } = manager.recovery as unknown as { signers: Array<Record<string, unknown>> };
+        expect(signers[0]).toMatchObject({ type: "external-wallet", address: "0xMember", onSign });
+        expect(signers[1]).toEqual({ type: "email", email: "alice@gmail.com", locator: "email:alice@gmail.com" });
+        expect(manager.adoptedAssemblableQuorumMember()).toMatchObject({ type: "external-wallet", onSign });
+    });
+
+    it("adoptedAssemblableQuorumMember() returns null when no member was selected this session", () => {
+        expect(makeManager({ recovery: quorumRecovery }).adoptedAssemblableQuorumMember()).toBeNull();
+    });
+
+    it("adoptedAssemblableQuorumMember() skips adopted members that cannot auto-assemble", () => {
+        const manager = makeManager({ recovery: quorumRecovery });
+        // An external-wallet member without an onSign callback cannot be reassembled silently.
+        manager.adoptQuorumMemberConfig("external-wallet:0xMember", {
+            type: "external-wallet",
+            address: "0xMember",
+            locator: "external-wallet:0xMember",
+        });
+        expect(manager.adoptedAssemblableQuorumMember()).toBeNull();
     });
 
     it.each([

--- a/packages/wallets/src/wallets/services/signer-manager.ts
+++ b/packages/wallets/src/wallets/services/signer-manager.ts
@@ -118,6 +118,10 @@ export class SignerManager<C extends Chain> {
         if (this.#recovery.type !== "quorum") {
             return;
         }
+        if (!this.#recovery.signers.some((member) => getQuorumMemberLocator(member) === memberLocator)) {
+            walletsLogger.warn("signerManager.adoptQuorumMemberConfig.noSuchMember", { memberLocator });
+            return;
+        }
         this.#recovery = {
             ...this.#recovery,
             signers: this.#recovery.signers.map((member) =>
@@ -153,11 +157,17 @@ export class SignerManager<C extends Chain> {
         if (this.#recovery.type === "quorum") {
             // Per-member counterpart of the single-signer strip below: once a server member's
             // derivation is resolved (and cached in the resolver), its secret is no longer needed.
+            // Only the member whose derivation is the cached one is stripped — the resolver holds
+            // a single resolution, so other members' secrets must survive until they are selected.
             // Members without an API address (no-API-config fallback path) are left untouched.
+            const resolvedRecoveryAddress = this.#serverSignerResolver.resolvedRecoveryAddress;
             this.#recovery = {
                 ...this.#recovery,
                 signers: this.#recovery.signers.map((member) =>
-                    member.type === "server" && "secret" in member && member.address != null
+                    member.type === "server" &&
+                    "secret" in member &&
+                    member.address != null &&
+                    member.address === resolvedRecoveryAddress
                         ? {
                               type: "server",
                               address: member.address,

--- a/packages/wallets/src/wallets/services/signer-manager.ts
+++ b/packages/wallets/src/wallets/services/signer-manager.ts
@@ -7,13 +7,15 @@ import {
     isApiSourcedServerSignerConfig,
     type InternalSignerConfig,
     type RecoverySignerConfigForChain,
+    type ResolvedQuorumMember,
+    type ServerSignerConfig,
     type SignerAdapter,
     type SignerConfigForChain,
     type SignerLocator,
     type ResolvedRecoveryConfigForChain,
 } from "../../signers/types";
 import { getPendingSignerOperation, mapApiSignerToSigner } from "../../utils/signer-mapping";
-import { QuorumSignerNotSupportedError } from "../../utils/errors";
+import { getQuorumMemberLocator, matchesQuorumMember } from "../../utils/quorum-members";
 import { walletsLogger } from "../../logger";
 import type { PendingSignerOperation, Signer as WalletSigner, SignerStatus, WalletOptions } from "../types";
 
@@ -33,6 +35,9 @@ export type SignerManagerParams<C extends Chain> = {
 export class SignerManager<C extends Chain> {
     #activeSigner: SignerAdapter | undefined;
     #recovery: ResolvedRecoveryConfigForChain<C>;
+    // Quorum members the caller explicitly selected via useSigner() this session. Recovery
+    // flows may silently reuse these, and only these — never a member the caller didn't pick.
+    #adoptedQuorumMemberLocators = new Set<string>();
     #apiClient: ApiClient;
     #options: WalletOptions | undefined;
     #chain: C;
@@ -84,7 +89,85 @@ export class SignerManager<C extends Chain> {
         this.#recovery = config as RecoverySignerConfigForChain<C>;
     }
 
+    /** Locators of the quorum members, or null when the recovery signer is not a quorum. */
+    quorumMemberLocators(): string[] | null {
+        if (this.#recovery.type !== "quorum") {
+            return null;
+        }
+        return this.#recovery.signers.map(getQuorumMemberLocator);
+    }
+
+    /** Quorum members the candidate config identifies; empty when recovery is not a quorum. */
+    matchQuorumMembers(candidate: { type: string } & Record<string, unknown>): ResolvedQuorumMember[] {
+        if (this.#recovery.type !== "quorum") {
+            return [];
+        }
+        return this.#recovery.signers.filter((member) =>
+            matchesQuorumMember(candidate, member, (config: ServerSignerConfig) =>
+                this.#serverSignerResolver.candidateAddresses(config)
+            )
+        );
+    }
+
+    /**
+     * Replace one quorum member with the caller's merged config (API identity + runtime fields)
+     * and remember the selection. The quorum-wide `adoptRecoveryConfig` must never be used for
+     * members — it would overwrite the whole member set.
+     */
+    adoptQuorumMemberConfig(memberLocator: string, merged: ResolvedQuorumMember): void {
+        if (this.#recovery.type !== "quorum") {
+            return;
+        }
+        this.#recovery = {
+            ...this.#recovery,
+            signers: this.#recovery.signers.map((member) =>
+                getQuorumMemberLocator(member) === memberLocator ? merged : member
+            ),
+        };
+        this.#adoptedQuorumMemberLocators.add(memberLocator);
+    }
+
+    /**
+     * A quorum member the caller selected via useSigner() this session and that can be
+     * reassembled without further input. Null when none — callers must then instruct the
+     * user to select a member, never pick one silently.
+     */
+    adoptedAssemblableQuorumMember(): ResolvedQuorumMember | null {
+        if (this.#recovery.type !== "quorum") {
+            return null;
+        }
+        const context = this.descriptorContext();
+        for (const member of this.#recovery.signers) {
+            if (!this.#adoptedQuorumMemberLocators.has(getQuorumMemberLocator(member))) {
+                continue;
+            }
+            const descriptor = getSignerDescriptor<C>(member.type as SignerConfigForChain<C>["type"]);
+            if (descriptor.canAutoAssemble(member as SignerConfigForChain<C>, context)) {
+                return member;
+            }
+        }
+        return null;
+    }
+
     stripSecretFromRecovery(): void {
+        if (this.#recovery.type === "quorum") {
+            // Per-member counterpart of the single-signer strip below: once a server member's
+            // derivation is resolved (and cached in the resolver), its secret is no longer needed.
+            // Members without an API address (no-API-config fallback path) are left untouched.
+            this.#recovery = {
+                ...this.#recovery,
+                signers: this.#recovery.signers.map((member) =>
+                    member.type === "server" && "secret" in member && member.address != null
+                        ? {
+                              type: "server",
+                              address: member.address,
+                              ...(member.locator != null ? { locator: member.locator } : {}),
+                          }
+                        : member
+                ),
+            };
+            return;
+        }
         const resolvedRecoveryAddress = this.#serverSignerResolver.resolvedRecoveryAddress;
         if (
             this.#recovery != null &&
@@ -124,9 +207,11 @@ export class SignerManager<C extends Chain> {
                 );
             }
             if (this.#recovery.type === "quorum") {
-                throw new QuorumSignerNotSupportedError(
-                    "No signer is set. This wallet uses a quorum recovery signer, " +
-                        "which is not yet supported for signing by this SDK version."
+                throw new Error(
+                    `No signer is set. This wallet's admin signer is a quorum of [${this.#recovery.signers
+                        .map(getQuorumMemberLocator)
+                        .join(", ")}]. ` +
+                        "Call wallet.useSigner() with the config of the quorum member you hold before signing operations."
                 );
             }
             const descriptor = getSignerDescriptor<C>(this.#recovery.type);
@@ -149,9 +234,16 @@ export class SignerManager<C extends Chain> {
     async withRecoverySigner<T>(operation: () => Promise<T>): Promise<T> {
         const originalSigner = this.#activeSigner;
         if (this.#recovery.type === "quorum") {
-            throw new QuorumSignerNotSupportedError(
-                "Cannot assemble a quorum as a single recovery signer. " +
-                    "Quorum signing is not yet supported by this SDK version."
+            // A quorum has no single assemblable signer. If the active signer is a member the
+            // caller selected, run the operation with it as-is — the approval loop routes its
+            // signature into `quorumApprovals`. Otherwise the caller must select a member first.
+            const memberLocators = this.#recovery.signers.map(getQuorumMemberLocator);
+            if (originalSigner != null && memberLocators.includes(originalSigner.locator())) {
+                return await operation();
+            }
+            throw new Error(
+                `This wallet's admin signer is a quorum of [${memberLocators.join(", ")}]. ` +
+                    "Call wallet.useSigner() with the config of the quorum member you hold before this operation."
             );
         }
         if (isApiSourcedServerSignerConfig(this.#recovery) && !this.#serverSignerResolver.hasRecoveryResolution) {

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -152,6 +152,12 @@ export class Wallet<C extends Chain> {
             projectId: this.#apiClient.projectId,
             environment: this.#apiClient.environment,
             apiRecoveryAddress,
+            apiQuorumServerMemberAddresses:
+                recovery.type === "quorum"
+                    ? recovery.signers
+                          .filter((member) => member.type === "server" && typeof member.address === "string")
+                          .map((member) => member.address as string)
+                    : [],
             apiDelegatedAddresses: this.#apiDelegatedServerSignerAddresses,
             knownOnChainAddresses: () => [
                 ...this.#initialSigners


### PR DESCRIPTION
Linear: [WAL-11292](https://linear.app/crossmint/issue/WAL-11292/m4-4-sdk-quorum-aware-recovery-identity-usesigner-disambiguation) · EDD §6.5 · **Part 2/4 of the M4-4 stack** (split from #1996)

## Summary

The `SignerManager` + `ServerSignerResolver` plumbing the `useSigner` member-selection flows (part 4) sit on. Dormant until part 4 lands — nothing can select a quorum member yet — but each piece is unit-tested here on its own contract:

- **`SignerManager` member APIs**: `quorumMemberLocators()`, `matchQuorumMembers()` (via the part-1 shared matcher), `adoptQuorumMemberConfig()` (replaces one member with the API-merged config and records the selection in an adopted-locator set — deliberately never the quorum-wide `adoptRecoveryConfig`), `adoptedAssemblableQuorumMember()` (only members the caller explicitly selected this session, and only if they can auto-assemble).
- **Per-member secret strip**: `stripSecretFromRecovery()` gains the quorum arm — resolved server members drop their `secret`, members without an API address pass through.
- **Actionable errors replace `QuorumSignerNotSupportedError`** in `require()` and `withRecoverySigner()`: they now list the member locators and point at `wallet.useSigner()`. `withRecoverySigner()` (used by `addSigner`/`removeSigner`) runs with the active signer when it is a quorum member — no reassembly, no silent member picking (EDD-strict).
- **`ServerSignerResolver`**: quorum server-member addresses join `apiRecoveryAddress` as admin addresses (`#isAdminAddress`), so a legacy derivation matching a member wins the pick and is cached as the recovery resolution. `Wallet`'s constructor feeds the member addresses in.

## Testing

- `signer-manager.test.ts`: require/withRecoverySigner quorum arms, adoption + assemblable-member gating, per-member secret strip.
- `resolver.test.ts`: legacy derivation via quorum member address, cached as recovery resolution.
- Full `packages/wallets` suite: 719 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
