### PR TITLE
fix(react-ui,react-native-ui): stop the remaining embed listeners leaking past unmount

### DIFF
--- a/.changeset/listener-leak-call-sites.md
+++ b/.changeset/listener-leak-call-sites.md
@@ -1,0 +1,8 @@
+---
+"@crossmint/client-sdk-react-native-ui": patch
+"@crossmint/client-sdk-react-ui": patch
+---
+
+Fixes the listener leak at the remaining call sites that passed an event name to `off()` and so never removed anything: `CrossmintPaymentMethodManagementIFrame`, `EmbeddedCheckoutV3IFrame` and `EmbeddedCheckoutV3WebView`. All three set their emitter once, so the cleanup only runs on unmount and the listeners simply outlived the component.
+
+`CrossmintPaymentMethodManagementIFrame` also read its callbacks from the render that mounted it, so a callback replaced after mount never fired, and it called `off("agentic-enrollment:created")` for an event it never subscribed to.

--- a/.changeset/listener-leak-call-sites.md
+++ b/.changeset/listener-leak-call-sites.md
@@ -6,3 +6,5 @@
 Fixes the listener leak at the remaining call sites that passed an event name to `off()` and so never removed anything: `CrossmintPaymentMethodManagementIFrame`, `EmbeddedCheckoutV3IFrame` and `EmbeddedCheckoutV3WebView`. All three set their emitter once, so the cleanup only runs on unmount and the listeners simply outlived the component.
 
 `CrossmintPaymentMethodManagementIFrame` also read its callbacks from the render that mounted it, so a callback replaced after mount never fired, and it called `off("agentic-enrollment:created")` for an event it never subscribed to.
+
+`CrossmintIdentityVerificationIFrame` was not leaking, but it shares that latest-callback pattern, which now lives in one place and assigns during render rather than in a passive effect. Both components therefore close a narrow window where an event delivered between commit and the effect flush invoked the previous render's callback.

--- a/packages/client/ui/react-native/src/components/embed/v3/EmbeddedCheckoutV3WebView.tsx
+++ b/packages/client/ui/react-native/src/components/embed/v3/EmbeddedCheckoutV3WebView.tsx
@@ -62,17 +62,17 @@ export function EmbeddedCheckoutV3WebView(props: CrossmintEmbeddedCheckoutV3Prop
         }
 
         const handleHeightChanged = (data: { height: number }) => setHeight(data.height);
-        webViewClient.on("ui:height.changed", handleHeightChanged);
+        const heightListener = webViewClient.on("ui:height.changed", handleHeightChanged);
 
         // Listen for order:updated events and re-emit as local event
         const handleOrderUpdated = (data: LocalEventEmitterEvents["order:updated"]) => {
             localEventEmitter.emit("order:updated", data);
         };
-        webViewClient.on("order:updated", handleOrderUpdated);
+        const orderListener = webViewClient.on("order:updated", handleOrderUpdated);
 
         return () => {
-            webViewClient.off("ui:height.changed");
-            webViewClient.off("order:updated");
+            webViewClient.off(heightListener);
+            webViewClient.off(orderListener);
         };
     }, [webViewClient]);
 

