### PR TITLE
identity: point the verification iframe at the identity-verification route

### DIFF
--- a/packages/client/base/src/services/identity-verification/identity-verification-service.test.ts
+++ b/packages/client/base/src/services/identity-verification/identity-verification-service.test.ts
@@ -17,10 +17,10 @@ function iframeUrl(props: Record<string, unknown>) {
 
 describe("createIdentityVerificationService", () => {
     describe("iframe.getUrl", () => {
-        test("points at the standalone kyc-verification route", () => {
+        test("points at the standalone identity-verification route", () => {
             const url = iframeUrl({ credentials: { provider: "persona", inquiryId: "inq-1" } });
 
-            expect(url.pathname).toBe("/sdk/unstable/kyc-verification");
+            expect(url.pathname).toBe("/sdk/unstable/identity-verification");
         });
 
         test("serializes credentials as JSON, the way the route's parser reads them", () => {

--- a/packages/client/base/src/services/identity-verification/identityVerificationService.ts
+++ b/packages/client/base/src/services/identity-verification/identityVerificationService.ts
@@ -13,7 +13,7 @@ export type IdentityVerificationServiceProps = {
 
 export function createIdentityVerificationService({ apiClient }: IdentityVerificationServiceProps) {
     function getIFrameUrl(props: CrossmintIdentityVerificationProps) {
-        const urlWithPath = apiClient.buildUrl("/sdk/unstable/kyc-verification");
+        const urlWithPath = apiClient.buildUrl("/sdk/unstable/identity-verification");
         const queryParams = new URLSearchParams();
 
         // appendObjectToQueryParams drops function values, so the lifecycle

--- a/packages/client/ui/react-ui/src/components/identity-verification/crossmint-identity-verification.test.tsx
+++ b/packages/client/ui/react-ui/src/components/identity-verification/crossmint-identity-verification.test.tsx
@@ -20,7 +20,7 @@ const iframeClient = {
 vi.mock("@crossmint/client-sdk-base", () => ({
     createIdentityVerificationService: () => ({
         iframe: {
-            getUrl: () => "https://staging.crossmint.com/sdk/unstable/kyc-verification?credentials=%7B%7D",
+            getUrl: () => "https://staging.crossmint.com/sdk/unstable/identity-verification?credentials=%7B%7D",
             createClient: () => iframeClient,
         },
     }),
@@ -52,11 +52,11 @@ describe("<CrossmintIdentityVerification />", () => {
     });
 
     describe("when mounted", () => {
-        test("renders an iframe pointed at the kyc-verification route", () => {
+        test("renders an iframe pointed at the identity-verification route", () => {
             render(<CrossmintIdentityVerification credentials={CREDENTIALS} />);
 
             const iframe = screen.getByTitle("Identity verification");
-            expect(iframe.getAttribute("src")).toContain("/sdk/unstable/kyc-verification");
+            expect(iframe.getAttribute("src")).toContain("/sdk/unstable/identity-verification");
         });
 
         test("allows camera access, which Persona's document capture needs", () => {


### PR DESCRIPTION
Part of ENG4-337. Pairs with the backend rename in Paella-Labs/crossbit-main.

`CrossmintIdentityVerification` frames a Crossmint-hosted route. That route is moving from `/sdk/unstable/kyc-verification` to `/sdk/unstable/identity-verification`, so the SDK's copy of the path moves with it. The two have to ship together or the component frames a dead URL.

## Why now

Nothing consumes the route yet, and `client-sdk-base` has not published the identity surface (latest on npm is 2.6.0, which predates the feature). Renaming the path costs nothing today. Once 2.7.0 is out and integrators have it in a lockfile, it stops being free.

## What is not in here

The `kyc:*` event keys stay. Every event-key namespace in this repo is a kebab-case domain noun (`payment-method:`, `order:`, `payment:`, `quote:`, `ui:`), never a camelCase feature name, and `payment-method:selected` already ships from a route directory called `payment-method-management`. The wire has never mirrored a product-surface name, so `kyc:` is the domain noun and it is already correct.

The parent still never calls `handshakeWithChild()`, so the child's events go out blind. That belongs with the target-origin decision in ENG4-354, not here.

## Changeset

None added on purpose. The identity feature is unreleased and the open release PR already queues it as `client-sdk-base@2.7.0`, so this path change rides that changeset.

## Verification

`pnpm test:vitest --filter @crossmint/client-sdk-base --filter @crossmint/client-sdk-react-ui`
