### PR TITLE
feat(react): quorum-aware recovery handling in wallet providers

### DIFF
--- a/.changeset/quorum-member-signing.md
+++ b/.changeset/quorum-member-signing.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": minor
+---
+
+Quorum-aware recovery identity: `useSigner` now selects the quorum member the caller holds — matched against the member configs by type (email/phone normalized, passkey by id or name, server by derived address including legacy derivations, external-wallet by address) — and assembles it as an admin signer, so approvals are submitted under the member's locator. `useSigner` gains an optional second `options` argument with `quorumLocator` to force the member interpretation for a key that exists both inside the quorum and as a delegated signer. Admin operations (`addSigner`/`removeSigner`) run with the active member when it belongs to the quorum, and device-signer recovery reuses a member previously selected via `useSigner` in the same session. The wallet factory now preserves member runtime config (server `secret`, external-wallet `onSign`, passkey callbacks) across the API round-trip, and server member secrets are stripped after resolution. The former `QuorumSignerNotSupportedError` guards are replaced by these working flows or actionable errors listing the member locators.

--- a/.changeset/quorum-provider-audit.md
+++ b/.changeset/quorum-provider-audit.md
@@ -1,0 +1,6 @@
+---
+"@crossmint/client-sdk-react-base": minor
+"@crossmint/client-sdk-react-native-ui": minor
+---
+
+Make the React providers quorum-recovery aware. All recovery checks now descend into quorum `methods`: the React Native WebView initializes when a quorum contains an email/phone member, passkey helper UI shows for a passkey quorum member, wallet creation waits for external-wallet quorum members missing an `address`, and the logged-in user's email is auto-filled into a quorum email member (only when exactly one email member is missing its address). On React Native, passkey members inside a quorum are now rejected with the same clear error as flat passkey signers. Adds `recoverySigners`, `recoveryNeedsEmailAutoFill`, and `fillRecoveryEmail` utilities to `@crossmint/client-sdk-react-base`.

--- a/packages/client/react-base/src/index.ts
+++ b/packages/client/react-base/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./hooks";
 export * from "./providers";
 export * from "./types";
+export * from "./utils";

--- a/packages/client/react-base/src/providers/CrossmintWalletBaseProvider.tsx
+++ b/packages/client/react-base/src/providers/CrossmintWalletBaseProvider.tsx
@@ -18,6 +18,7 @@ import type { signerInboundEvents, signerOutboundEvents } from "@crossmint/clien
 import { ApiClientError, type UIConfig } from "@crossmint/common-sdk-base";
 import { useCrossmint, useSignerAuth } from "@/hooks";
 import type { CreateOnLogin } from "@/types";
+import { fillRecoveryEmail, recoveryNeedsEmailAutoFill, recoverySigners } from "@/utils";
 import cloneDeep from "lodash.clonedeep";
 import { useLogger } from "./LoggerProvider";
 import { LoggerContext } from "./CrossmintProvider";
