### PR TITLE
feat(checkout): add identityVerificationHandling so a merchant can own the verification step

### DIFF
--- a/.changeset/embedded-checkout-identity-verification-handling.md
+++ b/.changeset/embedded-checkout-identity-verification-handling.md
@@ -1,0 +1,8 @@
+---
+"@crossmint/client-sdk-base": minor
+"@crossmint/client-sdk-react-ui": minor
+---
+
+Added `identityVerificationHandling` to embedded checkout on web. Setting it to `"external"` stops checkout from rendering the identity verification step, so a merchant can render `CrossmintIdentityVerification` in their own layout using `getIdentityVerificationCredentials(order)`.
+
+Requires a Crossmint deployment that understands the flag. Against an older one it is ignored, and checkout renders the verification step alongside the merchant's, both against the same inquiry.

--- a/.changeset/embedded-checkout-kyc-handling.md
+++ b/.changeset/embedded-checkout-kyc-handling.md
@@ -3,4 +3,6 @@
 "@crossmint/client-sdk-react-ui": minor
 ---
 
-Added `kycHandling` to embedded checkout. Setting it to `"external"` stops checkout from rendering the identity verification step, so a merchant can render `CrossmintIdentityVerification` in their own layout using `getIdentityVerificationCredentials(order)`.
+Added `kycHandling` to embedded checkout on web. Setting it to `"external"` stops checkout from rendering the identity verification step, so a merchant can render `CrossmintIdentityVerification` in their own layout using `getIdentityVerificationCredentials(order)`.
+
+Requires a Crossmint deployment that understands the flag. Against an older one it is ignored, and checkout renders the verification step alongside the merchant's, both against the same inquiry.

--- a/.changeset/embedded-checkout-kyc-handling.md
+++ b/.changeset/embedded-checkout-kyc-handling.md
@@ -1,0 +1,6 @@
+---
+"@crossmint/client-sdk-base": minor
+"@crossmint/client-sdk-react-ui": minor
+---
+
+Added `kycHandling` to embedded checkout. Setting it to `"external"` stops checkout from rendering the identity verification step, so a merchant can render `CrossmintIdentityVerification` in their own layout using `getIdentityVerificationCredentials(order)`.

--- a/.changeset/embedded-checkout-kyc-handling.md
+++ b/.changeset/embedded-checkout-kyc-handling.md
@@ -1,8 +1,0 @@
----
-"@crossmint/client-sdk-base": minor
-"@crossmint/client-sdk-react-ui": minor
----
-
-Added `kycHandling` to embedded checkout on web. Setting it to `"external"` stops checkout from rendering the identity verification step, so a merchant can render `CrossmintIdentityVerification` in their own layout using `getIdentityVerificationCredentials(order)`.
-
-Requires a Crossmint deployment that understands the flag. Against an older one it is ignored, and checkout renders the verification step alongside the merchant's, both against the same inquiry.

--- a/.changeset/window-transport-source-check.md
+++ b/.changeset/window-transport-source-check.md
@@ -1,0 +1,11 @@
+---
+"@crossmint/client-sdk-window": patch
+---
+
+`WindowTransport` now matches `event.source` against the peer window instead of trusting the origin alone.
+
+Each client subscribes to the global `message` event and accepted anything arriving from a matching origin. With one Crossmint iframe per page, no other frame could send from that origin, so the gap stayed invisible. Put two on a page and each client receives the other's events.
+
+Embedded checkout with `identityVerificationHandling="external"` puts two on the page. The verification iframe sends `ui:height.changed` at 660, the checkout iframe takes that height after collapsing to 0, and the merchant gets 660px of empty space above their widget. Reverse the order and checkout's 0 reaches the verification iframe and hides the Persona form.
+
+A message whose sending window has closed carries a null source. The transport drops it.

--- a/.changeset/window-transport-source-check.md
+++ b/.changeset/window-transport-source-check.md
@@ -1,5 +1,6 @@
 ---
 "@crossmint/client-sdk-window": patch
+"@crossmint/client-sdk-react-ui": patch
 ---
 
 `WindowTransport` now matches `event.source` against the peer window instead of trusting the origin alone.
@@ -9,3 +10,5 @@ Each client subscribes to the global `message` event and accepted anything arriv
 Embedded checkout with `identityVerificationHandling="external"` puts two on the page. The verification iframe sends `ui:height.changed` at 660, the checkout iframe takes that height after collapsing to 0, and the merchant gets 660px of empty space above their widget. Reverse the order and checkout's 0 reaches the verification iframe and hides the Persona form.
 
 A message whose sending window has closed carries a null source. The transport drops it.
+
+OAuth login moves its listeners onto the popup it opens. They used to sit on a `ChildWindow` built over `window.opener || window.parent`, which on a merchant's top-level page resolves to that page's own window, so the peer never matched the popup the callback arrives from. That client only ever listened, never sent, so the mismatch was invisible until the peer became part of the receive path. Attaching to the popup also unsubscribes correctly between attempts, where the previous `off(eventName)` calls passed an event name to an API that takes a listener id and silently did nothing.

