### PR TITLE
feat(wallets): sign arbitrary payloads with Solana email/phone signers (WAL-11952)

### DIFF
--- a/.changeset/solana-ncs-sign-message.md
+++ b/.changeset/solana-ncs-sign-message.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": minor
+---
+
+Solana email/phone signers can now sign arbitrary payloads: `SolanaNonCustodialSigner.signMessage(base58Payload)` returns a raw Ed25519 signature instead of rejecting.

--- a/packages/wallets/src/signers/non-custodial/ncs-solana-signer.test.ts
+++ b/packages/wallets/src/signers/non-custodial/ncs-solana-signer.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test, vi } from "vitest";
+import base58 from "bs58";
+import { Keypair, SystemProgram, TransactionMessage, VersionedTransaction } from "@solana/web3.js";
+
+import type { EmailInternalSignerConfig } from "../types";
+import { SolanaNonCustodialSigner } from "./ncs-solana-signer";
+
+const SIGNER_KEYPAIR = Keypair.generate();
+
+function makeSigner() {
+    const sendAction = vi.fn(async (args: { event: string }) => {
+        if (args.event === "request:get-status") {
+            return { status: "success", signerStatus: "ready" };
+        }
+        return {
+            status: "success",
+            signature: { bytes: "signature-bytes", encoding: "base58", keyType: "ed25519" },
+            publicKey: {
+                bytes: SIGNER_KEYPAIR.publicKey.toBase58(),
+                encoding: "base58",
+                keyType: "ed25519",
+            },
+        };
+    });
+    const config = {
+        type: "email",
+        email: "test@example.com",
+        locator: "email:test@example.com",
+        address: SIGNER_KEYPAIR.publicKey.toBase58(),
+        crossmint: { apiKey: "ck_staging_test", jwt: "test-jwt" },
+        clientTEEConnection: { sendAction },
+        onAuthRequired: vi.fn(async () => {}),
+    } as unknown as EmailInternalSignerConfig;
+
+    return { signer: new SolanaNonCustodialSigner(config), sendAction };
+}
+
+function signedBytes(sendAction: ReturnType<typeof makeSigner>["sendAction"]) {
+    const signCall = sendAction.mock.calls.find(([args]) => args.event === "request:sign");
+    if (signCall == null) {
+        throw new Error("No sign request was sent to the signer");
+    }
+    return (signCall[0] as unknown as { data: { data: { bytes: string } } }).data.data.bytes;
+}
+
+function makeTransaction() {
+    const message = new TransactionMessage({
+        payerKey: SIGNER_KEYPAIR.publicKey,
+        recentBlockhash: Keypair.generate().publicKey.toBase58(),
+        instructions: [
+            SystemProgram.transfer({
+                fromPubkey: SIGNER_KEYPAIR.publicKey,
+                toPubkey: Keypair.generate().publicKey,
+                lamports: 1,
+            }),
+        ],
+    }).compileToV0Message();
+    return new VersionedTransaction(message);
+}
+
+describe("SolanaNonCustodialSigner.signMessage", () => {
+    test("signs the payload bytes verbatim, without transaction deserialization", async () => {
+        // A canonical app payload: arbitrary bytes that are not a valid Solana transaction.
+        const payload = base58.encode(new Uint8Array(91).fill(7));
+        const { signer, sendAction } = makeSigner();
+
+        const result = await signer.signMessage(payload);
+
+        expect(result).toEqual({ signature: "signature-bytes" });
+        expect(signedBytes(sendAction)).toBe(payload);
+    });
+});
+
+describe("SolanaNonCustodialSigner.signTransaction", () => {
+    test("signs the serialized transaction message rather than the full transaction", async () => {
+        const transaction = makeTransaction();
+        const { signer, sendAction } = makeSigner();
+
+        const result = await signer.signTransaction(base58.encode(transaction.serialize()));
+
+        expect(result).toEqual({ signature: "signature-bytes" });
+        expect(signedBytes(sendAction)).toBe(base58.encode(transaction.message.serialize()));
+    });
+});

