### PR TITLE
feat(wallets): preserve quorum member runtime config in createWallet (M4-4 part 3/4)

### DIFF
--- a/packages/wallets/src/wallets/wallet-factory.test.ts
+++ b/packages/wallets/src/wallets/wallet-factory.test.ts
@@ -1406,4 +1406,49 @@ describe("WalletFactory - Quorum Recovery", () => {
             ).resolves.toBeDefined();
         });
     });
+
+    describe("createWallet quorum runtime config preservation", () => {
+        it("grafts member runtime fields onto the API members, keeping API identity fields", async () => {
+            mockApiClient.createWallet.mockResolvedValue(quorumWalletResponse(matchingQuorumAdminSigner));
+            const onSign = vi.fn();
+
+            const wallet = await walletFactory.createWallet({
+                chain: "solana",
+                recovery: {
+                    type: "quorum",
+                    threshold: 1,
+                    methods: [
+                        { type: "external-wallet", address: "MemberWallet111", onSign } as never,
+                        { type: "server", secret: TEST_SECRET },
+                        { type: "email", email: "Alice@GMAIL.com" },
+                    ],
+                },
+            });
+
+            const recovery = wallet.recovery as unknown as { signers: Array<Record<string, unknown>> };
+            const externalMember = recovery.signers.find((member) => member.type === "external-wallet");
+            expect(externalMember).toMatchObject({
+                address: "MemberWallet111",
+                locator: "external-wallet:MemberWallet111",
+                onSign,
+            });
+            const serverMember = recovery.signers.find((member) => member.type === "server");
+            expect(serverMember).toMatchObject({
+                address: serverMemberAddress,
+                locator: `server:${serverMemberAddress}`,
+                secret: TEST_SECRET,
+            });
+            const emailMember = recovery.signers.find((member) => member.type === "email");
+            // API identity fields win over the caller's denormalized input.
+            expect(emailMember).toMatchObject({ email: "alice@gmail.com", locator: "email:alice@gmail.com" });
+        });
+
+        it("keeps the API members verbatim when no recovery config is provided", async () => {
+            mockApiClient.getWallet.mockResolvedValue(quorumWalletResponse(matchingQuorumAdminSigner));
+
+            const wallet = await walletFactory.getWallet({ chain: "solana" });
+
+            expect(wallet.recovery).toEqual(matchingQuorumAdminSigner);
+        });
+    });
 });

--- a/packages/wallets/src/wallets/wallet-factory.ts
+++ b/packages/wallets/src/wallets/wallet-factory.ts
@@ -20,6 +20,7 @@ import type {
     QuorumMemberConfigForChain,
     QuorumRecoveryConfig,
     RecoveryConfigForChain,
+    ResolvedQuorumRecoveryConfig,
     ServerSignerConfig,
     SignerConfigForChain,
     ResolvedRecoveryConfigForChain,
@@ -262,7 +263,9 @@ export class WalletFactory {
         const recovery =
             createArgs.recovery?.type === "server" || createArgs.recovery?.type === "external-wallet"
                 ? createArgs.recovery
-                : apiRecovery ?? this.fallbackRecoveryFromArgs(createArgs.recovery);
+                : apiRecovery?.type === "quorum"
+                  ? this.mergeQuorumRuntimeConfig(apiRecovery, createArgs.recovery, args.chain)
+                  : apiRecovery ?? this.fallbackRecoveryFromArgs(createArgs.recovery);
         if (recovery == null) {
             throw new WalletCreationError(
                 "Unable to determine the wallet's recovery signer: the API response contains no admin signer configuration."
@@ -316,6 +319,38 @@ export class WalletFactory {
 
     private getWalletLocator<C extends Chain>(args: WalletArgsFor<C>): string {
         return `me:${this.getChainType(args.chain)}:smart` + (args.alias != null ? `:alias:${args.alias}` : "");
+    }
+
+    /**
+     * The quorum counterpart of the single server/external-wallet preservation above: the API
+     * cannot store runtime member data (server `secret`, external-wallet `onSign`, passkey
+     * callbacks), so graft each user-provided method onto the API member it identifies.
+     * API identity fields win (per-member `locator`, passkey `id`, derived `address`, exact
+     * `email`); matching is order-insensitive and consume-once, like the existing-wallet
+     * validation. API members with no matching method pass through verbatim.
+     */
+    private mergeQuorumRuntimeConfig<C extends Chain>(
+        apiQuorum: ResolvedQuorumRecoveryConfig,
+        userRecovery: RecoveryConfigForChain<C> | undefined,
+        chain: C
+    ): ResolvedQuorumRecoveryConfig {
+        if (userRecovery == null) {
+            return apiQuorum;
+        }
+        const normalized = this.normalizeRecovery(userRecovery);
+        if (!isQuorumRecovery(normalized)) {
+            return apiQuorum;
+        }
+        const unmatched = [...normalized.methods];
+        const signers = apiQuorum.signers.map((member) => {
+            const matchIndex = unmatched.findIndex((method) => this.isMatchingQuorumMember(method, member, chain));
+            if (matchIndex === -1) {
+                return member;
+            }
+            const [method] = unmatched.splice(matchIndex, 1);
+            return { ...method, ...member };
+        });
+        return { ...apiQuorum, signers };
     }
 
     /**


### PR DESCRIPTION
Linear: [WAL-11292](https://linear.app/crossmint/issue/WAL-11292/m4-4-sdk-quorum-aware-recovery-identity-usesigner-disambiguation) · EDD §6.5 · **Part 3/4 of the M4-4 stack** (split from #1996)

## Summary

Fixes a silent drop in `createWallet` for quorum wallets: the API cannot store runtime member data (server `secret`, external-wallet `onSign`, passkey callbacks), and the factory previously kept only the API-returned members — losing the caller's runtime fields.

`mergeQuorumRuntimeConfig` is the quorum counterpart of the existing single server/external-wallet preservation: each user-provided method is grafted onto the API member it identifies (via the part-1 shared matcher), with API identity fields winning (per-member `locator`, passkey `id`, derived `address`, normalized `email`). Matching is order-insensitive and consume-once, like the existing-wallet validation; API members with no matching method pass through verbatim.

## Testing

- `wallet-factory.test.ts`: runtime fields grafted with API identity winning; API members verbatim when no recovery config is provided.
- Full `packages/wallets` suite: 721 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
