### PR TITLE
fix(window): a timeout the caller handles is not an error

### DIFF
--- a/.changeset/event-emitter-timeout-not-an-error.md
+++ b/.changeset/event-emitter-timeout-not-an-error.md
@@ -1,0 +1,9 @@
+---
+"@crossmint/client-sdk-window": patch
+---
+
+`EventEmitter` no longer logs `console.error` for a timeout it hands back to the caller as a rejection.
+
+`sendAction` and `onAction` reject on timeout, and `sendAction` also rejects once it exhausts `maxRetries`. Each of those rejections was preceded by a `console.error`, so a caller that catches the rejection and recovers still left an error behind. Only the caller knows whether a timeout is fatal — `CrossmintWalletProvider` retries the WebView handshake twice and logs `handshake.error` itself if those run out.
+
+On React Native the duplicate is not just noise. `console.error` raises a LogBox notification, which renders on top of the app: a handshake that timed out at 30s and succeeded on retry 16s later left a toast covering the bottom of the screen, over the app's own controls.

--- a/.github/workflows/e2e-mobile-trigger.yml
+++ b/.github/workflows/e2e-mobile-trigger.yml
@@ -13,6 +13,8 @@ on:
             - "packages/client/react-base/**"
             - "packages/client/ui/react-native/**"
             - "packages/client/rn-window/**"
+            # rn-window builds its Parent/Child and transport on top of this.
+            - "packages/client/window/**"
 
 concurrency:
     group: mobile-e2e-${{ github.event.pull_request.number }}

--- a/packages/client/window/src/EventEmitter.test.ts
+++ b/packages/client/window/src/EventEmitter.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { z } from "zod";
+
+import { EventEmitter } from "./EventEmitter";
+import type { SimpleMessageEvent, Transport } from "./transport/Transport";
+
+const incoming = { pong: z.object({}) };
+const outgoing = { ping: z.object({}) };
+
+function silentTransport(): Transport<typeof outgoing> {
+    return {
+        send: vi.fn(),
+        addMessageListener: (_listener: (event: SimpleMessageEvent | MessageEvent) => void) => "id",
+        removeMessageListener: vi.fn(),
+    };
+}
+
+function emitter() {
+    return new EventEmitter(silentTransport(), incoming, outgoing);
+}
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe("a timeout the caller receives as a rejection", () => {
+    test("sendAction does not report it as an error", async () => {
+        const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+        await expect(
+            emitter().sendAction({ event: "ping", data: {}, responseEvent: "pong", options: { timeoutMs: 1 } })
+        ).rejects.toBeTruthy();
+
+        expect(consoleError).not.toHaveBeenCalled();
+    });
+
+    test("onAction does not report it as an error", async () => {
+        const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+        await expect(emitter().onAction({ event: "pong", options: { timeoutMs: 1 } })).rejects.toBeTruthy();
+
+        expect(consoleError).not.toHaveBeenCalled();
+    });
+
+    test("sendAction exhausting its retries does not report it as an error", async () => {
+        const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+        await expect(
+            emitter().sendAction({
+                event: "ping",
+                data: {},
+                responseEvent: "pong",
+                options: { timeoutMs: 10_000, intervalMs: 1, maxRetries: 1 },
+            })
+        ).rejects.toBeTruthy();
+
+        expect(consoleError).not.toHaveBeenCalled();
+    });
+});

--- a/packages/client/window/src/EventEmitter.ts
+++ b/packages/client/window/src/EventEmitter.ts
@@ -108,7 +108,7 @@ export class EventEmitter<IncomingEvents extends EventMap, OutgoingEvents extend
                     clearInterval(interval);
                 }
                 this.off(responseListenerId);
