### PR TITLE
feat(window)!: brand ListenerId so off() cannot take an event name

### DIFF
--- a/.changeset/listener-id-brand.md
+++ b/.changeset/listener-id-brand.md
@@ -8,4 +8,6 @@
 
 `Transport.addMessageListener()` / `removeMessageListener()` are branded the same way, so the ids are branded where they are minted and the publicly exported transports (`SignersWindowTransport`, `RNWebViewTransport`) no longer accept an event name either.
 
-This is breaking for every package that re-exposes an emitter's `off()`: `@crossmint/client-sdk-base` (`PaymentMethodManagementIFrameEmitter`, `EmbeddedCheckoutV3IFrameEmitter`, `IdentityVerificationIFrameEmitter`) and `@crossmint/client-sdk-rn-window` (`WebViewParent`).
+`Transport` is a public interface, so anyone implementing it now needs a way to produce a branded id without an unsafe cast. `mintListenerId()` is exported for that, and it is the only place in the codebase that casts.
+
+This is breaking for every package that re-exposes an emitter's `off()`: `@crossmint/client-sdk-base` (`PaymentMethodManagementIFrameEmitter`, `EmbeddedCheckoutV3IFrameEmitter`, `IdentityVerificationIFrameEmitter`) and `@crossmint/client-sdk-rn-window` (`WebViewParent`). Both now re-export the `ListenerId` type, so consumers migrating a `string`-typed variable can name it without adding a direct dependency on `@crossmint/client-sdk-window`.

--- a/.changeset/listener-id-brand.md
+++ b/.changeset/listener-id-brand.md
@@ -1,0 +1,11 @@
+---
+"@crossmint/client-sdk-window": major
+"@crossmint/client-sdk-rn-window": major
+"@crossmint/client-sdk-base": major
+---
+
+`EventEmitter.on()` now returns a branded `ListenerId` instead of a plain `string`, and `off()` only accepts one. Passing an event name to `off()` was a silent no-op that leaked the listener, and it type-checked because both are strings. It is now a compile error, so anyone holding an id in a `string`-typed variable has to switch to the exported `ListenerId`.
+
+`Transport.addMessageListener()` / `removeMessageListener()` are branded the same way, so the ids are branded where they are minted and the publicly exported transports (`SignersWindowTransport`, `RNWebViewTransport`) no longer accept an event name either.
+
+This is breaking for every package that re-exposes an emitter's `off()`: `@crossmint/client-sdk-base` (`PaymentMethodManagementIFrameEmitter`, `EmbeddedCheckoutV3IFrameEmitter`, `IdentityVerificationIFrameEmitter`) and `@crossmint/client-sdk-rn-window` (`WebViewParent`).

--- a/packages/client/base/src/index.ts
+++ b/packages/client/base/src/index.ts
@@ -5,3 +5,7 @@ export * from "./types";
 export * from "./services";
 export * from "./consts";
 export * from "./error";
+
+// Re-exported so consumers can name the ids the iframe emitters' `on()` hands back without
+// taking a direct dependency on @crossmint/client-sdk-window.
+export type { ListenerId } from "@crossmint/client-sdk-window";

--- a/packages/client/rn-window/src/index.ts
+++ b/packages/client/rn-window/src/index.ts
@@ -1,1 +1,5 @@
 export * from "./rn-webview";
+
+// Re-exported so consumers can name the ids `WebViewParent.on()` hands back without
+// taking a direct dependency on @crossmint/client-sdk-window.
+export type { ListenerId } from "@crossmint/client-sdk-window";

--- a/packages/client/rn-window/src/transport/RNWebViewTransport.ts
+++ b/packages/client/rn-window/src/transport/RNWebViewTransport.ts
@@ -2,7 +2,7 @@ import "../polyfills";
 import type { z } from "zod";
 import type { WebViewMessageEvent, WebView } from "react-native-webview";
 import type { EventMap, ListenerId, SimpleMessageEvent, Transport } from "@crossmint/client-sdk-window";