--- a/packages/client/ui/react-ui/src/components/card-management/CrossmintPaymentMethodManagementIFrame.tsx
+++ b/packages/client/ui/react-ui/src/components/card-management/CrossmintPaymentMethodManagementIFrame.tsx
@@ -6,12 +6,15 @@ import {
 import { useCrossmint } from "@crossmint/client-sdk-react-base";
 import { useEffect, useRef, useState } from "react";
 import type { CrossmintPaymentMethodManagementProps } from "@crossmint/client-sdk-base";
+import { useLatest } from "@/hooks/useLatest";
 
 export function CrossmintPaymentMethodManagementIFrame(props: CrossmintPaymentMethodManagementProps) {
     const [iframeClient, setIframeClient] = useState<PaymentMethodManagementIFrameEmitter | null>(null);
     const [height, setHeight] = useState(0);
 
     const ref = useRef<HTMLIFrameElement>(null);
+
+    const latestProps = useLatest(props);
 
     const { crossmint } = useCrossmint();
     const apiClient = createCrossmintApiClient(crossmint, {
@@ -31,13 +34,14 @@ export function CrossmintPaymentMethodManagementIFrame(props: CrossmintPaymentMe
         if (iframeClient == null) {
             return;
         }
-        iframeClient.on("ui:height.changed", (data) => setHeight(data.height));
-        iframeClient.on("payment-method:selected", (data) => props.onPaymentMethodSelected?.(data));
+        const heightListener = iframeClient.on("ui:height.changed", (data) => setHeight(data.height));
+        const selectedListener = iframeClient.on("payment-method:selected", (data) =>
+            latestProps.current.onPaymentMethodSelected?.(data)
+        );
 
         return () => {
-            iframeClient.off("ui:height.changed");
-            iframeClient.off("payment-method:selected");
-            iframeClient.off("agentic-enrollment:created");
+            iframeClient.off(heightListener);
+            iframeClient.off(selectedListener);
         };
     }, [iframeClient]);
 

--- a/packages/client/ui/react-ui/src/components/card-management/crossmint-payment-method-management.test.tsx
+++ b/packages/client/ui/react-ui/src/components/card-management/crossmint-payment-method-management.test.tsx
@@ -1,0 +1,75 @@
+import "@testing-library/jest-dom/vitest";
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { emit, iframeClient, resetIFrameEmitter } from "../../../tests/shared/iframeEmitter";
+import { CrossmintPaymentMethodManagement } from "./CrossmintPaymentMethodManagement";
+
+vi.mock("@crossmint/client-sdk-base", async () => {
+    const { iframeClient } = await import("../../../tests/shared/iframeEmitter");
+    return {
+        createPaymentMethodManagementService: () => ({
+            iframe: {
+                getUrl: () => "https://staging.crossmint.com/sdk/unstable/payment-method-management",
+                createClient: () => iframeClient,
+            },
+        }),
+    };
+});
+
+vi.mock("@crossmint/client-sdk-react-base", () => ({
+    useCrossmint: () => ({ crossmint: { apiKey: "ck_staging_key" } }),
+}));
+
+vi.mock("@/utils/createCrossmintApiClient", () => ({
+    createCrossmintApiClient: () => ({}),
+}));
+
+const PAYMENT_METHOD = { id: "pm-1", type: "card" };
+
+function getIFrame() {
+    return document.getElementById("crossmint-payment-method-management.iframe") as HTMLIFrameElement;
+}
+
+describe("<CrossmintPaymentMethodManagement />", () => {
+    afterEach(() => {
+        cleanup();
+        resetIFrameEmitter();
+    });
+
+    describe("when the iframe relays events", () => {
+        test("calls the callback from the latest render, not the one captured at subscribe time", () => {
+            const stale = vi.fn();
+            const fresh = vi.fn();
+            const { rerender } = render(<CrossmintPaymentMethodManagement jwt="jwt" onPaymentMethodSelected={stale} />);
+
+            rerender(<CrossmintPaymentMethodManagement jwt="jwt" onPaymentMethodSelected={fresh} />);
+            emit("payment-method:selected", PAYMENT_METHOD);
+
+            expect(fresh).toHaveBeenCalledWith(PAYMENT_METHOD);
+            expect(stale).not.toHaveBeenCalled();
+        });
+
+        test("applies the relayed height to the iframe", () => {
+            render(<CrossmintPaymentMethodManagement jwt="jwt" />);
+
+            emit("ui:height.changed", { height: 480 });
+
+            expect(getIFrame()).toHaveStyle({ height: "480px" });
+        });
+    });
+
+    describe("when unmounted", () => {
+        test("removes every listener by its returned id, not by event name", () => {
+            const { unmount } = render(<CrossmintPaymentMethodManagement jwt="jwt" />);
+
+            unmount();
+
+            for (const event of ["ui:height.changed", "payment-method:selected"]) {
+                expect(iframeClient.off).toHaveBeenCalledWith(`listener-id:${event}`);
+            }
+            expect(iframeClient.off).toHaveBeenCalledTimes(2);
+        });
+    });
+});

--- a/packages/client/ui/react-ui/src/components/embed/v3/EmbeddedCheckoutV3IFrame.tsx
+++ b/packages/client/ui/react-ui/src/components/embed/v3/EmbeddedCheckoutV3IFrame.tsx
@@ -55,10 +55,10 @@ export function EmbeddedCheckoutV3IFrame(props: CrossmintEmbeddedCheckoutV3Props
         if (iframeClient == null) {
             return;
         }
-        iframeClient.on("ui:height.changed", (data) => setHeight(data.height));
+        const heightListener = iframeClient.on("ui:height.changed", (data) => setHeight(data.height));
 
         return () => {
-            iframeClient.off("ui:height.changed");
+            iframeClient.off(heightListener);
         };
     }, [iframeClient]);
 

--- a/packages/client/ui/react-ui/src/components/embed/v3/embedded-checkout-v3-iframe.test.tsx
+++ b/packages/client/ui/react-ui/src/components/embed/v3/embedded-checkout-v3-iframe.test.tsx
@@ -1,0 +1,68 @@
+import "@testing-library/jest-dom/vitest";
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { emit, iframeClient, resetIFrameEmitter } from "../../../../tests/shared/iframeEmitter";
+import { EmbeddedCheckoutV3IFrame } from "./EmbeddedCheckoutV3IFrame";
+
+vi.mock("@crossmint/client-sdk-base", async () => {
+    const { iframeClient } = await import("../../../../tests/shared/iframeEmitter");
+    return {
+        crossmintEmbeddedCheckoutV3Service: () => ({
+            iframe: {
+                getUrl: () => "https://staging.crossmint.com/sdk/2024-03-05/embeddedCheckout",
+                createClient: () => iframeClient,
+            },
+        }),
+    };
+});
+
+vi.mock("@crossmint/client-sdk-react-base", () => ({
+    useCrossmint: () => ({ crossmint: { apiKey: "ck_staging_key" } }),
+}));
+
+vi.mock("@/utils/createCrossmintApiClient", () => ({
+    createCrossmintApiClient: () => ({ parsedAPIKey: { environment: "staging" } }),
+}));
+
+// Crypto disabled and no payer, so neither connection handler mounts and the iframe's own
+// listeners are the only ones under test.
+const PROPS = {
+    lineItems: { collectionLocator: "crossmint:col-1" },
+    payment: { crypto: { enabled: false }, fiat: { enabled: true } },
+} as unknown as Parameters<typeof EmbeddedCheckoutV3IFrame>[0];
+
+function getIFrame() {
+    return document.getElementById("crossmint-embedded-checkout.iframe") as HTMLIFrameElement;
+}
+
+describe("<EmbeddedCheckoutV3IFrame />", () => {
+    afterEach(() => {
+        cleanup();
+        resetIFrameEmitter();
+    });
+
+    describe("when the iframe relays events", () => {
+        test("applies the relayed height to the iframe", () => {
+            render(<EmbeddedCheckoutV3IFrame {...PROPS} />);
+
+            emit("ui:height.changed", { height: 720 });
+
+            expect(getIFrame()).toHaveStyle({ height: "720px" });
+        });
+    });
+
+    describe("when unmounted", () => {
+        test("removes both listeners by their returned ids, not by event name", () => {
+            const { unmount } = render(<EmbeddedCheckoutV3IFrame {...PROPS} />);
+
+            unmount();
+
+            for (const event of ["ui:height.changed", "crypto:load"]) {
+                expect(iframeClient.off).toHaveBeenCalledWith(`listener-id:${event}`);
+            }
+            expect(iframeClient.off).toHaveBeenCalledTimes(2);
+        });
+    });
+});

--- a/packages/client/ui/react-ui/src/components/identity-verification/CrossmintIdentityVerificationIFrame.tsx
+++ b/packages/client/ui/react-ui/src/components/identity-verification/CrossmintIdentityVerificationIFrame.tsx
@@ -6,6 +6,7 @@ import {
 } from "@crossmint/client-sdk-base";
 import { useCrossmint } from "@crossmint/client-sdk-react-base";
 import { useEffect, useRef, useState } from "react";
+import { useLatest } from "@/hooks/useLatest";
 
 export function CrossmintIdentityVerificationIFrame(props: CrossmintIdentityVerificationProps) {
     const [iframeClient, setIframeClient] = useState<IdentityVerificationIFrameEmitter | null>(null);
@@ -13,12 +14,7 @@ export function CrossmintIdentityVerificationIFrame(props: CrossmintIdentityVeri
 
     const ref = useRef<HTMLIFrameElement>(null);
 
-    // The listeners are subscribed once, so reading callbacks off this ref is what keeps a
-    // late event calling the render's props rather than the ones captured at subscribe time.
-    const latestProps = useRef(props);
-    useEffect(() => {
-        latestProps.current = props;
-    });
+    const latestProps = useLatest(props);
 
     const { crossmint } = useCrossmint();
     const apiClient = createCrossmintApiClient(crossmint, { usageOrigin: "client" });

--- a/packages/client/ui/react-ui/src/components/identity-verification/crossmint-identity-verification.test.tsx
+++ b/packages/client/ui/react-ui/src/components/identity-verification/crossmint-identity-verification.test.tsx
@@ -1,30 +1,22 @@
 import "@testing-library/jest-dom/vitest";
 
-import { act, cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
+import { emit, iframeClient, resetIFrameEmitter } from "../../../tests/shared/iframeEmitter";
 import { CrossmintIdentityVerification } from "./CrossmintIdentityVerification";
 
-const listeners = new Map<string, (data: unknown) => void>();
-// Returns an id distinct from the event name on purpose, so the unmount test
-// fails if cleanup passes event names to off() instead of the returned ids.
-// CrossmintPaymentMethodManagementIFrame has exactly that bug today.
-const iframeClient = {
-    on: vi.fn((event: string, handler: (data: unknown) => void) => {
-        listeners.set(event, handler);
-        return `listener-id:${event}`;
-    }),
-    off: vi.fn(),
-};
-
-vi.mock("@crossmint/client-sdk-base", () => ({
-    createIdentityVerificationService: () => ({
-        iframe: {
-            getUrl: () => "https://staging.crossmint.com/sdk/unstable/kyc-verification?credentials=%7B%7D",
-            createClient: () => iframeClient,
-        },
-    }),
-}));
+vi.mock("@crossmint/client-sdk-base", async () => {
+    const { iframeClient } = await import("../../../tests/shared/iframeEmitter");
+    return {
+        createIdentityVerificationService: () => ({
+            iframe: {
+                getUrl: () => "https://staging.crossmint.com/sdk/unstable/kyc-verification?credentials=%7B%7D",
+                createClient: () => iframeClient,
+            },
+        }),
+    };
+});
 
 vi.mock("@crossmint/client-sdk-react-base", () => ({
     useCrossmint: () => ({ crossmint: { apiKey: "ck_staging_key" } }),
@@ -36,19 +28,10 @@ vi.mock("@/utils/createCrossmintApiClient", () => ({
 
 const CREDENTIALS = { provider: "persona", inquiryId: "inq-1" } as const;
 
-function emit(event: string, data: unknown) {
-    const handler = listeners.get(event);
-    if (handler == null) {
-        throw new Error(`no listener registered for ${event}`);
-    }
-    act(() => handler(data));
-}
-
 describe("<CrossmintIdentityVerification />", () => {
     afterEach(() => {
         cleanup();
-        listeners.clear();
-        vi.clearAllMocks();
+        resetIFrameEmitter();
     });
 
     describe("when mounted", () => {

--- a/packages/client/ui/react-ui/src/hooks/use-latest.test.ts
+++ b/packages/client/ui/react-ui/src/hooks/use-latest.test.ts
@@ -1,0 +1,22 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import { useLatest } from "./useLatest";
+
+describe("useLatest", () => {
+    describe("when the value changes", () => {
+        test("exposes the new value during that same render, not after the effects flush", () => {
+            const seenDuringRender: number[] = [];
+            const { rerender } = renderHook(
+                ({ value }) => {
+                    seenDuringRender.push(useLatest(value).current);
+                },
+                { initialProps: { value: 1 } }
+            );
+
+            rerender({ value: 2 });
+
+            expect(seenDuringRender).toEqual([1, 2]);
+        });
+    });
+});

--- a/packages/client/ui/react-ui/src/hooks/useLatest.ts
+++ b/packages/client/ui/react-ui/src/hooks/useLatest.ts
@@ -1,0 +1,13 @@
+import { useRef } from "react";
+
+/**
+ * Keeps a ref pointing at the newest value. For listeners subscribed once, reading callbacks off
+ * this ref is what keeps a late event calling the current render's props rather than the ones
+ * captured at subscribe time. Assigned during render, not in an effect, so an event delivered
+ * between commit and the effect flush still sees the newest value.
+ */
+export function useLatest<T>(value: T) {
+    const ref = useRef(value);
+    ref.current = value;
+    return ref;
+}

--- a/packages/client/ui/react-ui/tests/shared/iframeEmitter.ts
+++ b/packages/client/ui/react-ui/tests/shared/iframeEmitter.ts
@@ -1,0 +1,27 @@
+import { act } from "@testing-library/react";
+import { vi } from "vitest";
+
+const listeners = new Map<string, (data: unknown) => void>();
+
+// `on` returns an id distinct from the event name on purpose, so a cleanup that passes event names
+// to `off()` instead of the returned ids fails the unmount tests instead of silently leaking.
+export const iframeClient = {
+    on: vi.fn((event: string, handler: (data: unknown) => void) => {
+        listeners.set(event, handler);
+        return `listener-id:${event}`;
+    }),
+    off: vi.fn(),
+};
+
+export function emit(event: string, data: unknown) {
+    const handler = listeners.get(event);
+    if (handler == null) {
+        throw new Error(`no listener registered for ${event}`);
+    }
+    act(() => handler(data));
+}
+
+export function resetIFrameEmitter() {
+    listeners.clear();
+    vi.clearAllMocks();
+}


### PR DESCRIPTION
Split out of #2007. Stacked on #2014, but touches disjoint files from it, so review order does not matter. Patch release, no API change.

## The bug

Three components passed **event names** to `off()`:

```ts
iframeClient.off("ui:height.changed");
```

Listener ids are 13-char strings from `generateRandomString()`, so this looked up an event name in a map keyed by ids, found nothing, and removed nothing. Capturing the id `on()` already returns is the whole fix, and it needs no type change.

| Site | Cleanup runs | Async resume points | Risk |
|---|---|---|---|
| `CrossmintPaymentMethodManagementIFrame` | unmount only | none | low |
| `EmbeddedCheckoutV3IFrame` | unmount only | none | low |
| `EmbeddedCheckoutV3WebView` | unmount only | none | low |

All three set their emitter once behind a guard (`if (!iframe || iframeClient) return`), so the cleanup only ever fires on unmount and the listeners simply outlived the component. **None has async work in flight**, so there is no in-flight state to lose by tearing down for real. `useOAuthWindowListener` was the only site that did, which is why it shipped separately in #2014.

`EmbeddedCheckoutV3WebView` additionally lets `RNWebViewTransport` detach its global `message` handler now that the listener map actually drains.

`EventEmitter.sendAction()` / `onAction()` always passed real ids, so they were never leaking. The blast radius is exactly the four hand-written sites.

## Two extras in `CrossmintPaymentMethodManagementIFrame`

- It read its callbacks from the render that **mounted** it, so a callback replaced after mount never fired.
- It called `off("agentic-enrollment:created")` for an event it never subscribed to. Removed.

The latest-props pattern it shares with `CrossmintIdentityVerificationIFrame` moves into a `useLatest` hook that assigns **during render** rather than in a passive effect, closing the window where a message delivered between commit and the effect flush hit the previous render's callback. Reverting it to the effect form fails `use-latest.test.ts`.

## Tests

`EmbeddedCheckoutV3IFrame` had no coverage at all and now has two tests. The ~40 lines of iframe emitter harness duplicated between the card-management and identity-verification suites move to `tests/shared/iframeEmitter.ts` (the duplicate had already drifted on its first day).

Mutation-checked: reverting any of these cleanups to an event name fails an unmount test.

`pnpm build:libs` 16/16, `pnpm test:vitest` 11/11 packages, react-ui 42 tests, `pnpm lint` clean.

## Known gap

`EmbeddedCheckoutV3WebView` still has no test: `react-native-ui` has a `vitest.config.ts` and a declared turbo task but no `test:vitest` script, so CI skips the package. Happy to wire it up here or take it as a separate ticket.