### PR TITLE
Make isSignerApproved throw on errors

### DIFF
--- a/.changeset/is-signer-approved-throws.md
+++ b/.changeset/is-signer-approved-throws.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+`wallet.isSignerApproved` now throws when the signer state cannot be fetched instead of resolving to `false`, so callers can tell a failed request apart from a signer that is not approved. A signer that is not registered still resolves to `false`. This matches the behavior of the Swift and Kotlin SDKs.

--- a/packages/wallets/src/api/client.test.ts
+++ b/packages/wallets/src/api/client.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi, type MockedFunction } from "vitest";
+import { ApiClientError } from "@crossmint/common-sdk-base";
 import type { ApiClient } from "./client";
 import type { ApproveSignatureParams, CreateWalletParams, SendParams } from "./types";
 import { WALLET_LOCATORS, TOKEN_LOCATORS } from "./__tests__/constants";
@@ -1069,6 +1070,47 @@ describe("ApiClient - send()", () => {
                 const body = JSON.parse(call.options.body as string);
                 expect(body.amount).toBe("1e-18");
             }
+        });
+    });
+});
+
+describe("ApiClient - getSigner()", () => {
+    let apiClient: ApiClient;
+    let mockGet: MockedFunction<ApiClient["get"]>;
+
+    beforeEach(() => {
+        apiClient = createTestApiClient();
+        mockGet = vi.spyOn(apiClient, "get") as MockedFunction<ApiClient["get"]>;
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe("success cases", () => {
+        it("returns the signer body for an ok response", async () => {
+            const signerBody = {
+                type: "email",
+                locator: "email:user@example.com",
+                chains: { "base-sepolia": { status: "success" } },
+            };
+            mockGet.mockResolvedValue(createMockSuccessResponse(signerBody));
+
+            await expect(
+                apiClient.getSigner(WALLET_LOCATORS.EVM_SMART_WALLET, "email:user@example.com")
+            ).resolves.toEqual(signerBody);
+        });
+    });
+
+    describe("error cases", () => {
+        it("throws an ApiClientError carrying the status for a non-ok response", async () => {
+            mockGet.mockResolvedValue(
+                createMockErrorResponse({ error: true, message: "Signer not found" }, 404, "Not Found")
+            );
+
+            const request = apiClient.getSigner(WALLET_LOCATORS.EVM_SMART_WALLET, "email:missing@example.com");
+            await expect(request).rejects.toBeInstanceOf(ApiClientError);
+            await expect(request).rejects.toMatchObject({ status: 404 });
         });
     });
 });

--- a/packages/wallets/src/api/client.ts
+++ b/packages/wallets/src/api/client.ts
@@ -2,6 +2,7 @@ import {
     type Crossmint,
     APIKeyEnvironmentPrefix,
     APIKeyUsageOrigin,
+    ApiClientError,
     CrossmintApiClient,
 } from "@crossmint/common-sdk-base";
 
@@ -261,6 +262,18 @@ class ApiClient extends CrossmintApiClient {
         const response = await this.get(`${this.apiPrefix}/${walletLocator}/signers/${encodedSigner}`, {
             headers: this.headers,
         });
+        if (!response.ok) {
+            let responseBody: string | null = null;
+            try {
+                responseBody = await response.text();
+            } catch {}
+            throw new ApiClientError(
+                `API request failed: ${response.status} ${response.statusText}`,
+                response.status,
+                response.statusText,
+                responseBody
+            );
+        }
         return response.json();
     }
 

--- a/packages/wallets/src/wallets/services/signer-manager.test.ts
+++ b/packages/wallets/src/wallets/services/signer-manager.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiClientError } from "@crossmint/common-sdk-base";
 import type { ApiClient } from "../../api";
 import type { Chain } from "../../chains/chains";
 import type { RecoverySignerConfigForChain, SignerAdapter, SignerLocator } from "../../signers/types";
@@ -66,6 +67,7 @@ const apiKeyConfig = { type: "api-key" } as const;
 beforeEach(() => {
     vi.clearAllMocks();
     walletsLogger.warn = vi.fn();
+    walletsLogger.error = vi.fn();
 });
 
 describe("SignerManager", () => {
@@ -205,6 +207,46 @@ describe("SignerManager", () => {
         expect(walletsLogger.warn).toHaveBeenCalledWith(
             "wallet.signers.getSignerState.errorResponse",
             expect.objectContaining({ signerLocator: "api-key" })
+        );
+    });
+
+    it.each([
+        ["success", true],
+        ["awaiting-approval", false],
+    ] as const)("isSignerApproved() maps a fetched signer with status %s to %s", async (status, expected) => {
+        const getSigner = vi.fn().mockResolvedValue({
+            type: "api-key",
+            locator: "api-key:delegated",
+            chains: { "base-sepolia": { status } },
+        });
+        const manager = makeManager({ apiClient: makeApiClient({ getSigner }) });
+        await expect(manager.isSignerApproved("api-key:delegated")).resolves.toBe(expected);
+    });
+
+    it("isSignerApproved() resolves false when the signer is not registered", async () => {
+        const notFound = new ApiClientError("API request failed: 404 Not Found", 404, "Not Found", null);
+        const getSigner = vi.fn().mockRejectedValue(notFound);
+        const manager = makeManager({ apiClient: makeApiClient({ getSigner }) });
+        await expect(manager.isSignerApproved("api-key:unregistered")).resolves.toBe(false);
+    });
+
+    it.each([
+        [
+            "getSigner throws a non-404 API error",
+            vi
+                .fn()
+                .mockRejectedValue(
+                    new ApiClientError("API request failed: 401 Unauthorized", 401, "Unauthorized", null)
+                ),
+        ],
+        ["getSigner throws a network error", vi.fn().mockRejectedValue(new Error("network"))],
+        ["getSigner resolves with an error shape", vi.fn().mockResolvedValue({ error: true, message: "nope" })],
+    ])("isSignerApproved() rejects and logs when %s", async (_name, getSigner) => {
+        const manager = makeManager({ apiClient: makeApiClient({ getSigner }) });
+        await expect(manager.isSignerApproved("api-key:delegated")).rejects.toThrow();
+        expect(walletsLogger.error).toHaveBeenCalledWith(
+            "wallet.signers.isSignerApproved.failed",
+            expect.objectContaining({ signerLocator: "api-key:delegated" })
         );
     });
 

--- a/packages/wallets/src/wallets/services/signer-manager.ts
+++ b/packages/wallets/src/wallets/services/signer-manager.ts
@@ -1,3 +1,5 @@
+import { ApiClientError } from "@crossmint/common-sdk-base";
+
 import type { ApiClient, GetSignerResponse, WalletLocator } from "../../api";
 import type { Chain } from "../../chains/chains";
 import { getSignerDescriptor, type SignerDescriptorContext } from "../../signers/descriptors";
@@ -203,11 +205,27 @@ export class SignerManager<C extends Chain> {
     }
 
     async isSignerApproved(signerLocator: SignerLocator | string): Promise<boolean> {
-        const signerState = await this.getSignerState(signerLocator as SignerLocator);
-        return this.isApprovedSignerStatus(signerState.signer?.status);
+        try {
+            const signer = await this.#fetchSigner(signerLocator as SignerLocator);
+            return this.isApprovedSignerStatus(signer?.status);
+        } catch (error) {
+            if (error instanceof ApiClientError && error.status === 404) {
+                return false;
+            }
+            walletsLogger.error("wallet.signers.isSignerApproved.failed", { signerLocator, error });
+            throw error;
+        }
     }
 
     isApprovedSignerStatus(status: SignerStatus | undefined): boolean {
         return status === "success" || status === "active";
+    }
+
+    async #fetchSigner(signerLocator: SignerLocator): Promise<WalletSigner | null> {
+        const signerResponse = await this.#apiClient.getSigner(this.#walletLocator(), signerLocator);
+        if (signerResponse == null || typeof signerResponse !== "object" || "error" in signerResponse) {
+            throw new Error(`Failed to fetch the approval state of signer ${signerLocator}`);
+        }
+        return mapApiSignerToSigner(signerResponse, this.#chain);
     }
 }

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -971,7 +971,8 @@ export class Wallet<C extends Chain> {
     /**
      * Check if a signer is approved and usable for the current wallet chain.
      * @param signerLocator - The locator of the signer to check
-     * @returns true if the signer is approved for this chain
+     * @returns true if the signer is approved for this chain, false if it is not approved or not registered
+     * @throws if the approval state could not be fetched
      */
     public async isSignerApproved(signerLocator: SignerLocator | string): Promise<boolean> {
         return this.#signerManager.isSignerApproved(signerLocator);


### PR DESCRIPTION
`wallet.isSignerApproved` swallowed every error and resolved to `false`, so callers couldn't tell a signer that isn't approved from a request that failed. It now throws on real failures and keeps resolving `false` for a signer that isn't registered, matching Swift ([#128](https://github.com/Crossmint/crossmint-swift-sdk/pull/128)) and Kotlin ([#131](https://github.com/Crossmint/crossmint-kotlin-sdk/pull/131)).

## Changes

- `ApiClient.getSigner` now throws an `ApiClientError` carrying the HTTP status on non-ok responses, instead of returning the error body as a regular result
- `SignerManager.isSignerApproved` maps a 404 to `false` (the signer isn't registered) and lets every other error bubble up to the caller
- `getSignerState` keeps its lenient null-state fallback, since `assemble` and the recovery flow rely on it to degrade gracefully
- Added `getSigner` tests for the ok and non-ok paths, and `isSignerApproved` tests for the approved, not registered, and failure cases