### PR TITLE
feat(wallets): add channel option for phone signer OTP delivery

### DIFF
--- a/.changeset/whatsapp-channel.md
+++ b/.changeset/whatsapp-channel.md
@@ -1,0 +1,6 @@
+---
+"@crossmint/client-signers": minor
+"@crossmint/wallets-sdk": minor
+---
+
+Added a `channel` option to the phone signer `start-onboarding` flow so OTPs can be delivered via WhatsApp as well as SMS.

--- a/apps/wallets/quickstart-devkit/app/providers.tsx
+++ b/apps/wallets/quickstart-devkit/app/providers.tsx
@@ -299,6 +299,7 @@ function QueryParamsProvider({ children }: { children: React.ReactNode }) {
     const signerType = searchParams.get("signer") || "email";
     const chainId = searchParams.get("chainId") || process.env.NEXT_PUBLIC_EVM_CHAIN;
     const phoneNumber = searchParams.get("phoneNumber");
+    const phoneChannel = searchParams.get("channel"); // "sms" | "whatsapp" — only used when signer=phone
     const crossmintApiKey = searchParams.get("crossmintApiKey") || undefined;
     const alias = searchParams.get("alias") || undefined;
 
@@ -321,6 +322,7 @@ function QueryParamsProvider({ children }: { children: React.ReactNode }) {
                     createOnLogin.recovery = {
                         type: signerType,
                         phone: decodeURIComponent(phoneNumber),
+                        ...(phoneChannel != null ? { channel: phoneChannel } : {}),
                     };
                 }
                 return (
@@ -348,6 +350,7 @@ function QueryParamsProvider({ children }: { children: React.ReactNode }) {
                     createOnLogin.recovery = {
                         type: signerType,
                         phone: decodeURIComponent(phoneNumber),
+                        ...(phoneChannel != null ? { channel: phoneChannel } : {}),
                     };
                 }
                 return (
@@ -366,6 +369,7 @@ function QueryParamsProvider({ children }: { children: React.ReactNode }) {
             createOnLogin.recovery = {
                 type: signerType,
                 phone: decodeURIComponent(phoneNumber),
+                ...(phoneChannel != null ? { channel: phoneChannel } : {}),
             };
         }
         return (

--- a/packages/client/signers/src/communications/schemas.ts
+++ b/packages/client/signers/src/communications/schemas.ts
@@ -55,6 +55,7 @@ export const StartOnboardingPayloadSchema = {
         data: z
             .object({
                 authId: z.string().describe("Authentication identifier for the signer"),
+                channel: z.enum(["sms", "whatsapp"]).optional().describe("OTP delivery channel for phone signers"),
             })
             .describe("Data needed to create a new signer"),
     }),

--- a/packages/wallets/src/signers/descriptors/descriptors.test.ts
+++ b/packages/wallets/src/signers/descriptors/descriptors.test.ts
@@ -88,6 +88,23 @@ it.each<[type: "email" | "phone", field: "email" | "phone", value: string]>([
     });
 });
 
+it("buildInternalConfig: phone threads channel from config", () => {
+    const result = getSignerDescriptor("phone").buildInternalConfig(
+        { type: "phone", phone: "+15551234", channel: "whatsapp" } as never,
+        makeCtx()
+    );
+    expect(result).toEqual({
+        type: "phone",
+        phone: "+15551234",
+        channel: "whatsapp",
+        locator: "phone:+15551234",
+        address: WALLET_ADDRESS,
+        crossmint,
+        clientTEEConnection,
+        onAuthRequired,
+    });
+});
+
 it("buildInternalConfig: api-key returns locator and wallet address", () => {
     const result = getSignerDescriptor("api-key").buildInternalConfig({ type: "api-key" } as never, makeCtx());
     expect(result).toEqual({ type: "api-key", locator: "api-key", address: WALLET_ADDRESS });

--- a/packages/wallets/src/signers/descriptors/phone.ts
+++ b/packages/wallets/src/signers/descriptors/phone.ts
@@ -25,6 +25,7 @@ export const phoneSignerDescriptor: SignerDescriptor = {
         return {
             type: "phone",
             phone: phoneConfig.phone,
+            channel: phoneConfig.channel,
             locator: `phone:${phoneConfig.phone}` as SignerLocator,
             address: ctx.walletAddress,
             crossmint: ctx.crossmint,

--- a/packages/wallets/src/signers/non-custodial/ncs-signer.test.ts
+++ b/packages/wallets/src/signers/non-custodial/ncs-signer.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 
-import type { EmailInternalSignerConfig } from "../types";
+import type { EmailInternalSignerConfig, PhoneInternalSignerConfig } from "../types";
 import { OnboardingSessionExpiredError, OtpValidationError } from "../types";
 import { EVMNonCustodialSigner } from "./ncs-evm-signer";
 
@@ -27,6 +27,19 @@ function makeConfig(overrides: Partial<EmailInternalSignerConfig> = {}): EmailIn
     } as unknown as EmailInternalSignerConfig;
 }
 
+function makePhoneConfig(overrides: Partial<PhoneInternalSignerConfig> = {}): PhoneInternalSignerConfig {
+    return {
+        type: "phone",
+        phone: "+15551234",
+        locator: "phone:+15551234",
+        address: "0x0000000000000000000000000000000000000000",
+        crossmint: { apiKey: "ck_staging_test", jwt: "test-jwt" },
+        clientTEEConnection: makeReadyConnection(),
+        onAuthRequired: vi.fn(async () => {}),
+        ...overrides,
+    } as unknown as PhoneInternalSignerConfig;
+}
+
 describe("NonCustodialSigner.ensureAuthenticated", () => {
     it("resets the signer frame before checking signer status", async () => {
         const calls: string[] = [];
@@ -42,6 +55,49 @@ describe("NonCustodialSigner.ensureAuthenticated", () => {
         expect(clientTEEConnection.sendAction).toHaveBeenCalledTimes(1);
         // The reset must run before the status check so the OTP flow targets the fresh frame.
         expect(calls).toEqual(["reset", "get-status"]);
+    });
+
+    it("includes the channel in start-onboarding payload for phone signers", async () => {
+        const clientTEEConnection = {
+            connectionGeneration: 1,
+            sendAction: vi.fn(async (args: { event: string }) => {
+                if (args.event === "request:get-status") {
+                    return { status: "success", signerStatus: "new-device" };
+                }
+                return { status: "success" };
+            }),
+        };
+        let hasStarted = false;
+        const onAuthRequired = vi.fn(
+            async (
+                _type: string,
+                _locator: string,
+                _needsAuth: boolean,
+                send: () => Promise<void>,
+                verify: (otp: string) => Promise<void>
+            ) => {
+                if (hasStarted) {
+                    return;
+                }
+                hasStarted = true;
+                await send();
+                await verify("123456");
+            }
+        );
+        const signer = new EVMNonCustodialSigner(
+            makePhoneConfig({ clientTEEConnection, channel: "whatsapp", onAuthRequired })
+        );
+
+        await signer.ensureAuthenticated();
+
+        expect(clientTEEConnection.sendAction).toHaveBeenCalledWith(
+            expect.objectContaining({
+                event: "request:start-onboarding",
+                data: expect.objectContaining({
+                    data: { authId: "phone:+15551234", channel: "whatsapp" },
+                }),
+            })
+        );
     });
 
     it("resets the signer frame on every signature", async () => {

--- a/packages/wallets/src/signers/non-custodial/ncs-signer.ts
+++ b/packages/wallets/src/signers/non-custodial/ncs-signer.ts
@@ -254,6 +254,7 @@ export abstract class NonCustodialSigner implements SignerAdapter {
         const authId = this.getAuthId();
         walletsLogger.info("start-onboarding: sending request");
         const startTime = Date.now();
+        const channel = this.config.type === "phone" ? this.config.channel : undefined;
         const response = await handshakeParent.sendAction({
             event: "request:start-onboarding",
             responseEvent: "response:start-onboarding",
@@ -262,7 +263,7 @@ export abstract class NonCustodialSigner implements SignerAdapter {
                     jwt: this.config.crossmint.jwt ?? "",
                     apiKey: this.config.crossmint.apiKey,
                 },
-                data: { authId },
+                data: { authId, ...(channel != null ? { channel } : {}) },
             },
             options: DEFAULT_EVENT_OPTIONS,
         });

--- a/packages/wallets/src/signers/types.ts
+++ b/packages/wallets/src/signers/types.ts
@@ -88,6 +88,7 @@ export type PhoneSignerConfig = {
     type: "phone";
     phone?: string;
     locator?: string;
+    channel?: "sms" | "whatsapp";
 };
 
 export type NonCustodialSignerType = PhoneSignerConfig["type"] | EmailSignerConfig["type"];

--- a/packages/wallets/src/wallets/wallet-factory.ts
+++ b/packages/wallets/src/wallets/wallet-factory.ts
@@ -129,8 +129,12 @@ export class WalletFactory {
         // Inject a device signer as the default when key storage is available and the caller supplied none.
         // Some providers reject it at creation; createSmartWallet retries without it, gated on this same flag.
         const explicitSigners = validatedArgs.signers ?? [];
-        const didAutoInjectDeviceSigner =
-            validatedArgs.options?.deviceSignerKeyStorage != null && !explicitSigners.some((s) => s.type === "device");
+        // ⚠️ LOCAL-ONLY HARDCODE — DO NOT MERGE
+        // Disable the auto-injected device delegated signer so we can test a
+        // whatsapp-only wallet with no delegated signers. Restore the line below.
+        // const didAutoInjectDeviceSigner =
+        //     validatedArgs.options?.deviceSignerKeyStorage != null && !explicitSigners.some((s) => s.type === "device");
+        const didAutoInjectDeviceSigner = false;
         const signersToRegister = didAutoInjectDeviceSigner
             ? [...explicitSigners, { type: "device" } as SignerConfigForChain<C>]
             : explicitSigners;
@@ -222,6 +226,18 @@ export class WalletFactory {
         return typeof signer === "object" && signer != null && signer.type === "device";
     }
 
+    // `channel` (OTP delivery preference for phone signers) is a client-only field that the
+    // wallet-creation API never persists or returns, so it's always sourced from the caller's config.
+    private mergePhoneChannel<T extends { type: string }>(
+        apiConfig: T,
+        inputConfig?: { type: string; channel?: "sms" | "whatsapp" }
+    ): T {
+        if (apiConfig.type !== "phone" || inputConfig?.type !== "phone" || inputConfig.channel == null) {
+            return apiConfig;
+        }
+        return { ...apiConfig, channel: inputConfig.channel };
+    }
+
     private async createWalletInstance<C extends Chain>(
         walletResponse: GetWalletSuccessResponse,
         args: WalletArgsFor<C>
@@ -238,7 +254,7 @@ export class WalletFactory {
         const recovery =
             createArgs.recovery?.type === "server" || createArgs.recovery?.type === "external-wallet"
                 ? createArgs.recovery
-                : apiRecovery;
+                : this.mergePhoneChannel(apiRecovery, createArgs.recovery);
 
         const apiDelegatedSigners = (walletResponse.config as SmartWalletConfig).delegatedSigners;
         let signers = apiDelegatedSigners;
@@ -248,6 +264,19 @@ export class WalletFactory {
             (signers[0].type === "server" || signers[0].type === "external-wallet")
         ) {
             signers = createArgs.signers as SignerResponse[];
+        } else if (signers != null) {
+            // `channel` (OTP delivery preference for phone signers) is a client-only field that never
+            // round-trips through the wallet-creation API response, so merge it back in from the caller's
+            // config for any delegated phone signers.
+            const inputSigners = createArgs.signers;
+            signers = signers.map((s) =>
+                this.mergePhoneChannel(
+                    s,
+                    inputSigners?.find(
+                        (input) => input.type === "phone" && s.type === "phone" && getSignerLocator(input) === s.locator
+                    )
+                )
+            ) as SignerResponse[];
         }
 
         // Preserve the API-sourced server signer recovery address so the wallet can identify

--- a/packages/wallets/src/wallets/wallet-factory.ts
+++ b/packages/wallets/src/wallets/wallet-factory.ts
@@ -129,12 +129,8 @@ export class WalletFactory {
         // Inject a device signer as the default when key storage is available and the caller supplied none.
         // Some providers reject it at creation; createSmartWallet retries without it, gated on this same flag.
         const explicitSigners = validatedArgs.signers ?? [];
-        // ⚠️ LOCAL-ONLY HARDCODE — DO NOT MERGE
-        // Disable the auto-injected device delegated signer so we can test a
-        // whatsapp-only wallet with no delegated signers. Restore the line below.
-        // const didAutoInjectDeviceSigner =
-        //     validatedArgs.options?.deviceSignerKeyStorage != null && !explicitSigners.some((s) => s.type === "device");
-        const didAutoInjectDeviceSigner = false;
+        const didAutoInjectDeviceSigner =
+            validatedArgs.options?.deviceSignerKeyStorage != null && !explicitSigners.some((s) => s.type === "device");
         const signersToRegister = didAutoInjectDeviceSigner
             ? [...explicitSigners, { type: "device" } as SignerConfigForChain<C>]
             : explicitSigners;


### PR DESCRIPTION
## Description

Adds an optional `channel` option to the phone signer configuration so that OTPs can be delivered via WhatsApp as well as SMS.

- `PhoneSignerConfig` now accepts `channel?: "sms" | "whatsapp"`.
- The phone signer descriptor includes `channel` in the internal signer config.
- `NcsSigner.sendMessageWithOtp` forwards `channel` in the `request:start-onboarding` payload.
- `@crossmint/client-signers` `StartOnboardingPayloadSchema.request.data` allows an optional `channel` field.
- `WalletFactory` merges the client-supplied `channel` back into API-returned phone signer configs, since `channel` is a client-only field that does not round-trip through the wallet-creation API.
- Added changeset for `@crossmint/client-signers` and `@crossmint/wallets-sdk`.

## Test plan

- `pnpm lint` passes.
- `pnpm --filter @crossmint/wallets-sdk... build` succeeds.
- `pnpm --filter @crossmint/wallets-sdk test:vitest` passes, including the new phone signer `channel` test.

## Package updates

- Changeset added: `.changeset/whatsapp-channel.md` bumps `@crossmint/client-signers` and `@crossmint/wallets-sdk` as minor.

### Cross-repo dependencies

- This PR pairs with `Crossmint/open-signer#211` (TEE `channel` support) and `Crossmint/open-signer#212` (frame forwarding of `channel`), and `Paella-Labs/crossbit-main` (relay validation/forwarding of `channel`).

Link to Devin session: https://crossmint.devinenterprise.com/sessions/616ce59b2b1146ab96dd633e551f838e
Requested by: @maxsch-xmint