### PR TITLE
fix(identity): drop microphone from the verification iframe allow list

### DIFF
--- a/.changeset/identity-verification-microphone.md
+++ b/.changeset/identity-verification-microphone.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+---
+
+`CrossmintIdentityVerification` now grants its iframe `allow="camera"` rather than `allow="microphone; camera"`. Persona's document and selfie capture needs the camera, and no verification template records audio.

--- a/packages/client/ui/react-ui/src/components/identity-verification/CrossmintIdentityVerificationIFrame.tsx
+++ b/packages/client/ui/react-ui/src/components/identity-verification/CrossmintIdentityVerificationIFrame.tsx
@@ -58,7 +58,7 @@ export function CrossmintIdentityVerificationIFrame(props: CrossmintIdentityVeri
             src={identityVerificationService.iframe.getUrl(props)}
             id="crossmint-identity-verification.iframe"
             title="Identity verification"
-            allow="microphone; camera"
+            allow="camera"
             style={{
                 border: "none",
                 width: "100%",

--- a/packages/client/ui/react-ui/src/components/identity-verification/crossmint-identity-verification.test.tsx
+++ b/packages/client/ui/react-ui/src/components/identity-verification/crossmint-identity-verification.test.tsx
@@ -59,10 +59,10 @@ describe("<CrossmintIdentityVerification />", () => {
             expect(iframe.getAttribute("src")).toContain("/sdk/unstable/kyc-verification");
         });
 
-        test("allows camera access, which Persona's document capture needs", () => {
+        test("allows camera access only, which is all Persona's document capture needs", () => {
             render(<CrossmintIdentityVerification credentials={CREDENTIALS} />);
 
-            expect(screen.getByTitle("Identity verification").getAttribute("allow")).toContain("camera");
+            expect(screen.getByTitle("Identity verification").getAttribute("allow")).toBe("camera");
         });
     });
 


### PR DESCRIPTION
Closes ENG4-361.

`CrossmintIdentityVerificationIFrame` granted `allow="microphone; camera"`. It now grants `allow="camera"`.

## Why

Persona's document and selfie capture needs the camera. Nothing in that frame records audio: the templates crossbit-main wires up are `document-selfie` (`libraries/products/payments/kyc/src/db/DocumentSelfieDB.json`, `DocumentSelfieCrossmintThemedDB.json`) and the global onramp template, and all of them capture images.

The grant looked load-bearing because `persona@4.11.0` hardcodes `allow="camera;microphone"` on the widget iframe it injects, whatever the template asks for. Persona ships that attribute on every inquiry. Dropping the outer grant leaves the inner request unsatisfied, which is what we want.

Microphone arrived here for parity with `EmbeddedCheckoutV3IFrame` and `CrossmintPaymentMethodManagementIFrame`, which both grant `payment *; microphone; camera`. #2003 describes this iframe as `allow="camera"` in its own commit message, so the attribute that shipped disagreed with the change that introduced it.

## Camera still reaches Persona

The camera crosses three frames: this iframe, then the Crossmint-hosted `/sdk/unstable/kyc-verification` page, then Persona's iframe on withpersona.com. `allow="camera"` enables camera in the hosted page, whose origin is the `'src'` the default allowlist resolves to, and that page delegates onward through the allow attribute Persona sets on its own iframe.

Measured rather than assumed. A three-origin frame chain in Chrome, mirroring the production markup, reports `document.permissionsPolicy.allowsFeature('camera')` at the leaf as true under both the old attribute and the new one. Microphone at the leaf goes true to false, which is the whole change. Nothing server-side interferes either: crossbit-main sets no `Permissions-Policy` header anywhere, so this attribute is the only governor (`apps/crossmint-nextjs/next.config.js:669-702`).

## Risk

Persona's bundle carries the event names `selfie-camera-capture` and `selfie-record-upload`, so their widget supports a recorded-selfie step even though no repo here enables one. Which steps run on those three templates lives in the Persona dashboard, and no key on disk can query it, so source alone cannot close that gap. If such a step were ever turned on and Persona asked for `{video: true, audio: true}`, the call rejects with `NotAllowedError` and takes the video capture down with it.

Two ways to close it before release: `GET /api/v1/inquiry-templates/<id>` with `PERSONA_API_KEY` for each of the three templates, or one framed pass through `kyc-e2e-harness/`. Putting one word back is the fix either way.

## Test

The `allow` assertion moves from `toContain("camera")` to `toBe("camera")`, which pins the whole attribute rather than one entry. `toContain` passed before and after the change, so it could never have caught this. Restoring the old value fails the new one: `expected 'microphone; camera' to be 'camera'`.

## Out of scope

`EmbeddedCheckoutV3IFrame.tsx:86` and `CrossmintPaymentMethodManagementIFrame.tsx:50` still grant microphone. `EmbeddedCheckoutPerformKYC.tsx:99` renders the same `KycVerification` inline behind the first of them, so the two paths to Persona now disagree about audio. Those frames have shipped, so they get their own ticket rather than riding along here.