--- a/packages/wallets/src/signers/non-custodial/ncs-solana-signer.ts
+++ b/packages/wallets/src/signers/non-custodial/ncs-solana-signer.ts
@@ -9,17 +9,23 @@ export class SolanaNonCustodialSigner extends NonCustodialSigner {
         super(config);
     }
 
-    async signMessage() {
-        return await Promise.reject(new Error("signMessage method not implemented for email signer"));
+    /**
+     * Produce a raw Ed25519 signature over an arbitrary payload.
+     * @param message - The payload to sign, base58 encoded
+     */
+    async signMessage(message: string): Promise<{ signature: string }> {
+        return await this.sign(base58.decode(message));
     }
 
     async signTransaction(transaction: string): Promise<{ signature: string }> {
-        await this.handleAuthRequired();
-        const jwt = this.getJwtOrThrow();
-
         const transactionBytes = base58.decode(transaction);
         const deserializedTransaction = VersionedTransaction.deserialize(transactionBytes);
-        const messageData = deserializedTransaction.message.serialize();
+        return await this.sign(deserializedTransaction.message.serialize());
+    }
+
+    private async sign(messageData: Uint8Array): Promise<{ signature: string }> {
+        await this.handleAuthRequired();
+        const jwt = this.getJwtOrThrow();
 
         walletsLogger.info("sign: sending request", { keyType: "ed25519" });
         const startTime = Date.now();
@@ -49,7 +55,7 @@ export class SolanaNonCustodialSigner extends NonCustodialSigner {
         }
 
         if (res?.signature == null) {
-            throw new Error("Failed to sign transaction");
+            throw new Error("Failed to sign payload");
         }
         SolanaNonCustodialSigner.verifyPublicKeyFormat(res.publicKey);
         return { signature: res.signature.bytes };


### PR DESCRIPTION
## Description

[WAL-11952](https://linear.app/crossmint/issue/WAL-11952/signmessage-stubbed-out-for-solana-email-signers): apps need a raw Ed25519 signature from a signer of a Solana smart wallet (verified on-chain with the Ed25519 precompile), and `SolanaNonCustodialSigner.signMessage()` rejected outright.

The TEE `request:sign` primitive is already generic and already Ed25519 — `signTransaction()` only deserializes the transaction to pick the message bytes before handing them over. So this splits that step out instead of adding a signing capability:

```
signMessage(base58Payload)     -> sign(base58.decode(payload))
signTransaction(base58Tx)      -> sign(VersionedTransaction.deserialize(tx).message.serialize())
sign(bytes)                    -> handleAuthRequired() + TEE request:sign { keyType: "ed25519", encoding: "base58" }
```

Input/output encoding matches the already-implemented `SolanaServerSigner.signMessage()` (base58 in, base58 signature out), so both Solana signer flavors are now interchangeable for this use case. Nothing else changes: no API surface (`/signatures` still rejects `type: "message"` for `solana-smart-wallet`), and `Wallet.approveSignature` remains EVM-only via `chainAdapter.supportsSignatures`, so no approval path starts routing through the new method.

Consumers reach it through the already-public `wallet.signer` (`wallet.signer.signMessage(payload)`), and the signer's Ed25519 pubkey — needed to check the signer against the wallet on-chain — is available from `wallet.signers()` as the email/phone signer's `address`. Stellar non-custodial signers still reject.

## Test plan

* Unit tests in `ncs-solana-signer.test.ts`: a 91-byte payload that is *not* a valid transaction reaches the TEE verbatim, and `signTransaction` still signs the serialized transaction message (i.e. the split preserved the transaction path).
* Not exercised end-to-end against a real TEE/email signer.

## Package updates

* `@crossmint/wallets-sdk`: minor — changeset added.


Link to Devin session: https://crossmint.devinenterprise.com/sessions/6863854835a744aab9481705a95bf4d7
Open in Devin Desktop: https://crossmint.devinenterprise.com/desktop/session/6863854835a744aab9481705a95bf4d7?variant=devin
Requested by: @alberto-crossmint