### PR TITLE
fix(react-native-ui): submit the signer OTP from the keyboard

### DIFF
--- a/.changeset/otp-submit-from-keyboard.md
+++ b/.changeset/otp-submit-from-keyboard.md
@@ -1,0 +1,9 @@
+---
+"@crossmint/client-sdk-react-native-ui": patch
+---
+
+The signer OTP field now submits from the keyboard's done key.
+
+`BaseCodeInput` only accepted the code via the Submit button, which sits below the field and therefore behind the keyboard the field just opened. Entering a code meant dismissing the keyboard first — and dismissing it reflows the dialog, moving the button that was the only way to continue.
+
+`returnKeyType="done"` with `onSubmitEditing` submits in place, from where the user already is. The Submit button is unchanged.

--- a/packages/client/ui/react-native/src/components/signers/BaseCodeInput.tsx
+++ b/packages/client/ui/react-native/src/components/signers/BaseCodeInput.tsx
@@ -198,6 +198,8 @@ export function BaseCodeInput({
                 textContentType={textContentType}
                 editable={!isLoading}
                 maxLength={otpLength}
+                returnKeyType="done"
+                onSubmitEditing={handleSubmitOTP}
             />
 
             {error && <Text style={dynamicStyles.errorText}>{error}</Text>}


### PR DESCRIPTION
## What

`BaseCodeInput`'s code field gets `returnKeyType="done"` and `onSubmitEditing`. Two lines; the Submit button is unchanged.

## Why

The Submit button sits below the code field, so it is behind the keyboard the field itself opens. Continuing meant dismissing the keyboard first — and dismissing it reflows the dialog, moving the button that was the only way forward.

Measured on a 1080x2280 RN Android device in nightly mobile-e2e run [31427343627](https://github.com/Crossmint/crossmint-mobile-e2e-tests/actions/runs/31427343627). With the keyboard down, the Submit label resolved to `[470,1318][610,1377]`. With it up, the dialog had reflowed and the same label sat at `[470,923][610,982]` — **395px higher**. A tap aimed at the first position lands in dead space in the second (nothing occupies y=1347 in the reflowed tree).

That is what happened: `start-onboarding` succeeded, the code was typed, one tap was delivered at the pre-reflow coordinates, and no OTP-validation request was ever issued. The dialog then sat untouched for 30 minutes with the code still in the field — no spinner, no error, so `handleSubmitOTP` never ran.

A human hits the same layout: the target moves between deciding to tap it and tapping it. Submitting in place removes the keyboard dance entirely.

## Notes

- The IME action key is present on the numeric keyboard used here, so the done key is reachable for a 9-digit code.
- Single-line `TextInput` blurs on submit, so the keyboard closes *as a result of* submitting rather than as a prerequisite.
- Not included: `testID`s on the dialog's controls. There are currently zero in `@crossmint/client-sdk-react-native-ui`, so introducing them is a convention worth deciding separately — happy to follow up if you want them.