### PR TITLE
fix(wallets): make the unavailable-approval-signer error say what actually failed

### DIFF
--- a/.changeset/funky-dancers-sink.md
+++ b/.changeset/funky-dancers-sink.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+Clarify approval signer availability and remediation

--- a/packages/wallets/src/wallets/wallet.test.ts
+++ b/packages/wallets/src/wallets/wallet.test.ts
@@ -843,7 +843,13 @@ describe("Wallet - approve()", () => {
             } as any);
             mockStorage.hasKey.mockResolvedValue(false);
 
-            await expect(fallbackWallet.approve({ signatureId: "sig-2" })).rejects.toThrow(InvalidSignerError);
+            await expect(fallbackWallet.approve({ signatureId: "sig-2" })).rejects.toThrow(
+                new InvalidSignerError(
+                    "The transaction requires approval from signer device:missingkey, but this signer is not " +
+                        "available to this wallet instance. Available signers: external-wallet:0x123. Initialize " +
+                        "the wallet with device:missingkey, or pass it through the additionalSigners approve option."
+                )
+            );
             expect(mockStorage.hasKey).toHaveBeenCalledWith("missingkey");
             expect(mockApiClient.approveSignature).not.toHaveBeenCalled();
         });

--- a/packages/wallets/src/wallets/wallet.test.ts
+++ b/packages/wallets/src/wallets/wallet.test.ts
@@ -845,9 +845,10 @@ describe("Wallet - approve()", () => {
 
             await expect(fallbackWallet.approve({ signatureId: "sig-2" })).rejects.toThrow(
                 new InvalidSignerError(
-                    "The transaction requires approval from signer device:missingkey, but this signer is not " +
-                        "available to this wallet instance. Available signers: external-wallet:0x123. Initialize " +
-                        "the wallet with device:missingkey, or pass it through the additionalSigners approve option."
+                    "The transaction or signature requires approval from signer device:missingkey, but this signer " +
+                        "is not available to this wallet instance. Available signers: external-wallet:0x123. " +
+                        "Initialize the wallet with device:missingkey, or pass it through the additionalSigners " +
+                        "approve option."
                 )
             );
             expect(mockStorage.hasKey).toHaveBeenCalledWith("missingkey");

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -1154,7 +1154,13 @@ export class Wallet<C extends Chain> {
             signer = (await this.#resolveMissingDeviceSigner(locator)) ?? undefined;
         }
         if (signer == null) {
-            throw new InvalidSignerError(`Signer ${locator} not found in pending approvals`);
+            const availableSigners = signers.map((availableSigner) => availableSigner.locator());
+            const availableSignersMessage = availableSigners.length > 0 ? availableSigners.join(", ") : "none";
+            throw new InvalidSignerError(
+                `The transaction requires approval from signer ${locator}, but this signer is not available ` +
+                    `to this wallet instance. Available signers: ${availableSignersMessage}. Initialize the ` +
+                    `wallet with ${locator}, or pass it through the additionalSigners approve option.`
+            );
         }
         return signer;
     }

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -1157,9 +1157,9 @@ export class Wallet<C extends Chain> {
             const availableSigners = signers.map((availableSigner) => availableSigner.locator());
             const availableSignersMessage = availableSigners.length > 0 ? availableSigners.join(", ") : "none";
             throw new InvalidSignerError(
-                `The transaction requires approval from signer ${locator}, but this signer is not available ` +
-                    `to this wallet instance. Available signers: ${availableSignersMessage}. Initialize the ` +
-                    `wallet with ${locator}, or pass it through the additionalSigners approve option.`
+                `The transaction or signature requires approval from signer ${locator}, but this signer is not ` +
+                    `available to this wallet instance. Available signers: ${availableSignersMessage}. Initialize ` +
+                    `the wallet with ${locator}, or pass it through the additionalSigners approve option.`
             );
         }
         return signer;


### PR DESCRIPTION
## Description

`wallet.approve` threw `Signer phone:+X not found in pending approvals`, which describes the wrong thing. The signer *was* in the transaction's pending approvals — the server had put it there. What actually failed is the opposite: the required signer is not among the signers this wallet instance holds (`[...options.additionalSigners, walletSigner]`), so `#resolveApprovalSigner` has nothing to sign with and bails before any approval request is sent.

This wording cost a customer real time today. Their app was upgraded to a device signer as the operational signer while their backend kept creating transfers without a `signer`, so the pending approval routed to the wallet's phone admin signer. The app then read the error as "the server lost my phone signer" and the investigation went after server-side pending-approval state, when the fix was on the caller: supply the signer the transaction is waiting for.

The message now states the required signer, that it is unavailable to this wallet instance, which locators *are* available (`none` when empty), and the two remedies — initialize the wallet with that signer, or pass it via the `additionalSigners` approve option:

```
The transaction or signature requires approval from signer device:missingkey, but this signer is not
available to this wallet instance. Available signers: external-wallet:0x123. Initialize the wallet
with device:missingkey, or pass it through the additionalSigners approve option.
```

Message-only change: `InvalidSignerError`, the signer lookup, and the `#resolveMissingDeviceSigner` device fallback are untouched, so nothing about which approvals succeed changes.

## Test plan

* Existing `Wallet - approve()` test that asserts this throw now asserts the full new message, including the available-signers list.
* `pnpm --filter @crossmint/wallets-sdk... build` then `pnpm --filter @crossmint/wallets-sdk test:vitest`: 672 tests pass across 27 files.
* `pnpm lint` clean.

## Package updates

* `@crossmint/wallets-sdk` — patch, changeset added (`.changeset/funky-dancers-sink.md`).


Link to Devin session: https://crossmint.devinenterprise.com/sessions/97f9c67465a1439d840937371c413eb6
Requested by: @alfonso-paella