### PR TITLE
fix(quickstart-devkit): seed Solana test wallets from our own devnet keypair

### DIFF
--- a/.github/workflows/e2e-regression-tests.yml
+++ b/.github/workflows/e2e-regression-tests.yml
@@ -59,13 +59,20 @@ jobs:
                   # simultaneous OTP requests for the same email get rate-limited/blocked.
                   # Each browser gets its own persistent wallet, reused across runs.
                   TESTS_WALLET_EMAIL_SUFFIX: e2e-${{ matrix.browser }}
+                  # The public devnet faucet's requestAirdrop no longer works from the
+                  # runners, so Solana test wallets are seeded from our own keypair.
+                  SOLANA_DEVNET_FUNDER_SECRET_KEY: ${{ secrets.SOLANA_DEVNET_FUNDER_SECRET_KEY }}
               run: |
                   mkdir -p test-results
-                  pnpm exec playwright test --project=${{ matrix.browser }} || true
+                  set +e
+                  pnpm exec playwright test --project=${{ matrix.browser }}
+                  tests_exit_code=$?
+                  set -e
                   if [ ! -f test-results/playwright-results.json ]; then
                       echo "::error::No test results file generated — no tests were discovered. Check testMatch patterns in playwright.config.ts."
                       exit 1
                   fi
+                  exit $tests_exit_code
 
             - name: Generate test report
               if: always()

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -59,9 +59,6 @@ jobs:
                   # Dedicated persistent wallet identity so smoke runs never share
                   # emails (and OTP requests) with concurrently running e2e jobs.
                   TESTS_WALLET_EMAIL_SUFFIX: smoke
-                  # The public devnet faucet's requestAirdrop no longer works from the
-                  # runners, so Solana test wallets are seeded from our own keypair.
-                  SOLANA_DEVNET_FUNDER_SECRET_KEY: ${{ secrets.SOLANA_DEVNET_FUNDER_SECRET_KEY }}
               run: |
                   pnpm exec playwright test --project=smoke
 

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -59,6 +59,9 @@ jobs:
                   # Dedicated persistent wallet identity so smoke runs never share
                   # emails (and OTP requests) with concurrently running e2e jobs.
                   TESTS_WALLET_EMAIL_SUFFIX: smoke
+                  # The public devnet faucet's requestAirdrop no longer works from the
+                  # runners, so Solana test wallets are seeded from our own keypair.
+                  SOLANA_DEVNET_FUNDER_SECRET_KEY: ${{ secrets.SOLANA_DEVNET_FUNDER_SECRET_KEY }}
               run: |
                   pnpm exec playwright test --project=smoke
 

--- a/apps/wallets/quickstart-devkit/.env.template
+++ b/apps/wallets/quickstart-devkit/.env.template
@@ -17,3 +17,6 @@ MAILOSAUR_API_KEY=
 MAILOSAUR_SERVER_ID=
 MAILOSAUR_PHONE_NUMBER=
 TESTS_CROSSMINT_API_KEY=
+# Devnet keypair that seeds Solana test wallets with SOL for fees, as the JSON
+# array solana-keygen writes. See e2e/README.md.
+SOLANA_DEVNET_FUNDER_SECRET_KEY=