@@ -219,17 +220,22 @@ export function CrossmintWalletBaseProvider({
         [showPasskeyHelpers]
     );
 
+    // Covers both a flat passkey recovery and a passkey member inside a quorum recovery.
+    const recoveryIncludesPasskey = recoverySigners(createOnLogin?.recovery).some(
+        (signer) => signer.type === "passkey"
+    );
+
     const updateCallbacks = useMemo(() => {
         let onWalletCreationStart = callbacks?.onWalletCreationStart;
         let onTransactionStart = callbacks?.onTransactionStart;
 
-        if (createOnLogin?.recovery?.type === "passkey" && showPasskeyHelpers) {
+        if (recoveryIncludesPasskey && showPasskeyHelpers) {
             onWalletCreationStart = createPasskeyPrompt("create-wallet");
             onTransactionStart = createPasskeyPrompt("transaction");
         }
 
         return { onWalletCreationStart, onTransactionStart };
-    }, [callbacks, createOnLogin?.recovery?.type, showPasskeyHelpers, createPasskeyPrompt]);
+    }, [callbacks, recoveryIncludesPasskey, showPasskeyHelpers, createPasskeyPrompt]);
 
     const wrappedOnAuthRequired = useCallback(
         async (
@@ -253,11 +259,8 @@ export function CrossmintWalletBaseProvider({
     );
 
     const initializeWebViewIfNeeded = useCallback(
-        async (signer: WalletCreateArgs<Chain>["recovery"]) => {
-            // TODO(WAL-11294): a quorum recovery containing email/phone members skips WebView
-            // init here. Quorum member signing is not reachable until the quorum approval-loop
-            // work lands; the react provider audit covers initializing the WebView for members.
-            if (signer.type === "email" || signer.type === "phone") {
+        async (recovery: WalletCreateArgs<Chain>["recovery"]) => {
+            if (recoverySigners(recovery).some((signer) => signer.type === "email" || signer.type === "phone")) {
                 await initializeWebView?.();
             }
         },
@@ -444,9 +447,11 @@ export function CrossmintWalletBaseProvider({
             return;
         }
 
-        // Check if any email signer (in recovery or signers array) is missing its email value
+        // Check if any email signer (in recovery — flat or quorum member — or signers array) is
+        // missing its email value. For a quorum, auto-fill applies only when exactly one email
+        // member is incomplete; filling several with the same address would create duplicates.
         const hasEmailSignerNeedingPopulation =
-            (createOnLogin.recovery?.type === "email" && createOnLogin.recovery.email == null) ||
+            recoveryNeedsEmailAutoFill(createOnLogin.recovery) ||
             (createOnLogin.signers?.some((s) => s.type === "email" && s.email == null) ?? false);
 
         if (hasEmailSignerNeedingPopulation) {
@@ -465,9 +470,9 @@ export function CrossmintWalletBaseProvider({
             const userEmail = authBaseContext.user.email;
             const processed = { ...createOnLogin };
 
-            // Populate email on recovery signer if needed
-            if (processed.recovery?.type === "email" && processed.recovery.email == null) {
-                processed.recovery = { ...processed.recovery, email: userEmail };
+            // Populate email on the recovery signer (flat, or the single incomplete quorum member)
+            if (processed.recovery != null) {
+                processed.recovery = fillRecoveryEmail(processed.recovery, userEmail) as typeof processed.recovery;
             }
 
             // Populate email on each signer in the signers array if needed
@@ -492,7 +497,7 @@ export function CrossmintWalletBaseProvider({
         if (processedCreateOnLogin != null) {
             // Guard: don't attempt wallet creation if required signer fields are still missing.
             const { recovery, signers } = processedCreateOnLogin;
-            if (recovery?.type === "external-wallet" && recovery.address == null) {
+            if (recoverySigners(recovery).some((s) => s.type === "external-wallet" && s.address == null)) {
                 return;
             }
             if (signers?.some((s) => s.type === "external-wallet" && s.address == null)) {

--- a/packages/client/react-base/src/utils/index.ts
+++ b/packages/client/react-base/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./quorum-recovery";

--- a/packages/client/react-base/src/utils/quorum-recovery.test.ts
+++ b/packages/client/react-base/src/utils/quorum-recovery.test.ts
@@ -1,0 +1,159 @@
+import type { Chain, WalletCreateArgs } from "@crossmint/wallets-sdk";
+import { describe, expect, test } from "vitest";
+
+import { fillRecoveryEmail, recoveryNeedsEmailAutoFill, recoverySigners } from "./quorum-recovery";
+
+type RecoveryConfig = WalletCreateArgs<Chain>["recovery"];
+
+const USER_EMAIL = "user@example.com";
+
+describe("recoverySigners", () => {
+    describe("when the recovery is undefined", () => {
+        test("returns no signers", () => {
+            expect(recoverySigners(undefined)).toEqual([]);
+        });
+    });
+
+    describe("when the recovery is a flat signer", () => {
+        test("returns the signer itself", () => {
+            const recovery: RecoveryConfig = { type: "email", email: USER_EMAIL };
+            expect(recoverySigners(recovery)).toEqual([recovery]);
+        });
+    });
+
+    describe("when the recovery is a quorum", () => {
+        test("returns the member signers", () => {
+            const recovery: RecoveryConfig = {
+                type: "quorum",
+                methods: [
+                    { type: "email", email: USER_EMAIL },
+                    { type: "phone", phone: "+15555550100" },
+                ],
+            };
+            expect(recoverySigners(recovery)).toEqual(recovery.type === "quorum" ? recovery.methods : []);
+        });
+
+        test("surfaces email, phone and passkey members to per-signer checks", () => {
+            const recovery: RecoveryConfig = {
+                type: "quorum",
+                methods: [
+                    { type: "passkey", name: "my-key" },
+                    { type: "external-wallet", address: "0xabc", onSign: (payload: string) => Promise.resolve(payload) },
+                ],
+            };
+            const signers = recoverySigners(recovery);
+            expect(signers.some((s) => s.type === "passkey")).toBe(true);
+            expect(signers.some((s) => s.type === "email" || s.type === "phone")).toBe(false);
+        });
+    });
+});
+
+describe("recoveryNeedsEmailAutoFill", () => {
+    describe("when the recovery is a flat email signer without an email", () => {
+        test("requests auto-fill", () => {
+            expect(recoveryNeedsEmailAutoFill({ type: "email" })).toBe(true);
+        });
+    });
+
+    describe("when the recovery is a flat email signer with an email", () => {
+        test("does not request auto-fill", () => {
+            expect(recoveryNeedsEmailAutoFill({ type: "email", email: USER_EMAIL })).toBe(false);
+        });
+    });
+
+    describe("when the recovery is a flat non-email signer", () => {
+        test("does not request auto-fill", () => {
+            expect(recoveryNeedsEmailAutoFill({ type: "passkey" })).toBe(false);
+            expect(recoveryNeedsEmailAutoFill(undefined)).toBe(false);
+        });
+    });
+
+    describe("when a quorum has exactly one email member missing its email", () => {
+        test("requests auto-fill", () => {
+            expect(
+                recoveryNeedsEmailAutoFill({
+                    type: "quorum",
+                    methods: [{ type: "email" }, { type: "phone", phone: "+15555550100" }],
+                })
+            ).toBe(true);
+        });
+    });
+
+    describe("when a quorum has two email members missing their email", () => {
+        test("does not request auto-fill, leaving the config for validation", () => {
+            expect(
+                recoveryNeedsEmailAutoFill({
+                    type: "quorum",
+                    methods: [{ type: "email" }, { type: "email" }],
+                })
+            ).toBe(false);
+        });
+    });
+
+    describe("when a quorum's email members all carry an email", () => {
+        test("does not request auto-fill", () => {
+            expect(
+                recoveryNeedsEmailAutoFill({
+                    type: "quorum",
+                    methods: [
+                        { type: "email", email: USER_EMAIL },
+                        { type: "phone", phone: "+15555550100" },
+                    ],
+                })
+            ).toBe(false);
+        });
+    });
+});
+
+describe("fillRecoveryEmail", () => {
+    describe("when the recovery is a flat email signer without an email", () => {
+        test("fills the email without mutating the input", () => {
+            const recovery: RecoveryConfig = { type: "email" };
+            const filled = fillRecoveryEmail(recovery, USER_EMAIL);
+            expect(filled).toEqual({ type: "email", email: USER_EMAIL });
+            expect(recovery).toEqual({ type: "email" });
+        });
+    });
+
+    describe("when a quorum has exactly one email member missing its email", () => {
+        test("fills only that member without mutating the input", () => {
+            const recovery: RecoveryConfig = {
+                type: "quorum",
+                threshold: 1,
+                methods: [
+                    { type: "email" },
+                    { type: "email", email: "cosigner@example.com" },
+                    { type: "phone", phone: "+15555550100" },
+                ],
+            };
+            const filled = fillRecoveryEmail(recovery, USER_EMAIL);
+            expect(filled).toEqual({
+                type: "quorum",
+                threshold: 1,
+                methods: [
+                    { type: "email", email: USER_EMAIL },
+                    { type: "email", email: "cosigner@example.com" },
+                    { type: "phone", phone: "+15555550100" },
+                ],
+            });
+            expect(recovery.type === "quorum" && recovery.methods[0]).toEqual({ type: "email" });
+        });
+    });
+
+    describe("when a quorum has two email members missing their email", () => {
+        test("returns the config untouched so validation surfaces the real problem", () => {
+            const recovery: RecoveryConfig = {
+                type: "quorum",
+                methods: [{ type: "email" }, { type: "email" }],
+            };
+            expect(fillRecoveryEmail(recovery, USER_EMAIL)).toBe(recovery);
+        });
+    });
+
+    describe("when nothing needs filling", () => {
+        test("returns the same object", () => {
+            const recovery: RecoveryConfig = { type: "email", email: USER_EMAIL };
+            expect(fillRecoveryEmail(recovery, "other@example.com")).toBe(recovery);
+        });
+    });
+});

--- a/packages/client/react-base/src/utils/quorum-recovery.ts
+++ b/packages/client/react-base/src/utils/quorum-recovery.ts
@@ -1,0 +1,53 @@
+import {
+    type Chain,
+    type DeviceSignerConfig,
+    isQuorumRecovery,
+    type SignerConfigForChain,
+    type WalletCreateArgs,
+} from "@crossmint/wallets-sdk";
+
+type RecoveryConfig = WalletCreateArgs<Chain>["recovery"];
+type RecoverySignerConfig = Exclude<SignerConfigForChain<Chain>, DeviceSignerConfig>;
+
+/**
+ * The signer configs a recovery carries: the signer itself for a flat recovery, or the member
+ * signers for a quorum. Lets callers apply per-signer checks (e.g. "does this recovery involve
+ * an email signer") without branching on the recovery's shape.
+ */
+export function recoverySigners(recovery: RecoveryConfig | undefined): RecoverySignerConfig[] {
+    if (recovery == null) {
+        return [];
+    }
+    return isQuorumRecovery(recovery) ? recovery.methods : [recovery];
+}
+
+/**
+ * True when the logged-in user's email should be auto-filled into the recovery: exactly one
+ * contained email signer is missing its `email`. Filling two or more quorum members with the
+ * same address would create duplicate members (which the API rejects), so those configs pass
+ * through untouched and validation surfaces the real problem.
+ */
+export function recoveryNeedsEmailAutoFill(recovery: RecoveryConfig | undefined): boolean {
+    return recoverySigners(recovery).filter((signer) => signer.type === "email" && signer.email == null).length === 1;
+}
+
+/**
+ * Returns a copy of the recovery with the single email signer missing `email` filled in, or the
+ * original object when `recoveryNeedsEmailAutoFill` does not hold. Never mutates the input.
+ */
+export function fillRecoveryEmail(recovery: RecoveryConfig, email: string): RecoveryConfig {
+    if (!recoveryNeedsEmailAutoFill(recovery)) {
+        return recovery;
+    }
+    if (isQuorumRecovery(recovery)) {
+        return {
+            ...recovery,
+            methods: recovery.methods.map((member) =>
+                member.type === "email" && member.email == null ? { ...member, email } : member
+            ),
+        };
+    }
+    // recoveryNeedsEmailAutoFill guarantees the flat signer is an incomplete email signer,
+    // but the type system needs the explicit narrow.
+    return recovery.type === "email" ? { ...recovery, email } : recovery;
+}

--- a/packages/client/ui/react-native/README.md
+++ b/packages/client/ui/react-native/README.md
@@ -119,6 +119,32 @@ function WalletActions() {
 | `deviceSignerKeyStorage` | `DeviceSignerKeyStorage` | — | Override the default native key storage. |
 | `appearance` | `UIConfig` | — | Styling for built-in UI components. |
 
+### `createOnLogin` Configuration
+
+`recovery` accepts a single signer or a quorum of member signers:
+
+```tsx
+<CrossmintWalletProvider
+  createOnLogin={{
+    chain: "base-sepolia",
+    recovery: { type: "email" }, // single recovery signer
+  }}
+>
+
+<CrossmintWalletProvider
+  createOnLogin={{
+    chain: "base-sepolia",
+    recovery: {
+      type: "quorum",
+      methods: [{ type: "email" }, { type: "phone", phone: "+15555550100" }],
+      // threshold defaults to 1; `api-key` and `device` members are not allowed
+    },
+  }}
+>
+```
+
+> **Note:** Passkey signers are not supported in React Native — this includes passkey **members inside a quorum**. Such configs are rejected with an error at mount/creation time.
+
 ## Hooks
 
 ### `useWallet()`

--- a/packages/client/ui/react-native/examples.json
+++ b/packages/client/ui/react-native/examples.json
@@ -8,7 +8,7 @@
         "language": "bash"
     },
     "rnWalletProviderSetup": {
-        "code": "import {\n    CrossmintProvider,\n    CrossmintWalletProvider,\n} from \"@crossmint/client-sdk-react-native-ui\";\n\nfunction App() {\n    return (\n        <CrossmintProvider apiKey=\"YOUR_CLIENT_API_KEY\">\n            <CrossmintWalletProvider\n                createOnLogin={{\n                    chain: \"base-sepolia\",\n                    recovery: { type: \"email\" },\n                }}\n            >\n                {/* Your app components */}\n            </CrossmintWalletProvider>\n        </CrossmintProvider>\n    );\n}",
+        "code": "import {\n    CrossmintProvider,\n    CrossmintWalletProvider,\n} from \"@crossmint/client-sdk-react-native-ui\";\n\nfunction App() {\n    return (\n        <CrossmintProvider apiKey=\"YOUR_CLIENT_API_KEY\">\n            <CrossmintWalletProvider\n                createOnLogin={{\n                    chain: \"base-sepolia\",\n                    recovery: { type: \"email\" }, // or a quorum: { type: \"quorum\", methods: [{ type: \"email\" }, { type: \"phone\" }] }\n                }}\n            >\n                {/* Your app components */}\n            </CrossmintWalletProvider>\n        </CrossmintProvider>\n    );\n}",
         "language": "tsx"
     },
     "rnWalletQuickExample": {
@@ -20,7 +20,7 @@
         "language": "tsx"
     },
     "CrossmintWalletProvider": {
-        "code": "import {\n    CrossmintProvider,\n    CrossmintWalletProvider,\n} from \"@crossmint/client-sdk-react-native-ui\";\n\nfunction App() {\n    return (\n        <CrossmintProvider apiKey=\"YOUR_CLIENT_API_KEY\">\n            <CrossmintWalletProvider\n                createOnLogin={{\n                    chain: \"base-sepolia\",\n                    recovery: { type: \"email\" },\n                }}\n            >\n                {/* Your app content */}\n            </CrossmintWalletProvider>\n        </CrossmintProvider>\n    );\n}",
+        "code": "import {\n    CrossmintProvider,\n    CrossmintWalletProvider,\n} from \"@crossmint/client-sdk-react-native-ui\";\n\nfunction App() {\n    return (\n        <CrossmintProvider apiKey=\"YOUR_CLIENT_API_KEY\">\n            <CrossmintWalletProvider\n                createOnLogin={{\n                    chain: \"base-sepolia\",\n                    recovery: { type: \"email\" }, // or a quorum: { type: \"quorum\", methods: [{ type: \"email\" }, { type: \"phone\" }] }\n                }}\n            >\n                {/* Your app content */}\n            </CrossmintWalletProvider>\n        </CrossmintProvider>\n    );\n}",
         "language": "tsx",
         "note": "CrossmintWalletProvider must be nested inside CrossmintProvider. showOtpSignerPrompt defaults to true in React Native, showing built-in OTP dialogs automatically. Set to false to handle signing flows manually via the useWalletOtpSigner hook."
     },

--- a/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
@@ -15,6 +15,7 @@ import {
     CrossmintWalletBaseContext,
     type UIRenderProps,
     type CreateOnLogin,
+    recoverySigners,
     useCrossmint,
 } from "@crossmint/client-sdk-react-base";
 import type { DeviceSignerKeyStorage } from "@crossmint/wallets-sdk";
@@ -60,11 +61,12 @@ const DEVICE_STORAGE_MEMORY = "memory";
 const PASSKEY_RN_ERROR =
     "Passkey signers are not supported in React Native. Use a different signer type such as 'device', or 'external-wallet'.";
 
-function hasPasskeySigner(config?: CreateOnLogin): boolean {
+function hasPasskeySigner(config?: Pick<CreateOnLogin, "recovery" | "signers">): boolean {
     if (config == null) {
         return false;
     }
-    if (config.recovery?.type === "passkey") {
+    // recoverySigners covers both a flat passkey recovery and a passkey member inside a quorum.
+    if (recoverySigners(config.recovery).some((s) => s.type === "passkey")) {
         return true;
     }
     if (config.signers?.some((s) => s.type === "passkey")) {
@@ -83,10 +85,10 @@ function PasskeyGuard({ children }: { children: ReactNode }) {
 
     const guardedCreateWallet: typeof baseContext.createWallet = useCallback(
         async (args) => {
-            if (args.recovery?.type === "passkey" || args.signers?.some((s) => s.type === "passkey")) {
+            if (hasPasskeySigner(args as Pick<CreateOnLogin, "recovery" | "signers">)) {
                 throw new Error(PASSKEY_RN_ERROR);
             }
-            return baseContext.createWallet(args);
+            return await baseContext.createWallet(args);
         },
         [baseContext.createWallet]
     );

--- a/packages/client/ui/react-ui/README.md
+++ b/packages/client/ui/react-ui/README.md
@@ -127,6 +127,23 @@ When `createOnLogin` is set on `CrossmintWalletProvider`, a wallet is automatica
 >
 ```
 
+`recovery` also accepts a quorum of member signers instead of a single signer:
+
+```tsx
+<CrossmintWalletProvider
+  createOnLogin={{
+    chain: "base-sepolia",
+    recovery: {
+      type: "quorum",
+      methods: [{ type: "email" }, { type: "phone", phone: "+15555550100" }],
+      // threshold defaults to 1; `api-key` and `device` members are not allowed
+    },
+  }}
+>
+```
+
+Like a single email recovery signer, a quorum email member without an explicit `email` is auto-filled from the logged-in user — but only when exactly one email member is missing its address.
+
 ## Hooks
 
 ### `useWallet()`

--- a/packages/client/ui/react-ui/examples.json
+++ b/packages/client/ui/react-ui/examples.json
@@ -8,7 +8,7 @@
         "language": "bash"
     },
     "walletProviderSetup": {
-        "code": "import {\n    CrossmintProvider,\n    CrossmintWalletProvider,\n} from \"@crossmint/client-sdk-react-ui\";\n\nfunction App() {\n    return (\n        <CrossmintProvider apiKey=\"YOUR_CLIENT_API_KEY\">\n            <CrossmintWalletProvider\n                createOnLogin={{\n                    chain: \"base-sepolia\",\n                    recovery: { type: \"email\" },\n                }}\n            >\n                {/* Your app components */}\n            </CrossmintWalletProvider>\n        </CrossmintProvider>\n    );\n}",
+        "code": "import {\n    CrossmintProvider,\n    CrossmintWalletProvider,\n} from \"@crossmint/client-sdk-react-ui\";\n\nfunction App() {\n    return (\n        <CrossmintProvider apiKey=\"YOUR_CLIENT_API_KEY\">\n            <CrossmintWalletProvider\n                createOnLogin={{\n                    chain: \"base-sepolia\",\n                    recovery: { type: \"email\" }, // or a quorum: { type: \"quorum\", methods: [{ type: \"email\" }, { type: \"phone\" }] }\n                }}\n            >\n                {/* Your app components */}\n            </CrossmintWalletProvider>\n        </CrossmintProvider>\n    );\n}",
         "language": "tsx"
     },
     "walletQuickExample": {
@@ -24,7 +24,7 @@
         "language": "tsx"
     },
     "CrossmintWalletProvider": {
-        "code": "import {\n    CrossmintProvider,\n    CrossmintWalletProvider,\n} from \"@crossmint/client-sdk-react-ui\";\n\nfunction App() {\n    return (\n        <CrossmintProvider apiKey=\"YOUR_CLIENT_API_KEY\">\n            <CrossmintWalletProvider\n                createOnLogin={{\n                    chain: \"base-sepolia\",\n                    recovery: { type: \"email\" },\n                }}\n            >\n                {/* Your app content */}\n            </CrossmintWalletProvider>\n        </CrossmintProvider>\n    );\n}",
+        "code": "import {\n    CrossmintProvider,\n    CrossmintWalletProvider,\n} from \"@crossmint/client-sdk-react-ui\";\n\nfunction App() {\n    return (\n        <CrossmintProvider apiKey=\"YOUR_CLIENT_API_KEY\">\n            <CrossmintWalletProvider\n                createOnLogin={{\n                    chain: \"base-sepolia\",\n                    recovery: { type: \"email\" }, // or a quorum: { type: \"quorum\", methods: [{ type: \"email\" }, { type: \"phone\" }] }\n                }}\n            >\n                {/* Your app content */}\n            </CrossmintWalletProvider>\n        </CrossmintProvider>\n    );\n}",
         "language": "tsx",
         "note": "CrossmintWalletProvider must be nested inside CrossmintProvider."
     },

--- a/packages/client/ui/scripts/generate-reference.mjs
+++ b/packages/client/ui/scripts/generate-reference.mjs
@@ -35,12 +35,12 @@ const WALLET_CREATE_ARGS_CHILDREN = [
     },
     {
         name: "recovery",
-        type: { type: "reference", name: "SignerConfigForChain" },
+        type: { type: "reference", name: "RecoveryConfigForChain" },
         comment: {
             summary: [
                 {
                     kind: "text",
-                    text: 'The recovery signer configuration (e.g. `{ type: "email" }`). Used for wallet recovery and adding new signers.',
+                    text: 'The recovery signer configuration: a single signer (e.g. `{ type: "email" }`) or a quorum of member signers (e.g. `{ type: "quorum", methods: [{ type: "email" }, { type: "phone" }] }`; `threshold` defaults to 1; `api-key` and `device` members are not allowed). Used for wallet recovery and adding new signers.',
                 },
             ],
         },

--- a/packages/wallets/README.md
+++ b/packages/wallets/README.md
@@ -141,7 +141,7 @@ const wallet = await wallets.getWallet("0xWalletAddress", {
 
 Wallets SDK uses a two-tier signer model:
 
-- **Recovery signer** — High-security, used for wallet recovery and adding new signers. Supports email OTP, phone OTP, external wallet, or server key.
+- **Recovery signer** — High-security, used for wallet recovery and adding new signers. Supports email OTP, phone OTP, external wallet, or server key. Can also be a quorum of member signers: `recovery: { type: "quorum", methods: [{ type: "email" }, { type: "phone" }] }` (`threshold` defaults to 1; `api-key` and `device` members are not allowed).
 - **Operational signer** — Low-friction, used for day-to-day signing. Supports server key, external wallet, passkey, and device (browser/mobile only). For server-side (Node.js) usage, use a **server** or **external-wallet** signer.
 
 When no operational signer is available, the recovery signer automatically serves as a fallback for signing.

--- a/packages/wallets/src/index.ts
+++ b/packages/wallets/src/index.ts
@@ -44,6 +44,7 @@ export type {
     ApproveOptions,
     AddSignerOptions,
     RemoveSignerOptions,
+    UseSignerOptions,
 } from "./wallets/types";
 export type { Chain, EVMChain, SolanaChain, StellarChain } from "./chains/chains";
 

--- a/packages/wallets/src/wallets/services/device-recovery-service.test.ts
+++ b/packages/wallets/src/wallets/services/device-recovery-service.test.ts
@@ -40,6 +40,8 @@ function makeSignerManager(overrides: Record<string, unknown> = {}) {
             active = signer;
         }),
         recovery: overrides.recovery ?? { type: "api-key" },
+        adoptedAssemblableQuorumMember: overrides.adoptedAssemblableQuorumMember ?? vi.fn(() => null),
+        quorumMemberLocators: overrides.quorumMemberLocators ?? vi.fn(() => null),
         descriptorContext: vi.fn(() => ({ walletAddress: WALLET_ADDRESS })),
         isApprovedSignerStatus: (status: unknown) => status === "success" || status === "active",
         getSignerState: overrides.getSignerState ?? vi.fn().mockResolvedValue(NULL_STATE),
@@ -262,6 +264,51 @@ describe("DeviceRecoveryService", () => {
             });
             await expect(service.recover()).rejects.toThrow(expected);
             expect(signerManager.setActiveSigner).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("recover() quorum resume", () => {
+        const quorumRecovery = {
+            type: "quorum",
+            locator: "quorum:abc",
+            signers: [{ type: "email", email: "alice@gmail.com", locator: "email:alice@gmail.com" }],
+        };
+
+        function quorumSetup(overrides: { adoptedMember?: unknown; approveSignature?: ReturnType<typeof vi.fn> } = {}) {
+            return setup({
+                approveSignature: overrides.approveSignature,
+                signerManager: {
+                    activeSigner: makeSigner("device", "device:active"),
+                    recovery: quorumRecovery,
+                    adoptedAssemblableQuorumMember: vi.fn(() => overrides.adoptedMember ?? null),
+                    quorumMemberLocators: vi.fn(() => ["email:alice@gmail.com"]),
+                    getSignerState: vi.fn().mockResolvedValue(pendingState("signature", "sig-1")),
+                },
+            });
+        }
+
+        it("throws an actionable error when no quorum member was selected this session", async () => {
+            const { service, signerManager } = quorumSetup();
+            await expect(service.recover()).rejects.toThrow(
+                /quorum admin signer \[email:alice@gmail\.com\].*wallet\.useSigner\(\)/s
+            );
+            expect(signerManager.setActiveSigner).not.toHaveBeenCalled();
+        });
+
+        it("approves the pending operation with the adopted member and restores the device signer", async () => {
+            const memberAdapter = makeSigner("email", "email:alice@gmail.com");
+            mockedAssembleSigner.mockReturnValue(memberAdapter);
+            const approveSignature = vi.fn().mockResolvedValue(undefined);
+            const { service, signerManager } = quorumSetup({
+                adoptedMember: { type: "email", email: "alice@gmail.com", locator: "email:alice@gmail.com" },
+                approveSignature,
+            });
+
+            await service.recover();
+
+            expect(approveSignature).toHaveBeenCalledWith("sig-1");
+            expect(signerManager.setActiveSigner).toHaveBeenNthCalledWith(1, memberAdapter);
+            expect(signerManager.setActiveSigner).toHaveBeenLastCalledWith(expect.objectContaining({ type: "device" }));
         });
     });
 

--- a/packages/wallets/src/wallets/services/device-recovery-service.ts
+++ b/packages/wallets/src/wallets/services/device-recovery-service.ts
@@ -8,11 +8,12 @@ import {
     type InternalSignerConfig,
     isApiSourcedServerSignerConfig,
     OtpValidationError,
+    type RecoverySignerConfigForChain,
     type SignerAdapter,
     type SignerConfigForChain,
     type SignerLocator,
 } from "../../signers/types";
-import { DeviceSignerNotSupportedError, QuorumSignerNotSupportedError } from "../../utils/errors";
+import { DeviceSignerNotSupportedError } from "../../utils/errors";
 import { createDeviceSigner } from "@/utils/device-signers";
 import type { DeviceSignerKeyStorage } from "@/utils/device-signers/DeviceSignerKeyStorage";
 import { walletsLogger } from "../../logger";
@@ -272,31 +273,13 @@ export class DeviceRecoveryService<C extends Chain> {
         pendingOperation: PendingSignerOperation
     ): Promise<void> {
         const originalSigner = this.#signerManager.activeSigner;
-        const recovery = this.#signerManager.recovery;
-        if (recovery.type === "quorum") {
-            throw new QuorumSignerNotSupportedError(
-                "Cannot resume pending approval with a quorum recovery signer. " +
-                    "Quorum signing is not yet supported by this SDK version."
-            );
-        }
-        if (isApiSourcedServerSignerConfig(recovery) && !this.#serverSignerResolver.hasRecoveryResolution) {
-            throw new Error(
-                "Cannot resume pending approval: no secret available. " +
-                    'Call wallet.useSigner({ type: "server", secret: ... }) first with the recovery server secret.'
-            );
-        }
-        const signerDescriptor = getSignerDescriptor<C>(recovery.type);
+        const recoveryConfig = this.#resolveResumeRecoveryConfig();
+        const signerDescriptor = getSignerDescriptor<C>(recoveryConfig.type as SignerConfigForChain<C>["type"]);
         const signerDescriptorContext = this.#signerManager.descriptorContext();
-        if (
-            recovery.type === "external-wallet" &&
-            !signerDescriptor.canAutoAssemble(recovery, signerDescriptorContext)
-        ) {
-            throw new Error(
-                "Cannot resume pending approval: no onSign callback available. " +
-                    'Call wallet.useSigner({ type: "external-wallet", address: "0x...", onSign: async (tx) => ... }) first.'
-            );
-        }
-        const recoveryInternalConfig = signerDescriptor.buildInternalConfig(recovery, signerDescriptorContext);
+        const recoveryInternalConfig = signerDescriptor.buildInternalConfig(
+            recoveryConfig as SignerConfigForChain<C>,
+            signerDescriptorContext
+        );
         this.#signerManager.setActiveSigner(
             assembleSigner(this.#chain, recoveryInternalConfig, this.#options?.deviceSignerKeyStorage)
         );
@@ -320,6 +303,43 @@ export class DeviceRecoveryService<C extends Chain> {
             signerLocator: deviceSigner.locator(),
             resumed: true,
         });
+    }
+
+    /**
+     * The recovery-side config to assemble for approving a pending device-signer operation.
+     * For a quorum, only a member the caller already selected via useSigner() this session may
+     * be reused — never one picked silently on their behalf.
+     */
+    #resolveResumeRecoveryConfig(): RecoverySignerConfigForChain<C> {
+        const recovery = this.#signerManager.recovery;
+        if (recovery.type === "quorum") {
+            const member = this.#signerManager.adoptedAssemblableQuorumMember();
+            if (member == null) {
+                throw new Error(
+                    "This device signer has a pending approval that must be signed by a member of this wallet's " +
+                        `quorum admin signer [${(this.#signerManager.quorumMemberLocators() ?? []).join(", ")}]. ` +
+                        "Call wallet.useSigner() with the config of the member you hold, then select the device " +
+                        'again with wallet.useSigner({ type: "device" }) and retry.'
+                );
+            }
+            return member as RecoverySignerConfigForChain<C>;
+        }
+        if (isApiSourcedServerSignerConfig(recovery) && !this.#serverSignerResolver.hasRecoveryResolution) {
+            throw new Error(
+                "Cannot resume pending approval: no secret available. " +
+                    'Call wallet.useSigner({ type: "server", secret: ... }) first with the recovery server secret.'
+            );
+        }
+        if (
+            recovery.type === "external-wallet" &&
+            !getSignerDescriptor<C>(recovery.type).canAutoAssemble(recovery, this.#signerManager.descriptorContext())
+        ) {
+            throw new Error(
+                "Cannot resume pending approval: no onSign callback available. " +
+                    'Call wallet.useSigner({ type: "external-wallet", address: "0x...", onSign: async (tx) => ... }) first.'
+            );
+        }
+        return recovery;
     }
 
     async #findLocalDeviceSigner(deviceSignerKeyStorage: DeviceSignerKeyStorage): Promise<SignerAdapter | null> {

--- a/packages/wallets/src/wallets/types.ts
+++ b/packages/wallets/src/wallets/types.ts
@@ -43,6 +43,16 @@ export type AddSignerOptions = PrepareOnly & {
 
 export type RemoveSignerOptions = PrepareOnly;
 
+export type UseSignerOptions = {
+    /**
+     * Locator of the wallet's quorum admin signer (`quorum:<id>`). Forces the signer config to be
+     * interpreted as a member of that quorum, skipping delegated-signer resolution — only needed
+     * to disambiguate a key that exists both inside the quorum and elsewhere in the wallet's
+     * signer hierarchy.
+     */
+    quorumLocator?: string;
+};
+
 export type UpgradeOptions = Partial<PrepareOnly> & {
     signer?: string | ServerSignerConfig;
 };

--- a/packages/wallets/src/wallets/wallet-factory.test.ts
+++ b/packages/wallets/src/wallets/wallet-factory.test.ts
@@ -1406,4 +1406,49 @@ describe("WalletFactory - Quorum Recovery", () => {
             ).resolves.toBeDefined();
         });
     });
+
+    describe("createWallet quorum runtime config preservation", () => {
+        it("grafts member runtime fields onto the API members, keeping API identity fields", async () => {
+            mockApiClient.createWallet.mockResolvedValue(quorumWalletResponse(matchingQuorumAdminSigner));
+            const onSign = vi.fn();
+
+            const wallet = await walletFactory.createWallet({
+                chain: "solana",
+                recovery: {
+                    type: "quorum",
+                    threshold: 1,
+                    methods: [
+                        { type: "external-wallet", address: "MemberWallet111", onSign } as never,
+                        { type: "server", secret: TEST_SECRET },
+                        { type: "email", email: "Alice@GMAIL.com" },
+                    ],
+                },
+            });
+
+            const recovery = wallet.recovery as unknown as { signers: Array<Record<string, unknown>> };
+            const externalMember = recovery.signers.find((member) => member.type === "external-wallet");
+            expect(externalMember).toMatchObject({
+                address: "MemberWallet111",
+                locator: "external-wallet:MemberWallet111",
+                onSign,
+            });
+            const serverMember = recovery.signers.find((member) => member.type === "server");
+            expect(serverMember).toMatchObject({
+                address: serverMemberAddress,
+                locator: `server:${serverMemberAddress}`,
+                secret: TEST_SECRET,
+            });
+            const emailMember = recovery.signers.find((member) => member.type === "email");
+            // API identity fields win over the caller's denormalized input.
+            expect(emailMember).toMatchObject({ email: "alice@gmail.com", locator: "email:alice@gmail.com" });
+        });
+
+        it("keeps the API members verbatim when no recovery config is provided", async () => {
+            mockApiClient.getWallet.mockResolvedValue(quorumWalletResponse(matchingQuorumAdminSigner));
+
+            const wallet = await walletFactory.getWallet({ chain: "solana" });
+
+            expect(wallet.recovery).toEqual(matchingQuorumAdminSigner);
+        });
+    });
 });

--- a/packages/wallets/src/wallets/wallet-factory.ts
+++ b/packages/wallets/src/wallets/wallet-factory.ts
@@ -20,6 +20,7 @@ import type {
     QuorumMemberConfigForChain,
     QuorumRecoveryConfig,
     RecoveryConfigForChain,
+    ResolvedQuorumRecoveryConfig,
     ServerSignerConfig,
     SignerConfigForChain,
     ResolvedRecoveryConfigForChain,
@@ -262,7 +263,9 @@ export class WalletFactory {
         const recovery =
             createArgs.recovery?.type === "server" || createArgs.recovery?.type === "external-wallet"
                 ? createArgs.recovery
-                : apiRecovery ?? this.fallbackRecoveryFromArgs(createArgs.recovery);
+                : apiRecovery?.type === "quorum"
+                  ? this.mergeQuorumRuntimeConfig(apiRecovery, createArgs.recovery, args.chain)
+                  : apiRecovery ?? this.fallbackRecoveryFromArgs(createArgs.recovery);
         if (recovery == null) {
             throw new WalletCreationError(
                 "Unable to determine the wallet's recovery signer: the API response contains no admin signer configuration."
@@ -316,6 +319,38 @@ export class WalletFactory {
 
     private getWalletLocator<C extends Chain>(args: WalletArgsFor<C>): string {
         return `me:${this.getChainType(args.chain)}:smart` + (args.alias != null ? `:alias:${args.alias}` : "");
+    }
+
+    /**
+     * The quorum counterpart of the single server/external-wallet preservation above: the API
+     * cannot store runtime member data (server `secret`, external-wallet `onSign`, passkey
+     * callbacks), so graft each user-provided method onto the API member it identifies.
+     * API identity fields win (per-member `locator`, passkey `id`, derived `address`, exact
+     * `email`); matching is order-insensitive and consume-once, like the existing-wallet
+     * validation. API members with no matching method pass through verbatim.
+     */
+    private mergeQuorumRuntimeConfig<C extends Chain>(
+        apiQuorum: ResolvedQuorumRecoveryConfig,
+        userRecovery: RecoveryConfigForChain<C> | undefined,
+        chain: C
+    ): ResolvedQuorumRecoveryConfig {
+        if (userRecovery == null) {
+            return apiQuorum;
+        }
+        const normalized = this.normalizeRecovery(userRecovery);
+        if (!isQuorumRecovery(normalized)) {
+            return apiQuorum;
+        }
+        const unmatched = [...normalized.methods];
+        const signers = apiQuorum.signers.map((member) => {
+            const matchIndex = unmatched.findIndex((method) => this.isMatchingQuorumMember(method, member, chain));
+            if (matchIndex === -1) {
+                return member;
+            }
+            const [method] = unmatched.splice(matchIndex, 1);
+            return { ...method, ...member };
+        });
+        return { ...apiQuorum, signers };
     }
 
     /**

--- a/packages/wallets/src/wallets/wallet.quorum-recovery.test.ts
+++ b/packages/wallets/src/wallets/wallet.quorum-recovery.test.ts
@@ -1,10 +1,10 @@
-import { afterEach, beforeEach, describe, expect, it, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { Wallet } from "./wallet";
 import { WalletFactory } from "./wallet-factory";
-import { QuorumSignerNotSupportedError } from "../utils/errors";
 import type { ApiClient, GetWalletSuccessResponse } from "../api";
 import type { Chain } from "../chains/chains";
-import type { SignerAdapter } from "../signers/types";
+import type { SignerAdapter, SignerConfigForChain } from "../signers/types";
+import { deriveServerSignerDetails } from "../signers/server";
 import { APIKeyEnvironmentPrefix } from "@crossmint/common-sdk-base";
 import { createMockApiClient, type MockedApiClient } from "./__tests__/test-helpers";
 
@@ -42,47 +42,295 @@ const singleAdminWallet = {
     createdAt: Date.now(),
 } as GetWalletSuccessResponse;
 
-describe("Wallet - quorum recovery signing guards", () => {
-    let mockApiClient: {
-        isServerSide: boolean;
-        crossmint: { projectId: string };
-        projectId: string;
-        environment: string;
-        getWallet: ReturnType<typeof vi.fn>;
-        createWallet: ReturnType<typeof vi.fn>;
-    };
+const evmQuorumWallet = {
+    chainType: "evm" as const,
+    type: "smart" as const,
+    address: "0x1234567890123456789012345678901234567890",
+    owner: "test-owner",
+    config: {
+        adminSigner: {
+            type: "quorum",
+            threshold: 1,
+            locator: "quorum:9f2c0000",
+            signers: [
+                { type: "external-wallet", address: "0xMemberAAA", locator: "external-wallet:0xMemberAAA" },
+                { type: "email", email: "bob@gmail.com", locator: "email:bob@gmail.com" },
+            ],
+        },
+    },
+    createdAt: Date.now(),
+} as unknown as GetWalletSuccessResponse;
+
+const passkeyQuorumWallet = {
+    chainType: "evm" as const,
+    type: "smart" as const,
+    address: "0x1234567890123456789012345678901234567890",
+    owner: "test-owner",
+    config: {
+        adminSigner: {
+            type: "quorum",
+            threshold: 1,
+            locator: "quorum:9f2c0000",
+            signers: [
+                { type: "passkey", id: "pk-1", name: "primary", locator: "passkey:pk-1" },
+                { type: "passkey", id: "pk-2", name: "backup", locator: "passkey:pk-2" },
+            ],
+        },
+    },
+    createdAt: Date.now(),
+} as unknown as GetWalletSuccessResponse;
+
+describe("Wallet - quorum member selection", () => {
+    const TEST_SECRET = "b".repeat(64);
+    const PROJECT_ID = "test-project";
+
+    let mockApiClient: MockedApiClient & { crossmint: { projectId: string }; projectId: string };
     let walletFactory: WalletFactory;
+    let onSign: ReturnType<typeof vi.fn>;
 
     beforeEach(() => {
+        vi.clearAllMocks();
         mockApiClient = {
-            isServerSide: false,
-            crossmint: { projectId: "test-project" },
-            projectId: "test-project",
+            ...createMockApiClient(),
+            crossmint: { projectId: PROJECT_ID },
+            projectId: PROJECT_ID,
             environment: APIKeyEnvironmentPrefix.STAGING,
-            getWallet: vi.fn().mockResolvedValue(quorumWallet),
-            createWallet: vi.fn().mockResolvedValue(quorumWallet),
         };
+        mockApiClient.getWallet.mockResolvedValue(quorumWallet);
         walletFactory = new WalletFactory(mockApiClient as unknown as ApiClient);
+        onSign = vi.fn().mockResolvedValue("0xmembersig");
     });
 
-    describe("useSigner with a quorum member", () => {
-        it("explains that quorum signing is unsupported instead of claiming the member is unregistered", async () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    describe("when the caller holds an external-wallet member", () => {
+        test("useSigner selects it as an admin signer under the member locator", async () => {
             const wallet = await walletFactory.getWallet({ chain: "solana" });
 
-            const attempt = wallet.useSigner({ type: "email", email: "alice@gmail.com" });
-            await expect(attempt).rejects.toThrow(QuorumSignerNotSupportedError);
-            await expect(wallet.useSigner({ type: "email", email: "alice@gmail.com" })).rejects.toThrow(
-                "signing with a quorum member is not yet supported by this SDK version"
+            await wallet.useSigner({ type: "external-wallet", address: "MemberWallet111", onSign } as Parameters<
+                Wallet<Chain>["useSigner"]
+            >[0]);
+
+            expect(wallet.signer?.locator()).toBe("external-wallet:MemberWallet111");
+            expect(wallet.signer?.status).toBe("active");
+            expect(mockApiClient.getSigner).not.toHaveBeenCalled();
+        });
+
+        test("a subsequent approve submits the member's signature under its locator", async () => {
+            mockApiClient.getWallet.mockResolvedValue(evmQuorumWallet);
+            const wallet = await walletFactory.getWallet({ chain: "base-sepolia" });
+            await wallet.useSigner({ type: "external-wallet", address: "0xMemberAAA", onSign } as Parameters<
+                Wallet<Chain>["useSigner"]
+            >[0]);
+            mockApiClient.getTransaction.mockResolvedValue({
+                id: "txn-1",
+                status: "success",
+                chainType: "evm",
+                approvals: {
+                    pending: [
+                        {
+                            signer: { type: "quorum", locator: "quorum:9f2c0000" },
+                            quorumApprovals: {
+                                threshold: 1,
+                                remaining: 1,
+                                pending: [
+                                    {
+                                        signer: {
+                                            type: "external-wallet",
+                                            address: "0xMemberAAA",
+                                            locator: "external-wallet:0xMemberAAA",
+                                        },
+                                        message: "member-message",
+                                    },
+                                    {
+                                        signer: {
+                                            type: "email",
+                                            email: "bob@gmail.com",
+                                            locator: "email:bob@gmail.com",
+                                        },
+                                        message: "member-message-bob",
+                                    },
+                                ],
+                                submitted: [],
+                            },
+                        },
+                    ],
+                    submitted: [],
+                },
+                onChain: { txId: "0xabcdef", explorerLink: "https://explorer.example.com/tx/0xabcdef" },
+            } as Awaited<ReturnType<ApiClient["getTransaction"]>>);
+            mockApiClient.approveTransaction.mockResolvedValue({ id: "txn-1", status: "success" } as Awaited<
+                ReturnType<ApiClient["approveTransaction"]>
+            >);
+
+            vi.useFakeTimers();
+            const approvePromise = wallet.approve({ transactionId: "txn-1" });
+            await vi.runAllTimersAsync();
+            const result = await approvePromise;
+
+            expect(result.hash).toBe("0xabcdef");
+            expect(onSign).toHaveBeenCalledWith("member-message");
+            expect(mockApiClient.approveTransaction).toHaveBeenCalledWith(expect.anything(), "txn-1", {
+                approvals: [{ signer: "external-wallet:0xMemberAAA", signature: "0xmembersig" }],
+            });
+        });
+    });
+
+    describe("when the caller holds the email member", () => {
+        test("a denormalized email input still selects the member", async () => {
+            const wallet = await walletFactory.getWallet({ chain: "solana" });
+
+            await wallet.useSigner({ type: "email", email: "Alice@GMAIL.com" });
+
+            expect(wallet.signer?.locator()).toBe("email:alice@gmail.com");
+            expect(wallet.signer?.status).toBe("active");
+        });
+    });
+
+    describe("when the caller holds the server member", () => {
+        test("useSigner with the secret resolves the member derivation and strips the secret", async () => {
+            const { derivedAddress } = deriveServerSignerDetails(
+                { type: "server", secret: TEST_SECRET },
+                "solana",
+                PROJECT_ID,
+                APIKeyEnvironmentPrefix.STAGING
+            );
+            mockApiClient.getWallet.mockResolvedValue({
+                ...(quorumWallet as unknown as Record<string, unknown>),
+                config: {
+                    adminSigner: {
+                        type: "quorum",
+                        threshold: 1,
+                        locator: "quorum:9f2c0000",
+                        signers: [
+                            { type: "server", address: derivedAddress, locator: `server:${derivedAddress}` },
+                            { type: "email", email: "alice@gmail.com", locator: "email:alice@gmail.com" },
+                        ],
+                    },
+                },
+            } as unknown as GetWalletSuccessResponse);
+            const wallet = await walletFactory.getWallet({ chain: "solana" });
+
+            await wallet.useSigner({ type: "server", secret: TEST_SECRET });
+
+            expect(wallet.signer?.locator()).toBe(`server:${derivedAddress}`);
+            expect(wallet.signer?.status).toBe("active");
+            const recovery = wallet.recovery as unknown as { signers: Array<Record<string, unknown>> };
+            const serverMember = recovery.signers.find((member) => member.type === "server");
+            expect(serverMember).toEqual({
+                type: "server",
+                address: derivedAddress,
+                locator: `server:${derivedAddress}`,
+            });
+        });
+    });
+
+    describe("when the config matches no member", () => {
+        test("the error lists the member locators and points at useSigner", async () => {
+            const wallet = await walletFactory.getWallet({ chain: "solana" });
+
+            await expect(wallet.useSigner({ type: "email", email: "mallory@example.com" })).rejects.toThrow(
+                'Signer "email:mallory@example.com" is not a registered delegated signer and does not match any member ' +
+                    "of this wallet's quorum admin signer [external-wallet:MemberWallet111, email:alice@gmail.com]. " +
+                    "Call wallet.useSigner() with the config of the quorum member you hold."
             );
         });
 
-        it("keeps the unregistered-signer error for wallets with a single admin signer", async () => {
+        test("keeps the unregistered-signer error for wallets with a single admin signer", async () => {
             mockApiClient.getWallet.mockResolvedValue(singleAdminWallet);
             const wallet = await walletFactory.getWallet({ chain: "solana" });
 
             await expect(wallet.useSigner({ type: "email", email: "not-a-signer@example.com" })).rejects.toThrow(
                 'Signer "email:not-a-signer@example.com" is not registered in this wallet.'
             );
+        });
+    });
+
+    describe("when quorumLocator is provided", () => {
+        test("forces the member interpretation without a registration lookup", async () => {
+            const wallet = await walletFactory.getWallet({ chain: "solana" });
+            const getWalletCallsAfterInit = mockApiClient.getWallet.mock.calls.length;
+
+            await wallet.useSigner(
+                { type: "external-wallet", address: "MemberWallet111", onSign } as Parameters<
+                    Wallet<Chain>["useSigner"]
+                >[0],
+                { quorumLocator: "quorum:9f2c0000" }
+            );
+
+            expect(wallet.signer?.locator()).toBe("external-wallet:MemberWallet111");
+            expect(wallet.signer?.status).toBe("active");
+            expect(mockApiClient.getWallet.mock.calls.length).toBe(getWalletCallsAfterInit);
+            expect(mockApiClient.getSigner).not.toHaveBeenCalled();
+        });
+
+        test("rejects a locator that names a different quorum", async () => {
+            const wallet = await walletFactory.getWallet({ chain: "solana" });
+
+            await expect(
+                wallet.useSigner({ type: "email", email: "alice@gmail.com" }, { quorumLocator: "quorum:deadbeef" })
+            ).rejects.toThrow(
+                'Quorum locator "quorum:deadbeef" does not match this wallet\'s quorum admin signer ("quorum:9f2c0000").'
+            );
+        });
+
+        test("rejects a config that matches no member", async () => {
+            const wallet = await walletFactory.getWallet({ chain: "solana" });
+
+            await expect(
+                wallet.useSigner({ type: "email", email: "mallory@example.com" }, { quorumLocator: "quorum:9f2c0000" })
+            ).rejects.toThrow(/does not match any member of this wallet's quorum admin signer/);
+        });
+
+        test("rejects device configs", async () => {
+            const wallet = await walletFactory.getWallet({ chain: "solana" });
+
+            await expect(wallet.useSigner({ type: "device" }, { quorumLocator: "quorum:9f2c0000" })).rejects.toThrow(
+                "Device signers cannot be quorum members — quorumLocator does not apply."
+            );
+        });
+
+        test("rejects wallets whose admin signer is not a quorum", async () => {
+            mockApiClient.getWallet.mockResolvedValue(singleAdminWallet);
+            const wallet = await walletFactory.getWallet({ chain: "solana" });
+
+            await expect(
+                wallet.useSigner({ type: "email", email: "alice@gmail.com" }, { quorumLocator: "quorum:9f2c0000" })
+            ).rejects.toThrow("A quorumLocator was provided, but this wallet's admin signer is not a quorum.");
+        });
+    });
+
+    describe("when the quorum has multiple passkey members", () => {
+        beforeEach(() => {
+            mockApiClient.getWallet.mockResolvedValue(passkeyQuorumWallet);
+        });
+
+        test("an id-less, name-less config is rejected as ambiguous", async () => {
+            const wallet = await walletFactory.getWallet({ chain: "base-sepolia" });
+
+            await expect(wallet.useSigner({ type: "passkey" } as SignerConfigForChain<"base-sepolia">)).rejects.toThrow(
+                /Multiple passkey members are in this wallet's quorum admin signer/
+            );
+        });
+
+        test("selecting by name adopts the stored credential id", async () => {
+            const wallet = await walletFactory.getWallet({ chain: "base-sepolia" });
+
+            await wallet.useSigner({ type: "passkey", name: "backup" } as SignerConfigForChain<"base-sepolia">);
+
+            expect(wallet.signer?.locator()).toBe("passkey:pk-2");
+            expect(wallet.signer?.status).toBe("active");
+        });
+
+        test("selecting by credential id works even though the passkey is not a registered signer", async () => {
+            const wallet = await walletFactory.getWallet({ chain: "base-sepolia" });
+
+            await wallet.useSigner({ type: "passkey", id: "pk-1" } as SignerConfigForChain<"base-sepolia">);
+
+            expect(wallet.signer?.locator()).toBe("passkey:pk-1");
+            expect(wallet.signer?.status).toBe("active");
         });
     });
 });

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -26,6 +26,7 @@ import type {
     ApproveResult,
     PrepareOnly,
     SendTokenTransactionOptions,
+    UseSignerOptions,
 } from "./types";
 import { mapApiSignerToSigner } from "../utils/signer-mapping";
 import {
@@ -33,7 +34,6 @@ import {
     DeviceSignerNotSupportedError,
     InvalidSignerError,
     InvalidTransferAmountError,
-    QuorumSignerNotSupportedError,
     SignatureFailedError,
     SignatureNotAvailableError,
     TransactionFailedError,
@@ -49,6 +49,7 @@ import type {
     ExternalWalletRegistrationConfig,
     PasskeySignerConfig,
     RecoverySignerConfigForChain,
+    ResolvedQuorumMember,
     ServerSignerConfig,
     SignerAdapter,
     SignerConfigForChain,
@@ -62,6 +63,7 @@ import { getSignerDescriptor } from "../signers/descriptors";
 import { walletsLogger } from "../logger";
 
 import { getSignerLocator } from "../utils/signer-locator";
+import { getQuorumMemberLocator } from "../utils/quorum-members";
 import { toRecipientLocator, toTokenLocator } from "../utils/locators";
 import { formatBalanceResponse } from "./services/balance-formatter";
 import { SignerManager } from "./services/signer-manager";
@@ -843,7 +845,14 @@ export class Wallet<C extends Chain> {
      * For external-wallet signers: the config object must include an onSign callback
      * (applies to both registered and recovery signers).
      *
+     * For quorum admin signers: pass the config of the member you hold — a member is selected
+     * like any other signer, and approvals are submitted under that member's locator. Members
+     * are matched before registered delegated signers (email/phone/external-wallet) or after
+     * them (passkey/server); pass `options.quorumLocator` to force the member interpretation
+     * for a key that exists both inside the quorum and as a delegated signer.
+     *
      * @param signer - The signer config object to use
+     * @param options - Optional selection modifiers (see {@link UseSignerOptions})
      */
     @WithLoggerContext({
         logger: walletsLogger,
@@ -852,7 +861,7 @@ export class Wallet<C extends Chain> {
             return { chain: thisArg.chain, address: thisArg.address };
         },
     })
-    public async useSigner(signer: SignerConfigForChain<C>): Promise<void> {
+    public async useSigner(signer: SignerConfigForChain<C>, options?: UseSignerOptions): Promise<void> {
         walletsLogger.info("wallet.useSigner.start");
         // Reset the delegated signer cache when processing a fresh server signer.
         // The recovery resolution is intentionally preserved — it's set once during
@@ -863,27 +872,45 @@ export class Wallet<C extends Chain> {
         getSignerDescriptor<C>(signer.type).validateConfig(signer);
 
         let isAdminSigner = false;
+        // A matched quorum member replaces the caller's config with the API-merged one, so the
+        // assembled adapter's locator equals the API's member locator (what the approval loop
+        // matches `quorumApprovals.pending` entries against).
+        let effectiveConfig = signer;
         if (signer.type === "device") {
+            if (options?.quorumLocator != null) {
+                throw new Error("Device signers cannot be quorum members — quorumLocator does not apply.");
+            }
             await this.#deviceRecovery.resolveAvailability(signer);
         } else {
-            isAdminSigner = await this.resolveNonDeviceSigner(signer);
+            ({ isAdminSigner, effectiveConfig } = await this.resolveNonDeviceSigner(signer, options));
         }
 
-        const internalConfig = getSignerDescriptor<C>(signer.type).buildInternalConfig(
-            signer,
+        const internalConfig = getSignerDescriptor<C>(effectiveConfig.type).buildInternalConfig(
+            effectiveConfig,
             this.#signerManager.descriptorContext()
         );
-        const signerLocator = getSignerLocator(signer);
+        const signerLocator = getSignerLocator(effectiveConfig);
         this.#signerManager.setActiveSigner(await this.#signerManager.assemble(internalConfig, { isAdminSigner }));
         walletsLogger.info("wallet.useSigner.success", { signerLocator });
     }
 
     /**
-     * Resolve a non-device signer: check registration first, then fall back to recovery.
+     * Resolve a non-device signer: check registration first, then fall back to recovery —
+     * either the single admin signer or, for quorum wallets, the member the config identifies.
      * For passkeys without an explicit credential id, auto-selects from registered signers.
-     * Returns true if the signer is an admin (recovery) signer.
+     * Returns whether the signer is admin-side and the config to assemble it from (the caller's
+     * config, or the API-merged member config for quorum members).
      */
-    private async resolveNonDeviceSigner(signer: SignerConfigForChain<C>): Promise<boolean> {
+    private async resolveNonDeviceSigner(
+        signer: SignerConfigForChain<C>,
+        options?: UseSignerOptions
+    ): Promise<{ isAdminSigner: boolean; effectiveConfig: SignerConfigForChain<C> }> {
+        // quorumLocator forces the member interpretation and skips delegated-signer resolution —
+        // it disambiguates a key that is both a quorum member and a registered delegated signer.
+        if (options?.quorumLocator != null) {
+            return this.resolveForcedQuorumMember(signer, options.quorumLocator);
+        }
+
         // For non-passkey, non-server signers, check if this is the recovery (admin) signer first.
         // Admin signers are always approved — skip the registration check and getSigner API call
         // which only works for delegated signers (returns 404/400 for admin signers).
@@ -891,9 +918,18 @@ export class Wallet<C extends Chain> {
         // incorrectly match a delegated passkey.
         // Server signers are excluded so they always flow through the server signer block below,
         // which resolves the correct (primary or legacy) derivation.
-        if (signer.type !== "passkey" && signer.type !== "server" && this.isRecoverySigner(signer)) {
-            this.#deviceRecovery.onSignerSelected();
-            return true;
+        if (signer.type !== "passkey" && signer.type !== "server") {
+            if (this.isRecoverySigner(signer)) {
+                this.#deviceRecovery.onSignerSelected();
+                return { isAdminSigner: true, effectiveConfig: signer };
+            }
+            // Same admin-first precedence for quorum members: a config identifying a member
+            // selects it without a registration round-trip.
+            const member = this.tryResolveQuorumMember(signer);
+            if (member != null) {
+                this.#deviceRecovery.onSignerSelected();
+                return { isAdminSigner: true, effectiveConfig: member };
+            }
         }
 
         // Passkey without id: try to auto-select from registered signers
@@ -903,39 +939,127 @@ export class Wallet<C extends Chain> {
                 // No registered passkeys — use recovery if this is the recovery signer
                 if (this.isRecoverySigner(signer)) {
                     this.#deviceRecovery.onSignerSelected();
-                    return true;
+                    return { isAdminSigner: true, effectiveConfig: signer };
+                }
+                // ... or the quorum member it identifies (by name, or the only passkey member).
+                const member = this.tryResolveQuorumMember(signer);
+                if (member != null) {
+                    this.#deviceRecovery.onSignerSelected();
+                    return { isAdminSigner: true, effectiveConfig: member };
                 }
                 throw new Error("No passkey signer is registered on this wallet.");
             }
         }
 
         if (signer.type === "server") {
-            return this.resolveServerSigner(signer);
+            return { isAdminSigner: await this.resolveServerSigner(signer), effectiveConfig: signer };
         }
 
         // Check if this is a registered signer
         const locator = this.resolveSignerLocator(signer);
         if (await this.signerIsRegistered(locator)) {
             this.#deviceRecovery.onSignerSelected();
-            return false;
+            return { isAdminSigner: false, effectiveConfig: signer };
         }
 
         // Not a registered signer — fall back to recovery
         if (this.isRecoverySigner(signer)) {
             this.#deviceRecovery.onSignerSelected();
-            return true;
+            return { isAdminSigner: true, effectiveConfig: signer };
+        }
+
+        // Passkey with an explicit id that isn't registered may still be a quorum member.
+        if (signer.type === "passkey") {
+            const member = this.tryResolveQuorumMember(signer);
+            if (member != null) {
+                this.#deviceRecovery.onSignerSelected();
+                return { isAdminSigner: true, effectiveConfig: member };
+            }
         }
 
         // A quorum member is part of the admin signer, not a delegated signer, so it can never
         // pass the registration check above — "not registered" would be misleading for it.
-        if (this.#signerManager.recovery.type === "quorum") {
-            throw new QuorumSignerNotSupportedError(
-                `Signer "${locator}" is not a registered delegated signer, and this wallet uses a quorum recovery signer — ` +
-                    "signing with a quorum member is not yet supported by this SDK version."
+        const memberLocators = this.#signerManager.quorumMemberLocators();
+        if (memberLocators != null) {
+            throw new Error(
+                `Signer "${locator}" is not a registered delegated signer and does not match any member ` +
+                    `of this wallet's quorum admin signer [${memberLocators.join(", ")}]. ` +
+                    "Call wallet.useSigner() with the config of the quorum member you hold."
             );
         }
 
         throw new Error(`Signer "${locator}" is not registered in this wallet.`);
+    }
+
+    /**
+     * Resolve a candidate config against the wallet's quorum members. On a unique match, the
+     * member is adopted (API identity fields merged over the caller's config, runtime callbacks
+     * preserved) and the merged config returned; null when nothing matches.
+     */
+    private tryResolveQuorumMember(signer: SignerConfigForChain<C>): SignerConfigForChain<C> | null {
+        const matches = this.#signerManager.matchQuorumMembers(signer);
+        if (matches.length === 0) {
+            return null;
+        }
+        if (matches.length > 1) {
+            // Only passkeys can match several members: id-less, name-less configs match permissively.
+            throw new Error(
+                "Multiple passkey members are in this wallet's quorum admin signer. " +
+                    'Specify the credential id or name: wallet.useSigner({ type: "passkey", id: "<credential-id>" })'
+            );
+        }
+        const member = matches[0];
+        const merged = { ...signer, ...member } as SignerConfigForChain<C> & ResolvedQuorumMember;
+        this.#signerManager.adoptQuorumMemberConfig(getQuorumMemberLocator(member), merged);
+        return merged;
+    }
+
+    /**
+     * quorumLocator path of useSigner: validate the locator and match the config strictly
+     * against the quorum's members, bypassing delegated-signer resolution.
+     */
+    private resolveForcedQuorumMember(
+        signer: SignerConfigForChain<C>,
+        quorumLocator: string
+    ): { isAdminSigner: boolean; effectiveConfig: SignerConfigForChain<C> } {
+        const recovery = this.#signerManager.recovery;
+        if (recovery.type !== "quorum") {
+            throw new Error("A quorumLocator was provided, but this wallet's admin signer is not a quorum.");
+        }
+        if (recovery.locator != null && recovery.locator !== quorumLocator) {
+            throw new Error(
+                `Quorum locator "${quorumLocator}" does not match this wallet's quorum admin signer ("${recovery.locator}").`
+            );
+        }
+
+        if (signer.type === "server") {
+            const matches = this.#signerManager.matchQuorumMembers(signer);
+            if (matches.length === 0) {
+                throw this.quorumNonMemberError(signer);
+            }
+            // Force the recovery resolution (no registered-signer preference) so the resolver
+            // caches the member-matching derivation, then drop the now-redundant secret.
+            this.#serverSignerResolver.resolveForUseSigner(signer as ServerSignerConfig, [], () => true);
+            this.#signerManager.adoptQuorumMemberConfig(getQuorumMemberLocator(matches[0]), matches[0]);
+            this.#signerManager.stripSecretFromRecovery();
+            this.#deviceRecovery.onSignerSelected();
+            return { isAdminSigner: true, effectiveConfig: signer };
+        }
+
+        const member = this.tryResolveQuorumMember(signer);
+        if (member == null) {
+            throw this.quorumNonMemberError(signer);
+        }
+        this.#deviceRecovery.onSignerSelected();
+        return { isAdminSigner: true, effectiveConfig: member };
+    }
+
+    private quorumNonMemberError(signer: SignerConfigForChain<C>): Error {
+        const memberLocators = this.#signerManager.quorumMemberLocators() ?? [];
+        return new Error(
+            `Signer "${getSignerLocator(signer)}" does not match any member of this wallet's quorum admin signer ` +
+                `[${memberLocators.join(", ")}]. Call wallet.useSigner() with the config of the quorum member you hold.`
+        );
     }
 
     /**
@@ -945,17 +1069,29 @@ export class Wallet<C extends Chain> {
     private async resolveServerSigner(signer: ServerSignerConfig): Promise<boolean> {
         const existingSigners = await this.signers();
         const registeredLocators = existingSigners.map((s) => s.locator);
+        const isQuorum = this.#signerManager.recovery.type === "quorum";
         const resolution = this.#serverSignerResolver.resolveForUseSigner(signer, registeredLocators, () =>
-            this.isRecoverySigner(signer as SignerConfigForChain<C>)
+            isQuorum
+                ? this.#signerManager.matchQuorumMembers(signer).length > 0
+                : this.isRecoverySigner(signer as SignerConfigForChain<C>)
         );
         switch (resolution.kind) {
             case "delegated":
                 this.#deviceRecovery.onSignerSelected();
                 return false;
-            case "recovery":
+            case "recovery": {
+                if (isQuorum) {
+                    // Record which member this secret resolved to; the derivation itself is
+                    // cached in the resolver, so only the member's API identity is stored.
+                    const matches = this.#signerManager.matchQuorumMembers(signer);
+                    if (matches.length === 1) {
+                        this.#signerManager.adoptQuorumMemberConfig(getQuorumMemberLocator(matches[0]), matches[0]);
+                    }
+                }
                 this.#signerManager.stripSecretFromRecovery();
                 this.#deviceRecovery.onSignerSelected();
                 return true;
+            }
             case "unregistered":
                 throw new Error(resolution.message);
         }


### PR DESCRIPTION
## Description

M4-6 of the quorum recovery milestone: audits the React / React Native providers for the create-side quorum `recovery` widening (WAL-11290) and fixes every check that assumed a flat single-signer recovery. Stacked on the M4-4 stack (#1997 → #1998 → #1999 → #1996).

All five flat-recovery checks now descend into quorum `methods` via a new shared `recoverySigners` helper in react-base:

1. **RN WebView init** (`initializeWebViewIfNeeded`): a quorum containing an email/phone member now boots the hidden signer WebView before wallet creation — previously it never initialized and creation crashed with "WebView not ready or handshake incomplete". Resolves the `TODO(WAL-11294)` left by M4-4. Member-aware: an all-external-wallet quorum still skips the WebView.
2. **RN passkey guard**: a passkey member hidden inside `recovery.methods` is now rejected with the same clear `PASSKEY_RN_ERROR` as a flat passkey recovery (both the mount-time check and `createWallet`).
3. **Email auto-population**: a quorum email member missing its `email` is auto-filled from the logged-in user — only when exactly one email member is incomplete; filling several with the same address would create duplicate members (which the API rejects), so those configs pass through and validation surfaces the real problem.
4. **External-wallet address guard**: wallet creation now also waits when an external-wallet quorum member lacks an `address` (previously create fired prematurely).
5. **Web passkey helper UI**: shows for a passkey quorum member, not just a flat passkey recovery.

Verification-only findings (no code needed): the OTP / `onAuthRequired` flow is already recovery-shape-agnostic — it keys off the active signer instance's `(type, locator)`, and the device-signer-while-recovering fallback (`activeAuthEmail`/`activeAuthPhone`) already covers a quorum member driving OTP. Known limitation flagged for M4-7: `useSignerAuth` holds a single set of send/verify/reject refs, so two members needing OTP concurrently would clobber — unreachable at launch (threshold = 1).

Docs: quorum `recovery` examples in the react-ui / react-native / wallets READMEs (RN notes that passkey quorum members are rejected), `examples.json` snippets, and the reference generator's `recovery` fallback now renders `RecoveryConfigForChain` with quorum prose.

## Test plan

- New `quorum-recovery.test.ts` in react-base: `recoverySigners` flat/quorum/undefined, `recoveryNeedsEmailAutoFill` exactly-one semantics, `fillRecoveryEmail` fill/no-mutation/pass-through cases. Full react-base suite: 23 pass.
- RN provider test wiring deferred to M4-7 (package has no vitest script yet).
- tsc `--noEmit` for react-base, react-ui, react-native: 0 errors in src (only pre-existing env noise).
- Biome clean on changed files.
- Changeset: minor for `@crossmint/client-sdk-react-base` and `@crossmint/client-sdk-react-native-ui`.

## Checklist

-   [ ] Run mainonly E2E tests (these tests always run in the merge queue regardless of this checkbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)