-                console.error(
+                console.warn(
                     `[EventEmitter] sendAction: timeout after ${timeoutMs / 1000}s waiting for ${String(responseEvent)}`
                 );
                 reject(
@@ -140,7 +140,7 @@ export class EventEmitter<IncomingEvents extends EventMap, OutgoingEvents extend
                         clearInterval(interval!);
                         clearTimeout(timer);
                         this.off(responseListenerId);
-                        console.error(
+                        console.warn(
                             `[EventEmitter] sendAction: max retries (${maxRetries}) reached for ${String(event)}`
                         );
                         reject(
@@ -168,7 +168,7 @@ export class EventEmitter<IncomingEvents extends EventMap, OutgoingEvents extend
         return new Promise((resolve, reject) => {
             const timer = setTimeout(() => {
                 this.off(responseListenerId);
-                console.error(
+                console.warn(
                     `[EventEmitter] onAction() - Timeout after ${timeoutMs / 1000}s waiting for ${String(event)}`
                 );
                 reject(


### PR DESCRIPTION
## What

`EventEmitter.sendAction` / `onAction` reject on timeout, and `sendAction` also rejects once it exhausts `maxRetries`. Each rejection was preceded by a `console.error`, so a caller that catches it and recovers still left an error behind. Downgraded to `console.warn` — the rejection is the signal, and only the caller knows whether a timeout is fatal.

`CrossmintWalletProvider` is exactly that caller: it retries the WebView handshake up to `MAX_HANDSHAKE_RETRIES` and logs `handshake.error` itself if those run out. That log is untouched.

## Why it isn't just noise

On React Native, LogBox renders a notification over the app for **both** `console.error` and `console.warn`, so this does not remove the overlay — it shrinks it. That is enough, because the overlay's size is what broke e2e.

From nightly mobile-e2e run [31427343627](https://github.com/Crossmint/crossmint-mobile-e2e-tests/actions/runs/31427343627), RN Android, `com.crossmint.walletsplayground`:

```
20:56:09.588  react-native.wallet.webview.handshake.start
20:56:40.110  E/ReactNativeJS [EventEmitter] sendAction: timeout after 30s waiting for handshakeResponse
20:56:41.088  react-native.wallet.webview.handshake.retry
20:56:56.920  react-native.wallet.webview.handshake.success
```

The handshake recovered 16s later, but the toast stayed. Measured from the Maestro view-hierarchy dumps on a 1080x2280 screen:

| | LogBox container | height | content |
| --- | --- | --- | --- |
| `console.error` (before) | `[28,1799][1053,2225]` | 426 px | the full log line, expanded |
| `console.warn` (after) | `[28,2014][1053,2145]` | 131 px | collapsed badge, `Open debugger to view warnings.` |

The playground's `signers-add-button` sits at `[99,1752][981,1876]`. The error-level container covered its center (y=1814), and two e2e flows failed with "no visible element found" for a button that was present in the hierarchy — with this exact log line as the toast text. The warning badge starts at y=2014, clearing the button by 138 px.

Confirmed on this PR's own e2e run: `device-logcat.txt` shows the downgrade live and the button no longer missed.

```
11:28:05.856 I/ReactNativeJS [EventEmitter] sendAction: handshakeRequest → waiting handshakeResponse (timeout: 30000ms)
11:28:35.885 W/ReactNativeJS [EventEmitter] sendAction: timeout after 30s waiting for handshakeResponse
11:29:04.363 I/ReactNativeJS [EventEmitter] sendAction: received handshakeResponse
```

`W/` rather than `E/` is the built change running; zero `signers-add-button` misses in that run.

Two things this deliberately does not do. It does not add `LogBox.ignoreLogs` — the app sets no LogBox policy at all, and silencing warnings app-wide to fix a test is the wrong trade. And it does not make the timeout silent — a handshake that needs a retry is worth seeing.

### What this does not fix

The fix is positional, not categorical: the warning badge still occupies `[28,2014][1053,2145]`. It clears `signers-add-button`, but any element a flow needs below y=2014 on a 2280-tall screen would still be covered. This removes the collision we hit; it does not make LogBox harmless to e2e in general.

The categorical fix would be a `LogBox.ignoreLogs` policy in the playground app — deliberately not done here, per the reasoning above, and a decision for the app rather than this package.

## Tests

`packages/client/window/src/EventEmitter.test.ts` (new) pins all three call sites. Verified they fail with `console.error` restored and pass with `console.warn`:

```
pnpm --filter @crossmint/client-sdk-window test:vitest
Tests  7 passed (7)          # with the fix
Tests  3 failed | 4 passed   # with console.error restored
```

`biome check --diagnostic-level=error` clean on both files.