--- a/apps/wallets/quickstart-devkit/e2e/README.md
+++ b/apps/wallets/quickstart-devkit/e2e/README.md
@@ -23,6 +23,22 @@ Tests are configured to:
 | `MAILOSAUR_PHONE_NUMBER` | ✅ | Your Mailosaur phone number |
 | `TESTS_CROSSMINT_API_KEY` | ✅ | Your Crossmint API key for e2e testing |
 | `PLAYWRIGHT_BASE_URL` | ❌ | App URL (defaults to http://localhost:3000) |
+| `SOLANA_DEVNET_RPC_URL` | ❌ | Devnet RPC (defaults to https://api.devnet.solana.com) |
+| `SOLANA_DEVNET_FUNDER_SECRET_KEY` | ❌ | Devnet keypair that seeds Solana test wallets with SOL |
+
+## ⛽ Funding Solana test wallets
+
+Solana transfers need native SOL for fees, and the Crossmint faucet only dispenses
+USDXM. `requestAirdrop` against the public devnet faucet now fails from every IP we
+have tried, CI runners included, so `SOLANA_DEVNET_FUNDER_SECRET_KEY` holds a devnet
+keypair that seeds the test wallets directly. Its value is the 64-byte secret key as
+the JSON array `solana-keygen` writes — the contents of `~/.config/solana/id.json`.
+
+Wallets are reused across runs and a transfer costs roughly 0.0002 SOL, so 1 SOL in
+the funder covers thousands of runs. Top it up through the
+[web faucet](https://faucet.solana.com), which is captcha-gated and still works when
+the RPC airdrop does not. Without the variable the tests fall back to `requestAirdrop`
+and fail on any wallet that holds no SOL.
 
 ---
 

--- a/apps/wallets/quickstart-devkit/tests/shared/utils/wallet.ts
+++ b/apps/wallets/quickstart-devkit/tests/shared/utils/wallet.ts
@@ -1,5 +1,13 @@
 import type { Page } from "@playwright/test";
-import { Connection, PublicKey, LAMPORTS_PER_SOL } from "@solana/web3.js";
+import {
+    Connection,
+    Keypair,
+    LAMPORTS_PER_SOL,
+    PublicKey,
+    SystemProgram,
+    Transaction,
+    sendAndConfirmTransaction,
+} from "@solana/web3.js";
 import { handleSignerConfirmation } from "./auth";
 import { AUTH_CONFIG } from "../constants/globalConstants";
 
@@ -56,14 +64,52 @@ const MIN_SOL_FOR_FEES = 0.003;
 // Since test wallets are reused across runs, a single successful airdrop keeps
 // the wallet funded for thousands of transfers.
 const AIRDROP_AMOUNTS_SOL = [5, 2, 1, 0.1];
+// Tops the wallet up well past MIN_SOL_FOR_FEES so a funded wallet needs no
+// further top-up for thousands of runs (a transfer costs ~0.0002 SOL).
+const FUNDER_TRANSFER_SOL = 0.05;
+
+/**
+ * Devnet keypair used to seed test wallets when the public faucet is exhausted.
+ * `SOLANA_DEVNET_FUNDER_SECRET_KEY` holds the 64-byte secret key as the JSON
+ * array `solana-keygen` writes, e.g. the contents of ~/.config/solana/id.json.
+ */
+function getFunderKeypair(): Keypair | null {
+    const rawSecretKey = process.env.SOLANA_DEVNET_FUNDER_SECRET_KEY;
+    if (!rawSecretKey) {
+        return null;
+    }
+    try {
+        return Keypair.fromSecretKey(Uint8Array.from(JSON.parse(rawSecretKey)));
+    } catch (error) {
+        console.warn("⚠️ SOLANA_DEVNET_FUNDER_SECRET_KEY is set but unusable, falling back to the faucet:", error);
+        return null;
+    }
+}
+
+async function transferSolFromFunder(connection: Connection, recipient: PublicKey, funder: Keypair): Promise<void> {
+    const lamports = Math.round(FUNDER_TRANSFER_SOL * LAMPORTS_PER_SOL);
+    const funderLamports = await connection.getBalance(funder.publicKey);
+    if (funderLamports < lamports) {
+        throw new Error(
+            `Devnet funder ${funder.publicKey.toBase58()} holds ${funderLamports / LAMPORTS_PER_SOL} SOL, ` +
+                `less than the ${FUNDER_TRANSFER_SOL} SOL transfer. Top it up at https://faucet.solana.com.`
+        );
+    }
+
+    const transaction = new Transaction().add(
+        SystemProgram.transfer({ fromPubkey: funder.publicKey, toPubkey: recipient, lamports })
+    );
+    await sendAndConfirmTransaction(connection, transaction, [funder], { commitment: "confirmed" });
+}
 
 /**
  * Ensures the wallet holds native SOL so it can pay transaction fees.
  * The Crossmint faucet only funds USDXM; without SOL the transfer tx is submitted
  * but never confirmed (silent on-chain failure due to insufficient fee balance).
  *
- * Skips the airdrop entirely when the (reused) wallet is already funded, so the
- * heavily rate-limited devnet faucet is only hit when strictly necessary.
+ * Skips funding entirely when the (reused) wallet is already funded. Prefers the
+ * funder keypair and keeps the public faucet as a fallback: `requestAirdrop` has
+ * been failing for every IP we tried, CI runners included.
  */
 export async function fundWalletWithSolAirdrop(walletAddress: string): Promise<void> {
     const connection = new Connection(SOLANA_DEVNET_RPC_URL, "confirmed");
@@ -76,6 +122,19 @@ export async function fundWalletWithSolAirdrop(walletAddress: string): Promise<v
     }
 
     let lastError: unknown;
+    const funder = getFunderKeypair();
+    if (funder) {
+        console.log(`💰 Transferring ${FUNDER_TRANSFER_SOL} SOL to ${walletAddress} from the devnet funder...`);
+        try {
+            await transferSolFromFunder(connection, publicKey, funder);
+            console.log(`✅ Funded ${walletAddress} with ${FUNDER_TRANSFER_SOL} SOL from the devnet funder`);
+            return;
+        } catch (error) {
+            lastError = error;
+            console.warn(`⚠️ Devnet funder transfer failed for ${walletAddress}, falling back to the faucet:`, error);
+        }
+    }
+
     for (const amountSol of AIRDROP_AMOUNTS_SOL) {
         console.log(`💰 Requesting SOL airdrop for ${walletAddress} (${amountSol} SOL)...`);
         try {
@@ -98,7 +157,10 @@ export async function fundWalletWithSolAirdrop(walletAddress: string): Promise<v
         return;
     }
 
-    console.error(`❌ All airdrop attempts failed for ${walletAddress} (balance: ${finalBalanceSol} SOL)`);
+    console.error(
+        `❌ Could not fund ${walletAddress} (balance: ${finalBalanceSol} SOL). ` +
+            "Set SOLANA_DEVNET_FUNDER_SECRET_KEY to a funded devnet keypair — the public faucet is exhausted from CI."
+    );
     throw lastError;
 }
 


### PR DESCRIPTION
## The suite has been failing daily, and silently

[Run 32343465121](https://github.com/Crossmint/crossmint-sdk/actions/runs/32343465121) reports **success**. The real results:

| Browser | Failed | Flaky | Did not run | Passed |
|---|---|---|---|---|
| chromium | 2 | 2 | 4 | 12 |
| firefox | 2 | 2 | 4 | 12 |
| webkit | 2 | 0 | 4 | 14 |

The test step ran `pnpm exec playwright test ... || true`, so the exit code never reached the job, and the Slack notifier's `MATRIX_RESULT: ${{ needs.e2e-regression-tests.result }}` was always `success`.

## Root cause: bootstrap, not supply

Live devnet balances for the six per-browser wallets:

```
2jeHeFwLtLKDYgreboXqW7hzVAkiyMk2p3FigCt2DxBY  999833680 lamports   (chromium solana-email)
7nLg9UNWsENkLKMagNCJF8JdacgSEMd7pt7BpRbcYuvr          0 lamports
Fp8ibSCjcacDNzdXEEKdwBWFKR9P3FgEwTCaKuGCEYe2          0 lamports
8mN5fovn2jb6tSCie3498HqCM6rzhqH2C4yYwMEAwre2          0 lamports
Gky2i4FiTTXpw8Nr7n6MtYqLZzNr3E93iGW9ZF2DbPtm          0 lamports
58SqgBatpEDRyhrbhaw4CTANzW7ywH4rKYEcGUs4ursp          0 lamports
```

Five wallets have **never** been funded. They were created by the `TESTS_WALLET_EMAIL_SUFFIX: e2e-${{ matrix.browser }}` identity scheme and never received an initial airdrop, because `requestAirdrop` against `api.devnet.solana.com` now fails from every IP tried — CI runners *and* a residential connection (`SolanaJSONRPCError: ... Internal error`, and `429 ... the airdrop faucet has run dry`).

The one funded wallet holds 0.99983368 SOL and has spent 166,320 lamports (~0.000166 SOL) in its entire life. That confirms the premise already written in `wallet.ts`: a wallet needs seeding **once**, not per run. So the answer is a funding source we own, used for bootstrap only.

## Alternatives considered

| Option | Verdict |
|---|---|
| Crossmint faucet dispenses SOL | **Closed.** `faucet.dto.ts` validates `z.literal(CryptoCurrency.USDXM)`, `FAUCET_SUPPORTED_SOLANA_TOKENS = ["usdxm"]`, and there is no native SOL treasury. |
| Paid RPC via `SOLANA_DEVNET_RPC_URL` | **Weak.** The variable already exists and is unset, but providers proxy the same exhausted faucet for `requestAirdrop`. Wired into the docs anyway. |
| Gas sponsorship (`fees: { mode: "project" }`) | **Best long term, out of scope here.** `solana-gas-sponsorship.e2e.test.ts` in crossbit-main proves a 0-SOL wallet can transact, but it needs project fee config plus an app change. Worth a follow-up — it would delete this helper entirely. |
| Our own devnet keypair | **This PR.** No rate limits, no product change, ~1 SOL covers thousands of runs. |

## Changes

- `fundWalletWithSolAirdrop` transfers `FUNDER_TRANSFER_SOL` from `SOLANA_DEVNET_FUNDER_SECRET_KEY` when set, and keeps the `requestAirdrop` ladder as fallback. Absent the variable, behaviour is byte-for-byte today's.
- Secret wired into the workflow; documented in `e2e/README.md` and `.env.template`.
- `|| true` replaced with an explicit `tests_exit_code` so a red suite fails its job, preserving the "no results file" discovery check that ran after it.

## Action required before this helps

Add a **`SOLANA_DEVNET_FUNDER_SECRET_KEY`** repository secret: the 64-byte secret key as the JSON array `solana-keygen` writes (the contents of `~/.config/solana/id.json`), for a devnet keypair topped up via [faucet.solana.com](https://faucet.solana.com) — the captcha-gated web faucet still works where the RPC does not.

Until then the suite fails as it does today, only visibly.

## Not fixed here

`chromium / solana - email › transfers funds` failed with **1 SOL and 19.97 USDXM in the wallet** — `Transaction did not start - transfer button is still enabled` (`wallet.ts:299`), then `Transaction timeout: Success link did not appear within 2 minutes` (`wallet.ts:302`). That is a UI/transaction failure independent of funding and needs its own investigation. `firefox / evm - email › transfers funds` also failed.

## Test plan

- [x] Keypair round-trips through the JSON-array env encoding (`Keypair.fromSecretKey(Uint8Array.from(JSON.parse(...)))`).
- [x] The transfer instruction builds and signs against devnet (215-byte tx).
- [x] `requestAirdrop` confirmed failing from a non-CI IP, ruling out an IP-reputation fix.
- [x] Reworked run block verified for all three cases: tests pass → exit 0, tests fail → exit 1, no results file → error annotation + exit 1.
- [x] `tsc --strict` clean on the modified helper.
- [x] Backward compatible with the secret absent: the smoke suite (which shares this helper) passed 5/5 on this branch — `getFunderKeypair()` returns `null` and the old airdrop path runs unchanged.
- [ ] Add the secret, then `workflow_dispatch` the suite and confirm the five wallets get seeded.