-import { generateRandomString } from "@crossmint/client-sdk-window";
+import { mintListenerId } from "@crossmint/client-sdk-window";
 import type { RefObject } from "react";
 
 export class RNWebViewTransport<OutgoingEvents extends EventMap = EventMap> implements Transport<OutgoingEvents> {
@@ -64,7 +64,7 @@ export class RNWebViewTransport<OutgoingEvents extends EventMap = EventMap> impl
     }
 
     addMessageListener(listener: (event: SimpleMessageEvent) => void): ListenerId {
-        const id = generateRandomString() as ListenerId;
+        const id = mintListenerId();
         this.listeners.set(id, listener);
 
         if (this.isWebView && !this.globalListenerAttached) {

--- a/packages/client/rn-window/src/transport/RNWebViewTransport.ts
+++ b/packages/client/rn-window/src/transport/RNWebViewTransport.ts
@@ -1,12 +1,12 @@
 import "../polyfills";
 import type { z } from "zod";
 import type { WebViewMessageEvent, WebView } from "react-native-webview";
-import type { EventMap, SimpleMessageEvent, Transport } from "@crossmint/client-sdk-window";
+import type { EventMap, ListenerId, SimpleMessageEvent, Transport } from "@crossmint/client-sdk-window";
 import { generateRandomString } from "@crossmint/client-sdk-window";
 import type { RefObject } from "react";
 
 export class RNWebViewTransport<OutgoingEvents extends EventMap = EventMap> implements Transport<OutgoingEvents> {
-    private listeners = new Map<string, (event: SimpleMessageEvent) => void>();
+    private listeners = new Map<ListenerId, (event: SimpleMessageEvent) => void>();
     private isWebView: boolean;
     private globalListenerAttached = false;
 
@@ -63,8 +63,8 @@ export class RNWebViewTransport<OutgoingEvents extends EventMap = EventMap> impl
         }
     }
 
-    addMessageListener(listener: (event: SimpleMessageEvent) => void): string {
-        const id = generateRandomString();
+    addMessageListener(listener: (event: SimpleMessageEvent) => void): ListenerId {
+        const id = generateRandomString() as ListenerId;
         this.listeners.set(id, listener);
 
         if (this.isWebView && !this.globalListenerAttached) {
@@ -75,7 +75,7 @@ export class RNWebViewTransport<OutgoingEvents extends EventMap = EventMap> impl
         return id;
     }
 
-    removeMessageListener(id: string): void {
+    removeMessageListener(id: ListenerId): void {
         const listener = this.listeners.get(id);
         if (listener != null) {
             this.listeners.delete(id);

--- a/packages/client/window/src/EventEmitter.ts
+++ b/packages/client/window/src/EventEmitter.ts
@@ -1,9 +1,15 @@
 import type { z } from "zod";
 import type { SimpleMessageEvent, Transport } from "./transport/Transport";
+import { generateRandomString } from "./utils/generateRandomString";
 
 export type EventMap = Record<string, z.ZodTypeAny>;
 
 export type ListenerId = string & { readonly __listenerId: true };
+
+/** The only sanctioned way to make a `ListenerId`, so the unsafe cast lives in one place. */
+export function mintListenerId(): ListenerId {
+    return generateRandomString() as ListenerId;
+}
 
 export interface EventEmitterOptions<
     IncomingEvents extends EventMap = EventMap,

--- a/packages/client/window/src/EventEmitter.ts
+++ b/packages/client/window/src/EventEmitter.ts
@@ -3,6 +3,8 @@ import type { SimpleMessageEvent, Transport } from "./transport/Transport";
 
 export type EventMap = Record<string, z.ZodTypeAny>;
 
+export type ListenerId = string & { readonly __listenerId: true };
+
 export interface EventEmitterOptions<
     IncomingEvents extends EventMap = EventMap,
     OutgoingEvents extends EventMap = EventMap,
@@ -71,7 +73,7 @@ export class EventEmitter<IncomingEvents extends EventMap, OutgoingEvents extend
         }
     }
 
-    on<K extends keyof IncomingEvents>(event: K, callback: (data: z.infer<IncomingEvents[K]>) => void): string {
+    on<K extends keyof IncomingEvents>(event: K, callback: (data: z.infer<IncomingEvents[K]>) => void): ListenerId {
         const listener = (message: SimpleMessageEvent) => {
             if (message.data.event === event) {
                 const data = this.incomingEvents[event].safeParse(message.data.data);
@@ -197,7 +199,14 @@ export class EventEmitter<IncomingEvents extends EventMap, OutgoingEvents extend
         });
     }
 
-    off(id: string) {
+    off(id: ListenerId) {
         this.transport.removeMessageListener(id);
     }
 }
+
+type AssertTrue<T extends true> = T;
+// The whole point of the major bump is that a plain string is no longer a listener id. Widening
+// `off()` back, or dropping the brand from `on()`, resolves these to `false` and fails the build.
+type _OffRejectsPlainStrings = AssertTrue<string extends Parameters<AnyEventEmitter["off"]>[0] ? false : true>;
+type _OnReturnsBrandedIds = AssertTrue<string extends ReturnType<AnyEventEmitter["on"]> ? false : true>;
+type AnyEventEmitter = EventEmitter<EventMap, EventMap>;

--- a/packages/client/window/src/index.ts
+++ b/packages/client/window/src/index.ts
@@ -1,6 +1,6 @@
 export * from "./windows";
 export * from "./handshake";
 export type { Transport, SimpleMessageEvent } from "./transport/Transport";
-export type { EventMap, SendActionArgs } from "./EventEmitter";
+export type { EventMap, ListenerId, SendActionArgs } from "./EventEmitter";
 export { generateRandomString } from "./utils/generateRandomString";
 export { SignersWindowTransport } from "./transport/SignersWindowTransport";

--- a/packages/client/window/src/index.ts
+++ b/packages/client/window/src/index.ts
@@ -2,5 +2,6 @@ export * from "./windows";
 export * from "./handshake";
 export type { Transport, SimpleMessageEvent } from "./transport/Transport";
 export type { EventMap, ListenerId, SendActionArgs } from "./EventEmitter";
+export { mintListenerId } from "./EventEmitter";
 export { generateRandomString } from "./utils/generateRandomString";
 export { SignersWindowTransport } from "./transport/SignersWindowTransport";

--- a/packages/client/window/src/transport/SignersWindowTransport.ts
+++ b/packages/client/window/src/transport/SignersWindowTransport.ts
@@ -1,9 +1,10 @@
+import type { ListenerId } from "../EventEmitter";
 import type { SimpleMessageEvent } from "./Transport";
 import { generateRandomString } from "../utils/generateRandomString";
 import { WindowTransport } from "./WindowTransport";
 
 export class SignersWindowTransport extends WindowTransport {
-    addMessageListener(listener: (event: SimpleMessageEvent) => void): string {
+    addMessageListener(listener: (event: SimpleMessageEvent) => void): ListenerId {
         const wrapped = (event: MessageEvent) => {
             const sameSource = event.source === this.otherWindow;
             const originMatches = this.isTargetOrigin(event.origin);
@@ -15,7 +16,7 @@ export class SignersWindowTransport extends WindowTransport {
             }
         };
 
-        const id = generateRandomString();
+        const id = generateRandomString() as ListenerId;
         window.addEventListener("message", wrapped);
         this.listeners.set(id, wrapped);
         return id;

--- a/packages/client/window/src/transport/SignersWindowTransport.ts
+++ b/packages/client/window/src/transport/SignersWindowTransport.ts
@@ -1,6 +1,5 @@
-import type { ListenerId } from "../EventEmitter";
+import { type ListenerId, mintListenerId } from "../EventEmitter";
 import type { SimpleMessageEvent } from "./Transport";
-import { generateRandomString } from "../utils/generateRandomString";
 import { WindowTransport } from "./WindowTransport";
 
 export class SignersWindowTransport extends WindowTransport {
@@ -16,7 +15,7 @@ export class SignersWindowTransport extends WindowTransport {
             }
         };
 
-        const id = generateRandomString() as ListenerId;
+        const id = mintListenerId();
         window.addEventListener("message", wrapped);
         this.listeners.set(id, wrapped);
         return id;

--- a/packages/client/window/src/transport/Transport.ts
+++ b/packages/client/window/src/transport/Transport.ts
@@ -1,5 +1,5 @@
 import type { z } from "zod";
-import type { EventMap } from "../EventEmitter";
+import type { EventMap, ListenerId } from "../EventEmitter";
 
 export type SimpleMessageEvent = {
     type: string;
@@ -11,6 +11,6 @@ export type SimpleMessageEvent = {
 
 export interface Transport<OutgoingEvents extends EventMap = EventMap> {
     send<K extends keyof OutgoingEvents>(message: { event: K; data: z.infer<OutgoingEvents[K]> }): void;
-    addMessageListener(listener: (event: SimpleMessageEvent | MessageEvent) => void): string;
-    removeMessageListener(id: string): void;
+    addMessageListener(listener: (event: SimpleMessageEvent | MessageEvent) => void): ListenerId;
+    removeMessageListener(id: ListenerId): void;
 }

--- a/packages/client/window/src/transport/WindowTransport.ts
+++ b/packages/client/window/src/transport/WindowTransport.ts
@@ -1,10 +1,10 @@
 import type { z } from "zod";
-import type { EventMap } from "../EventEmitter";
+import type { EventMap, ListenerId } from "../EventEmitter";
 import type { Transport, SimpleMessageEvent } from "./Transport";
 import { generateRandomString } from "../utils/generateRandomString";
 
 export class WindowTransport<OutgoingEvents extends EventMap = EventMap> implements Transport<OutgoingEvents> {
-    protected listeners = new Map<string, (event: MessageEvent) => void>();
+    protected listeners = new Map<ListenerId, (event: MessageEvent) => void>();
 
     constructor(
         protected otherWindow: Window,
@@ -21,7 +21,7 @@ export class WindowTransport<OutgoingEvents extends EventMap = EventMap> impleme
         }
     }
 
-    addMessageListener(listener: (event: SimpleMessageEvent) => void): string {
+    addMessageListener(listener: (event: SimpleMessageEvent) => void): ListenerId {
         const wrapped = (event: MessageEvent) => {
             const originMatches = this.isTargetOrigin(event.origin);
             if (originMatches) {
@@ -32,13 +32,13 @@ export class WindowTransport<OutgoingEvents extends EventMap = EventMap> impleme
             }
         };
 
-        const id = generateRandomString();
+        const id = generateRandomString() as ListenerId;
         window.addEventListener("message", wrapped);
         this.listeners.set(id, wrapped);
         return id;
     }
 
-    removeMessageListener(id: string): void {
+    removeMessageListener(id: ListenerId): void {
         const listener = this.listeners.get(id);
         if (listener != null) {
             window.removeEventListener("message", listener);

--- a/packages/client/window/src/transport/WindowTransport.ts
+++ b/packages/client/window/src/transport/WindowTransport.ts
@@ -1,7 +1,6 @@
 import type { z } from "zod";
-import type { EventMap, ListenerId } from "../EventEmitter";
+import { type EventMap, type ListenerId, mintListenerId } from "../EventEmitter";
 import type { Transport, SimpleMessageEvent } from "./Transport";
-import { generateRandomString } from "../utils/generateRandomString";
 
 export class WindowTransport<OutgoingEvents extends EventMap = EventMap> implements Transport<OutgoingEvents> {
     protected listeners = new Map<ListenerId, (event: MessageEvent) => void>();
@@ -32,7 +31,7 @@ export class WindowTransport<OutgoingEvents extends EventMap = EventMap> impleme
             }
         };
 
-        const id = generateRandomString() as ListenerId;
+        const id = mintListenerId();
         window.addEventListener("message", wrapped);
         this.listeners.set(id, wrapped);
         return id;


### PR DESCRIPTION
Now the type change only: **zero call-site edits**. Last in the stack, behind #2014 and #2015.

Correcting my earlier claim on this PR that the migration was "atomic by construction" — that was wrong. It is only atomic if the brand lands *first*. Land it last and each leak fix ships independently as a patch, which is what #2014 and #2015 now do.

## The bug

`on()` returns a listener id, `off()` takes one, and both were `string`:

```ts
on(event: K, callback: ...): string
off(id: string)
```

So `off("ui:height.changed")` type-checked, looked up an event name in a map keyed by 13-char random ids, and silently removed nothing. Four call sites did exactly that. `ListenerId` is now branded and `off()` only accepts one, so the mistake is a compile error.

## Why this ships last

The leaks are already in prod, so there is no reason to hold the fixes behind a breaking change. This PR is a **major for three packages**, which is a release-coordination event; #2014 and #2015 are patches that can ship on the next normal release.

By the time this lands every in-repo call site already passes a real id, so **this commit touches no call sites**. Verified: with #2014 and #2015 in the base, `pnpm build:libs` is 16/16 green with no component or hook changes in this diff.

## Branding at the mint point

The brand sits on `Transport.addMessageListener()` / `removeMessageListener()`, not only on `EventEmitter`, so ids are branded where they are created instead of laundered with `as ListenerId` inside `on()`. That also closes a hole: `SignersWindowTransport` and `RNWebViewTransport` are publicly exported, so a consumer calling `removeMessageListener(eventName)` directly still got the silent no-op this whole line of work is named after.

## Breaking scope

`client-sdk-base` (`PaymentMethodManagementIFrameEmitter`, `EmbeddedCheckoutV3IFrameEmitter`, `IdentityVerificationIFrameEmitter`) and `client-sdk-rn-window` (`WebViewParent`) re-expose the narrowed `off()` through their public types, so they are majors too. Left implicit they would have taken an automatic patch and broken consumer builds with no semver signal.

Migration for consumers: anything holding an id in a `string`-typed variable switches to the exported `ListenerId`.

## Verification

The guarantee is compile-time, so the check is too. Two lines in `EventEmitter.ts`:

```ts
type _OffRejectsPlainStrings = AssertTrue<string extends Parameters<AnyEventEmitter["off"]>[0] ? false : true>;
type _OnReturnsBrandedIds    = AssertTrue<string extends ReturnType<AnyEventEmitter["on"]> ? false : true>;
```

Mutation-tested, each fails the dts build:

- `off(id: string)` -> `TS2344: Type 'false' does not satisfy the constraint 'true'`
- `type ListenerId = string` -> same, on both lines

`pnpm build:libs` 16/16, `pnpm test:vitest` 11/11 packages, `pnpm lint` clean.