--- a/packages/client/base/src/services/identity-verification/get-identity-verification-credentials.test.ts
+++ b/packages/client/base/src/services/identity-verification/get-identity-verification-credentials.test.ts
@@ -8,6 +8,8 @@ function order(preparation: unknown): Order {
 }
 
 describe("getIdentityVerificationCredentials", () => {
+    // environmentId is on the wire but off the type on purpose: the backend hardcodes it to null and
+    // PAY-11803 deletes it. The fixture keeps it to pin that the reader passes the object through as-is.
     test("returns the credentials an order carries for its verification step", () => {
         const credentials = { provider: "persona", inquiryId: "inq-1", sessionToken: "tok-1", environmentId: null };
 

--- a/packages/client/base/src/services/identity-verification/get-identity-verification-credentials.test.ts
+++ b/packages/client/base/src/services/identity-verification/get-identity-verification-credentials.test.ts
@@ -27,4 +27,9 @@ describe("getIdentityVerificationCredentials", () => {
     test("returns undefined for an order carrying no payment at all", () => {
         expect(getIdentityVerificationCredentials({ orderId: "order-1" } as Order)).toBeUndefined();
     });
+
+    // useCrossmintCheckout() hands back `order?: Order`, so the documented call site passes this.
+    test("returns undefined before the checkout hook has an order", () => {
+        expect(getIdentityVerificationCredentials(undefined)).toBeUndefined();
+    });
 });

--- a/packages/client/base/src/services/identity-verification/get-identity-verification-credentials.test.ts
+++ b/packages/client/base/src/services/identity-verification/get-identity-verification-credentials.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "vitest";
+
+import type { Order } from "@/lib/hosted-checkout/Order";
+import { getIdentityVerificationCredentials } from "./getIdentityVerificationCredentials";
+
+function order(preparation: unknown): Order {
+    return { orderId: "order-1", payment: { status: "requires-kyc", preparation } } as Order;
+}
+
+describe("getIdentityVerificationCredentials", () => {
+    test("returns the credentials an order carries for its verification step", () => {
+        const credentials = { provider: "persona", inquiryId: "inq-1", sessionToken: "tok-1", environmentId: null };
+
+        expect(getIdentityVerificationCredentials(order({ kyc: credentials }))).toEqual(credentials);
+    });
+
+    // A crypto order's preparation shape, which is what the type actually models today.
+    test("returns undefined when the preparation is not a verification one", () => {
+        expect(getIdentityVerificationCredentials(order({ chain: "base", payerAddress: "0x1" }))).toBeUndefined();
+    });
+
+    test("returns undefined before the order needs verification", () => {
+        expect(getIdentityVerificationCredentials(order(undefined))).toBeUndefined();
+    });
+
+    // Orders reach a merchant over postMessage, so a shape the type forbids still has to not throw.
+    test("returns undefined for an order carrying no payment at all", () => {
+        expect(getIdentityVerificationCredentials({ orderId: "order-1" } as Order)).toBeUndefined();
+    });
+});

--- a/packages/client/base/src/services/identity-verification/getIdentityVerificationCredentials.ts
+++ b/packages/client/base/src/services/identity-verification/getIdentityVerificationCredentials.ts
@@ -1,0 +1,15 @@
+import type { Order } from "@/lib/hosted-checkout/Order";
+import type { IdentityVerificationCredentials } from "@/types/identity-verification/CrossmintIdentityVerificationProps";
+
+/**
+ * Reads an order's verification credentials, for a merchant taking the step over with
+ * `kycHandling="external"`. Undefined until the order needs verification.
+ */
+export function getIdentityVerificationCredentials(order: Order): IdentityVerificationCredentials | undefined {
+    // Cast because this Order type mirrors the backend schema by hand and does not model the kyc
+    // preparation variant yet.
+    // Optional chained because an order reaches the merchant over postMessage, where the type is a
+    // promise rather than a guarantee.
+    const preparation = order.payment?.preparation as { kyc?: IdentityVerificationCredentials } | undefined;
+    return preparation?.kyc;
+}

--- a/packages/client/base/src/services/identity-verification/getIdentityVerificationCredentials.ts
+++ b/packages/client/base/src/services/identity-verification/getIdentityVerificationCredentials.ts
@@ -5,11 +5,11 @@ import type { IdentityVerificationCredentials } from "@/types/identity-verificat
  * Reads an order's verification credentials, for a merchant taking the step over with
  * `kycHandling="external"`. Undefined until the order needs verification.
  */
-export function getIdentityVerificationCredentials(order: Order): IdentityVerificationCredentials | undefined {
-    // Cast because this Order type mirrors the backend schema by hand and does not model the kyc
-    // preparation variant yet.
-    // Optional chained because an order reaches the merchant over postMessage, where the type is a
-    // promise rather than a guarantee.
-    const preparation = order.payment?.preparation as { kyc?: IdentityVerificationCredentials } | undefined;
+export function getIdentityVerificationCredentials(
+    order: Order | undefined
+): IdentityVerificationCredentials | undefined {
+    // Cast and chained: this Order type is a hand-kept mirror with no kyc preparation variant, and
+    // an order reaches the merchant over postMessage typed as `any`.
+    const preparation = order?.payment?.preparation as { kyc?: IdentityVerificationCredentials } | undefined;
     return preparation?.kyc;
 }

--- a/packages/client/base/src/services/identity-verification/getIdentityVerificationCredentials.ts
+++ b/packages/client/base/src/services/identity-verification/getIdentityVerificationCredentials.ts
@@ -3,7 +3,7 @@ import type { IdentityVerificationCredentials } from "@/types/identity-verificat
 
 /**
  * Reads an order's verification credentials, for a merchant taking the step over with
- * `kycHandling="external"`. Undefined until the order needs verification.
+ * `identityVerificationHandling="external"`. Undefined until the order needs verification.
  */
 export function getIdentityVerificationCredentials(
     order: Order | undefined

--- a/packages/client/base/src/services/identity-verification/index.ts
+++ b/packages/client/base/src/services/identity-verification/index.ts
@@ -1,1 +1,2 @@
+export * from "./getIdentityVerificationCredentials";
 export * from "./identityVerificationService";

--- a/packages/client/base/src/types/embed/v3/CrossmintEmbeddedCheckoutV3Props.ts
+++ b/packages/client/base/src/types/embed/v3/CrossmintEmbeddedCheckoutV3Props.ts
@@ -7,6 +7,12 @@ interface CrossmintEmbeddedCheckoutV3CommonProps {
     appearance?: EmbeddedCheckoutV3Appearance;
     payment: EmbeddedCheckoutV3Payment;
     jwt?: string;
+    /**
+     * Who renders the identity verification step. `"external"` stops checkout from rendering it, so
+     * you have to mount `CrossmintIdentityVerification` yourself with the credentials from
+     * `getIdentityVerificationCredentials(order)`, or the buyer cannot finish the order.
+     */
+    kycHandling?: "checkout" | "external";
 }
 
 export interface CrossmintEmbeddedCheckoutV3ExistingOrderProps extends CrossmintEmbeddedCheckoutV3CommonProps {

--- a/packages/client/base/src/types/embed/v3/CrossmintEmbeddedCheckoutV3Props.ts
+++ b/packages/client/base/src/types/embed/v3/CrossmintEmbeddedCheckoutV3Props.ts
@@ -34,7 +34,7 @@ export type CrossmintEmbeddedCheckoutV3Props =
 export type CrossmintEmbeddedCheckoutV3WebProps = CrossmintEmbeddedCheckoutV3Props & {
     /** `"external"`: you mount `CrossmintIdentityVerification` from
      * `getIdentityVerificationCredentials(order)`, or the buyer cannot finish. */
-    kycHandling?: "checkout" | "external";
+    identityVerificationHandling?: "external";
 };
 
 export type EmbeddedCheckoutV3Recipient = EmbeddedCheckoutV3EmailRecipient | EmbeddedCheckoutV3WalletAddressRecipient;

--- a/packages/client/base/src/types/embed/v3/CrossmintEmbeddedCheckoutV3Props.ts
+++ b/packages/client/base/src/types/embed/v3/CrossmintEmbeddedCheckoutV3Props.ts
@@ -7,12 +7,6 @@ interface CrossmintEmbeddedCheckoutV3CommonProps {
     appearance?: EmbeddedCheckoutV3Appearance;
     payment: EmbeddedCheckoutV3Payment;
     jwt?: string;
-    /**
-     * Who renders the identity verification step. `"external"` stops checkout from rendering it, so
-     * you have to mount `CrossmintIdentityVerification` yourself with the credentials from
-     * `getIdentityVerificationCredentials(order)`, or the buyer cannot finish the order.
-     */
-    kycHandling?: "checkout" | "external";
 }
 
 export interface CrossmintEmbeddedCheckoutV3ExistingOrderProps extends CrossmintEmbeddedCheckoutV3CommonProps {
@@ -34,6 +28,14 @@ export interface CrossmintEmbeddedCheckoutV3NewOrderProps extends CrossmintEmbed
 export type CrossmintEmbeddedCheckoutV3Props =
     | CrossmintEmbeddedCheckoutV3ExistingOrderProps
     | CrossmintEmbeddedCheckoutV3NewOrderProps;
+
+// Web only: taking over the verification step needs CrossmintIdentityVerification, which renders an
+// iframe. React Native has no equivalent yet, so the flag stays off the shared props.
+export type CrossmintEmbeddedCheckoutV3WebProps = CrossmintEmbeddedCheckoutV3Props & {
+    /** `"external"`: you mount `CrossmintIdentityVerification` from
+     * `getIdentityVerificationCredentials(order)`, or the buyer cannot finish. */
+    kycHandling?: "checkout" | "external";
+};
 
 export type EmbeddedCheckoutV3Recipient = EmbeddedCheckoutV3EmailRecipient | EmbeddedCheckoutV3WalletAddressRecipient;
 

--- a/packages/client/base/src/types/embed/v3/CrossmintEmbeddedCheckoutV3Props.ts
+++ b/packages/client/base/src/types/embed/v3/CrossmintEmbeddedCheckoutV3Props.ts
@@ -29,8 +29,8 @@ export type CrossmintEmbeddedCheckoutV3Props =
     | CrossmintEmbeddedCheckoutV3ExistingOrderProps
     | CrossmintEmbeddedCheckoutV3NewOrderProps;
 
-// Web only: taking over the verification step needs CrossmintIdentityVerification, which renders an
-// iframe. React Native has no equivalent yet, so the flag stays off the shared props.
+// Web only: the takeover needs CrossmintIdentityVerification, a DOM iframe with no react-native
+// counterpart. RN checkout keeps running the verification step itself.
 export type CrossmintEmbeddedCheckoutV3WebProps = CrossmintEmbeddedCheckoutV3Props & {
     /** `"external"`: you mount `CrossmintIdentityVerification` from
      * `getIdentityVerificationCredentials(order)`, or the buyer cannot finish. */

--- a/packages/client/base/src/types/embed/v3/CrossmintEmbeddedCheckoutV3Props.ts
+++ b/packages/client/base/src/types/embed/v3/CrossmintEmbeddedCheckoutV3Props.ts
@@ -29,8 +29,8 @@ export type CrossmintEmbeddedCheckoutV3Props =
     | CrossmintEmbeddedCheckoutV3ExistingOrderProps
     | CrossmintEmbeddedCheckoutV3NewOrderProps;
 
-// Web only: the takeover needs CrossmintIdentityVerification, a DOM iframe with no react-native
-// counterpart. RN checkout keeps running the verification step itself.
+// Web only: CrossmintIdentityVerification renders a DOM iframe and react-native has no WebView
+// version yet. RN checkout runs the verification step itself.
 export type CrossmintEmbeddedCheckoutV3WebProps = CrossmintEmbeddedCheckoutV3Props & {
     /** `"external"`: you mount `CrossmintIdentityVerification` from
      * `getIdentityVerificationCredentials(order)`, or the buyer cannot finish. */

--- a/packages/client/ui/react-ui/src/components/embed/v3/CrossmintEmbeddedCheckoutV3.tsx
+++ b/packages/client/ui/react-ui/src/components/embed/v3/CrossmintEmbeddedCheckoutV3.tsx
@@ -1,6 +1,6 @@
 import { EmbeddedCheckoutV3IFrame } from "./EmbeddedCheckoutV3IFrame";
-import type { CrossmintEmbeddedCheckoutV3Props } from "@crossmint/client-sdk-base";
+import type { CrossmintEmbeddedCheckoutV3WebProps } from "@crossmint/client-sdk-base";
 
-export function CrossmintEmbeddedCheckout(props: CrossmintEmbeddedCheckoutV3Props) {
+export function CrossmintEmbeddedCheckout(props: CrossmintEmbeddedCheckoutV3WebProps) {
     return <EmbeddedCheckoutV3IFrame {...props} />;
 }

--- a/packages/client/ui/react-ui/src/components/embed/v3/EmbeddedCheckoutV3IFrame.tsx
+++ b/packages/client/ui/react-ui/src/components/embed/v3/EmbeddedCheckoutV3IFrame.tsx
@@ -3,6 +3,7 @@ import { lazy, useEffect, useRef, useState } from "react";
 
 import {
     type CrossmintEmbeddedCheckoutV3Props,
+    type CrossmintEmbeddedCheckoutV3WebProps,
     type EmbeddedCheckoutV3IFrameEmitter,
     crossmintEmbeddedCheckoutV3Service,
 } from "@crossmint/client-sdk-base";
@@ -18,7 +19,7 @@ const CryptoWalletConnectionHandler = lazy(() =>
     }))
 );
 
-export function EmbeddedCheckoutV3IFrame(props: CrossmintEmbeddedCheckoutV3Props) {
+export function EmbeddedCheckoutV3IFrame(props: CrossmintEmbeddedCheckoutV3WebProps) {
     const [iframeClient, setIframeClient] = useState<EmbeddedCheckoutV3IFrameEmitter | null>(null);
     const [height, setHeight] = useState(0);
     const [eventEnableCrypto, setEventEnableCrypto] = useState(false);

--- a/packages/client/ui/react-ui/src/hooks/use-oauth-window-listener.test.ts
+++ b/packages/client/ui/react-ui/src/hooks/use-oauth-window-listener.test.ts
@@ -1,0 +1,57 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import type { OAuthProvider } from "@crossmint/common-sdk-auth";
+
+const handleRefreshAuthMaterial = vi.fn();
+
+vi.mock("@/hooks", () => ({
+    useCrossmintAuth: () => ({ crossmintAuth: { handleRefreshAuthMaterial } }),
+}));
+
+import { useOAuthWindowListener } from "./useOAuthWindowListener";
+
+const OAUTH_URL_MAP = { google: "https://www.crossmint.com/auth/oauth/google" } as Record<OAuthProvider, string>;
+
+function fakeWindow(): Window {
+    return { postMessage: vi.fn(), close: vi.fn(), closed: false, location: { href: "" } } as unknown as Window;
+}
+
+function deliverAuthMaterial(source: Window) {
+    const event = new MessageEvent("message", {
+        data: { event: "authMaterialFromPopupCallback", data: { oneTimeSecret: "one-time-secret" } },
+        origin: "https://www.crossmint.com",
+    });
+    // jsdom's MessageEvent only accepts a real WindowProxy as `source`, so install the stub directly.
+    Object.defineProperty(event, "source", { value: source });
+    window.dispatchEvent(event);
+}
+
+describe("useOAuthWindowListener", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+        handleRefreshAuthMaterial.mockClear();
+    });
+
+    describe("when another window on the page sends the callback", () => {
+        test("takes auth material only from the popup it opened", async () => {
+            const popup = fakeWindow();
+            vi.spyOn(window, "open").mockReturnValue(popup);
+
+            const { result } = renderHook(() => useOAuthWindowListener(OAUTH_URL_MAP, vi.fn()));
+            await act(async () => {
+                await result.current.createPopupAndSetupListeners("google" as OAuthProvider);
+            });
+
+            await act(async () => {
+                deliverAuthMaterial(fakeWindow());
+            });
+            expect(handleRefreshAuthMaterial).not.toHaveBeenCalled();
+
+            await act(async () => {
+                deliverAuthMaterial(popup);
+            });
+            expect(handleRefreshAuthMaterial).toHaveBeenCalledWith("one-time-secret");
+        });
+    });
+});

--- a/packages/client/ui/react-ui/src/hooks/useOAuthWindowListener.ts
+++ b/packages/client/ui/react-ui/src/hooks/useOAuthWindowListener.ts
@@ -1,6 +1,6 @@
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useState, useCallback } from "react";
 import type { OAuthProvider } from "@crossmint/common-sdk-auth";
-import { ChildWindow, PopupWindow } from "@crossmint/client-sdk-window";
+import { PopupWindow } from "@crossmint/client-sdk-window";
 import { useCrossmintAuth } from "@/hooks";
 import { z } from "zod";
 
@@ -10,27 +10,9 @@ export const useOAuthWindowListener = (oauthUrlMap: OAuthUrlMap, setError: (erro
     const { crossmintAuth } = useCrossmintAuth();
     // Track which OAuth provider's window is currently being interacted with
     const [activeOAuthProvider, setActiveOAuthProvider] = useState<OAuthProvider | null>(null);
-    const childRef = useRef<ChildWindow<IncomingEvents, OutgoingEvents> | null>(null);
-
-    useEffect(() => {
-        if (childRef.current == null) {
-            childRef.current = new ChildWindow<IncomingEvents, OutgoingEvents>(window.opener || window.parent, "*", {
-                incomingEvents,
-            });
-        }
-
-        return () => {
-            if (childRef.current != null) {
-                childRef.current.off("authMaterialFromPopupCallback");
-            }
-        };
-    }, []);
 
     const createPopupAndSetupListeners = useCallback(
         async (provider: OAuthProvider, providerLoginHint?: string) => {
-            if (childRef.current == null) {
-                throw new Error("Child window not initialized");
-            }
             setActiveOAuthProvider(provider);
             setError(null);
 
@@ -81,31 +63,42 @@ export const useOAuthWindowListener = (oauthUrlMap: OAuthUrlMap, setError: (erro
                 popup.window.location.href = baseUrl.toString();
             }
 
+            // Listen on the popup itself: it is the window that sends these events, and its
+            // transport drops anything from another sender.
+            let stopListening = () => {
+                // reassigned below, once there is something to unsubscribe
+            };
+
             const handleAuthMaterial = async (data: { oneTimeSecret: string }) => {
                 await crossmintAuth?.handleRefreshAuthMaterial(data.oneTimeSecret);
-                childRef.current?.off("authMaterialFromPopupCallback");
+                stopListening();
                 popup.window?.close();
                 setActiveOAuthProvider(null);
             };
 
             const handleError = (data: { error: string }) => {
                 setError(data.error);
-                childRef.current?.off("errorFromPopupCallback");
+                stopListening();
                 popup.window?.close();
                 setActiveOAuthProvider(null);
             };
 
-            childRef.current.on("authMaterialFromPopupCallback", handleAuthMaterial);
-            childRef.current.on("errorFromPopupCallback", handleError);
+            const authMaterialListenerId = popup.on("authMaterialFromPopupCallback", handleAuthMaterial);
+            const errorListenerId = popup.on("errorFromPopupCallback", handleError);
             // Add a check for manual window closure
             // Ideally we should find a more explicit way of doing this, but I think this is fine for now.
             const checkWindowClosure = setInterval(() => {
                 if (popup.window?.closed) {
-                    clearInterval(checkWindowClosure);
+                    stopListening();
                     setActiveOAuthProvider(null);
-                    childRef.current?.off("authMaterialFromPopupCallback");
                 }
             }, 2500); // Check every 2.5 seconds
+
+            stopListening = () => {
+                popup.off(authMaterialListenerId);
+                popup.off(errorListenerId);
+                clearInterval(checkWindowClosure);
+            };
         },
         [oauthUrlMap, crossmintAuth, setError]
     );

--- a/packages/client/ui/react-ui/src/index.ts
+++ b/packages/client/ui/react-ui/src/index.ts
@@ -10,6 +10,7 @@ export {
     type CrossmintEvent,
     type CrossmintEventMap,
     CrossmintEvents,
+    getIdentityVerificationCredentials,
 } from "@crossmint/client-sdk-base";
 
 export { CrossmintProvider, type CrossmintProviderProps } from "./providers/CrossmintProvider";

--- a/packages/client/window/package.json
+++ b/packages/client/window/package.json
@@ -16,7 +16,8 @@
     "files": ["dist", "LICENSE"],
     "scripts": {
         "build": "tsup",
-        "dev": "tsup --watch"
+        "dev": "tsup --watch",
+        "test:vitest": "vitest run"
     },
     "dependencies": {
         "zod": "3.22.4"

--- a/packages/client/window/src/transport/WindowTransport.ts
+++ b/packages/client/window/src/transport/WindowTransport.ts
@@ -23,13 +23,14 @@ export class WindowTransport<OutgoingEvents extends EventMap = EventMap> impleme
 
     addMessageListener(listener: (event: SimpleMessageEvent) => void): string {
         const wrapped = (event: MessageEvent) => {
-            const originMatches = this.isTargetOrigin(event.origin);
-            if (originMatches) {
-                listener({
-                    type: event.type,
-                    data: event.data,
-                } as SimpleMessageEvent);
+            // Origin does not identify a sender: two same-origin frames each receive the other's events.
+            if (!this.isTargetOrigin(event.origin) || event.source !== this.otherWindow) {
+                return;
             }
+            listener({
+                type: event.type,
+                data: event.data,
+            } as SimpleMessageEvent);
         };
 
         const id = generateRandomString();

--- a/packages/client/window/src/transport/window-transport.test.ts
+++ b/packages/client/window/src/transport/window-transport.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { WindowTransport } from "./WindowTransport";
+
+function peer(): Window {
+    return { postMessage: vi.fn() } as unknown as Window;
+}
+
+function deliver(source: Window | null, origin = "https://www.crossmint.com") {
+    const event = new MessageEvent("message", { data: { event: "ui:height.changed" }, origin });
+    // jsdom's MessageEvent only accepts a real WindowProxy as `source`, so install the stub directly.
+    Object.defineProperty(event, "source", { value: source });
+    window.dispatchEvent(event);
+}
+
+describe("WindowTransport", () => {
+    describe("when another frame on the page shares the target origin", () => {
+        test("delivers only what the peer window sent", () => {
+            const otherWindow = peer();
+            const received = vi.fn();
+            new WindowTransport(otherWindow, "https://www.crossmint.com").addMessageListener(received);
+
+            deliver(otherWindow);
+            deliver(peer());
+
+            expect(received).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    test("drops a message whose sending window is gone", () => {
+        const received = vi.fn();
+        new WindowTransport(peer(), "https://www.crossmint.com").addMessageListener(received);
+
+        deliver(null);
+
+        expect(received).not.toHaveBeenCalled();
+    });
+
+    test("still drops a foreign origin, peer or not", () => {
+        const otherWindow = peer();
+        const received = vi.fn();
+        new WindowTransport(otherWindow, "https://www.crossmint.com").addMessageListener(received);
+
+        deliver(otherWindow, "https://evil.example.com");
+
+        expect(received).not.toHaveBeenCalled();
+    });
+
+    test("removeMessageListener stops delivery", () => {
+        const otherWindow = peer();
+        const received = vi.fn();
+        const transport = new WindowTransport(otherWindow, "https://www.crossmint.com");
+        const id = transport.addMessageListener(received);
+
+        transport.removeMessageListener(id);
+        deliver(otherWindow);
+
+        expect(received).not.toHaveBeenCalled();
+    });
+});

--- a/packages/client/window/vitest.config.ts
+++ b/packages/client/window/vitest.config.ts
@@ -1,0 +1,12 @@
+import { resolve } from "path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    test: {
+        environment: "jsdom",
+        include: ["**/*.test.{ts,tsx}"],
+        exclude: ["node_modules"],
+        globals: true,
+        alias: [{ find: "@", replacement: resolve(__dirname, "./src") }],
+    },
+});


### PR DESCRIPTION
The SDK half of the merchant escape hatch for KYC, §4.5 of the Identity SDK PRD. ENG4-367.

The checkout page half is [Paella-Labs/crossbit-main#28380](https://github.com/Paella-Labs/crossbit-main/pull/28380), which has to reach production before this ships. Unknown query params are stripped, so a newer SDK against an older page loses the flag and both checkout and the merchant render a widget for the same inquiry.

## What this adds

**`identityVerificationHandling?: "external"`** on `CrossmintEmbeddedCheckoutV3WebProps`, which only the react-ui component takes. It rides to the checkout page as a query param through `appendObjectToQueryParams`, which appends strings bare, so the page receives `identityVerificationHandling=external` and its zod enum accepts it. It intersects the shared props type, so both the existing-order and new-order shapes keep it.

Web only, deliberately. It started on the props type react-native shares with web, which meant an RN merchant could set the flag, typecheck, reach the page, and have checkout suppress the step with nothing able to replace it: `CrossmintIdentityVerification` renders a DOM iframe, and RN's barrel exports neither it nor the credentials reader. The order would sit at `requires-kyc` behind a collapsed WebView with no message. RN now rejects the flag at compile time, and gets it back when there is an RN component to mount.

**`getIdentityVerificationCredentials(order)`**, taking `Order | undefined` and returning `IdentityVerificationCredentials | undefined`. It has to accept undefined: `useCrossmintCheckout()` returns `order?: Order`, so a narrower parameter would have forced every merchant into `order!`, discarding exactly the defensiveness the reader exists to provide. A merchant taking the step over reads the order from the hook and passes the result to `CrossmintIdentityVerification`:

```tsx
const { order } = useCrossmintCheckout();
const credentials = getIdentityVerificationCredentials(order);

<CrossmintEmbeddedCheckout orderId={orderId} identityVerificationHandling="external" payment={...} />
{credentials && <CrossmintIdentityVerification credentials={credentials} onComplete={...} />}
```

Re-exported from `@crossmint/client-sdk-react-ui` so merchants do not have to depend on `client-sdk-base` directly.

## Why one value and not two

The prop started as `kycHandling?: "checkout" | "external"`. Two things changed.

The name is now `identityVerificationHandling`, matching the vocabulary the rest of this surface already uses (`CrossmintIdentityVerification`, `getIdentityVerificationCredentials`). KYC is the provider's term for one step of identity verification, and it was the odd one out. This diverges from §4.5 of the PRD, which writes `kycHandling`.

The union is a single value. Nothing branches on the non-external value on the checkout page, where the only read is `=== "external"`. Widening an optional union later is backward compatible and free, so a second value buys nothing today and commits us to a name before the third mode's real semantics are known. If the in-house UI never ships, we never paid for it. `"embedded"` was the leading candidate and is actively misleading besides, since the merchant's replacement is an iframe too: ownership is the axis, not where it renders.

Consequence for the page: `identityVerificationHandling="embedded"` is now rejected rather than ignored, so it hits checkout's validation error screen like any unknown value. That is the existing loud-rejection behaviour, and it means a second mode has to reach production on the page before it can ship here.

## A transport fix rides along

Running this flow in a browser turned up a bug in `WindowTransport`, and the fix ships here because `identityVerificationHandling="external"` is what exposes it.

`addMessageListener` subscribes to the global `message` event and filtered on `event.origin` alone. One Crossmint iframe per page kept that harmless, since no other frame could send from that origin. This flag puts two on the page: the checkout iframe, and the `CrossmintIdentityVerification` iframe the merchant mounts. Both serve from the same origin, and `ui:height.changed` is the one event name their maps share, so each client received the other's heights.

The result contradicted what this PR and #28380 both claim. Checkout suppressed its step and reported `height: 0`, the verification iframe reported 660, and the checkout iframe took that, so the merchant got 660px of blank space where the box should have collapsed. The failure flips with message order: checkout's 0 arriving last sets the merchant's Persona form to 0, and the buyer cannot verify at all. An early harness run recorded that version.

Captured in the parent with a listener that tags each message with its sending frame:

```
height= 146  from=crossmint-embedded-checkout.iframe
height=   0  from=crossmint-embedded-checkout.iframe      <- checkout collapses
height= 660  from=crossmint-identity-verification.iframe  <- and this overwrites it
```

`WindowTransport` now compares `event.source` to the peer window it already holds for sending. `SignersWindowTransport` does this today. `IFrameWindow`, `PopupWindow` and `NewTabWindow` construct the transport with the window they talk to, so the check holds for them. A message whose sending window has closed carries a null source and drops.

Worth a reviewer's attention: this narrows a trust boundary that has been loose since the transport was written, and it affects every product using these iframes, not only checkout.

## The one caller that pointed at the wrong window

`useOAuthWindowListener` built a `ChildWindow` over `window.opener || window.parent`. On a merchant's top-level page `window.opener` is null and `window.parent` is that same page, so the peer was the page's own window, while `authMaterialFromPopupCallback` arrives from the OAuth popup. Those cannot match, and social login would have hung with the popup open.

That client only listened, never sent, and its `targetOrigin` was `"*"`, so nothing read the peer until this change put it on the receive path. Callers passing `"*"` filtered nothing at all before, which is the second gap this closes: any frame on the merchant's page could post an `authMaterialFromPopupCallback` carrying a secret it chose, and the page handed it to `handleRefreshAuthMaterial`.

Both listeners now attach to the popup the same function opens, which is the window that sends them. That also clears a leak older than this PR: `off("authMaterialFromPopupCallback")` passes an event name to an API that takes a listener id, so each login attempt stacked another live handler that was never removed.

The changeset bumps `client-sdk-react-ui` for this half.

## Why a reader instead of typing the Order

`packages/client/base/src/lib/hosted-checkout/Order.ts` says at the top that it is kept in sync with `@crossmint/products-payments-headless-checkout` by hand, and it has drifted: the backend models the kyc preparation variant, this mirror has no `kyc` key anywhere in `preparation`. Editing a union inside 5000 lines of declared types is a bigger change than this feature and is not KYC-specific, so the reader holds the one cast inside the SDK instead of leaving it in every integration. Typing the mirror properly is filed separately, and it will simplify the reader's body without touching its signature.

The reader also optional-chains `order.payment`, because an order reaches the merchant over postMessage where `order` is typed `z.any()` on both ends. A shape the type forbids should return undefined rather than throw in the merchant's app.

## Test plan

- `get-identity-verification-credentials.test.ts`, new, 5 cases: returns the credentials, and returns undefined for a non-verification preparation, for no preparation, for an order with no payment at all, and for no order yet. All pass.
- `window-transport.test.ts`, new, 4 cases: a same-origin non-peer frame gets dropped, a null source gets dropped, a foreign origin still gets dropped, and `removeMessageListener` unsubscribes. Take the source check back out and the first two fail. This package had no tests before, so it also gains a `test:vitest` script and a `vitest.config.ts` copied from `client-sdk-base`.
- `use-oauth-window-listener.test.ts`, new, 1 case: a callback from a stranger window is ignored, the same callback from the popup reaches `handleRefreshAuthMaterial`. Restore the old `ChildWindow` and it fails with zero calls.
- `pnpm turbo build` on `client-sdk-base`, `client-sdk-react-ui` and `client-sdk-react-native-ui` passes, which is what typechecks this repo. In the built output I checked the three things that matter: base's declarations export `getIdentityVerificationCredentials` and `CrossmintEmbeddedCheckoutV3WebProps` carrying `identityVerificationHandling?: "external"`, react-ui's two embed components declare the web props type, and react-native's `dist/index.d.ts` contains no mention of the flag.
- `pnpm lint` is clean on the touched files. The three warnings biome reports on the props file are pre-existing `Record<string, any>` line items.

Run in a browser, against `~/dev/kyc-e2e-harness` §F: the quickstart on :3006 with `identityVerificationHandling="external"`, crossbit-main #28380 on :3000, driven by Playwright. Checkout's iframe measures 0 and its body is empty, the merchant's slot mounts a real Persona sandbox form at 660 as a sibling rather than a nested frame, `kyc:ready` fires, checkout polls `GET /orders` on its 3s cadence, and the verification iframe's `src` stays byte-identical across those ticks so the fresh-per-poll credentials object does not remount Persona.

Every other consumer of the transport was driven in a browser against the same local stack. Embedded checkout with the flag off reaches 660px with no identity iframe on the page. Payment method management in `apps/payments/nextjs` receives `ui:height.changed` at 214, 334 and 392, each with `event.source === iframe.contentWindow`. OAuth login ran twice in one page load: the second popup closed itself and one callback reached the page. An abandoned popup left no session and re-armed the button, which only the `checkWindowClosure` interval can do, and that block calls `stopListening()`.

Reloading an iframe in place kept `contentWindow` identical and the client kept receiving, so navigating an iframe does not mint a new peer. Re-parenting the element would, and nothing here re-parents.

Three consumers need no run. Hosted checkout popup and new tab register no listener: `PopupWindow.initSync` and `NewTabWindow.initSync` get no `incomingEvents`, and the overlay polls `windowClient.window.closed`. React Native uses `RNWebViewTransport`, a separate class. The signer iframes compare `event.source` today through `SignersWindowTransport`.

`getUrl()` on the built dist emits `?identityVerificationHandling=external`, omits the param when the prop is unset, and never emits the old `kycHandling` name. The receiving end has a schema test in #28380 that parses a bare `identityVerificationHandling=external`, plus a browser check that the page rejects any other value with its validation screen.

Not in this PR: docs for the takeover flow, and react-native support, which needs an identity verification component that is not an iframe before the flag can mean anything there.

The changeset states the deploy-order requirement too, since the changelog is where a merchant reads it rather than this description.

