### PR TITLE
fix(wallets): reject passkey assertions without user verification

### DIFF
--- a/.changeset/passkey-user-verification-guard.md
+++ b/.changeset/passkey-user-verification-guard.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+Reject passkey assertions returned by a custom `onSignWithPasskey` handler when the WebAuthn user verification flag is unset, since the on-chain verifier requires it and the bundler would reject the transaction with an opaque AA24 signature error.

--- a/packages/wallets/src/signers/passkey.test.ts
+++ b/packages/wallets/src/signers/passkey.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import type { PasskeyInternalSignerConfig, PasskeySignResult } from "./types";
+import { PasskeySigner } from "./passkey";
+
+const RP_ID_HASH = "8ce59ed7bf9a179c701898023a4171cc52c0b15a91cfda0defb35609c06a5904";
+
+function signResult(flags: string): PasskeySignResult {
+    return {
+        signature: { r: "0x1", s: "0x2" },
+        metadata: {
+            authenticatorData: `0x${RP_ID_HASH}${flags}00000000`,
+            challengeIndex: 23,
+            clientDataJSON: '{"type":"webauthn.get","challenge":"abc"}',
+            typeIndex: 1,
+            userVerificationRequired: false,
+        },
+    };
+}
+
+function signerWithCallback(result: PasskeySignResult): PasskeySigner {
+    return new PasskeySigner({
+        type: "passkey",
+        id: "credential-id",
+        locator: "evm-passkey:credential-id",
+        onSignWithPasskey: async () => result,
+    } as PasskeyInternalSignerConfig);
+}
+
+describe("PasskeySigner", () => {
+    describe("when the onSignWithPasskey callback returns a user-verified assertion", () => {
+        it("returns it unchanged", async () => {
+            const result = signResult("1d");
+
+            await expect(signerWithCallback(result).signMessage("0xdeadbeef")).resolves.toEqual(result);
+        });
+    });
+
+    describe("when the onSignWithPasskey callback returns an assertion without user verification", () => {
+        it("throws so the caller does not submit a signature the on-chain verifier rejects", async () => {
+            await expect(signerWithCallback(signResult("19")).signMessage("0xdeadbeef")).rejects.toThrow(
+                "without user verification"
+            );
+        });
+    });
+});

--- a/packages/wallets/src/signers/passkey.ts
+++ b/packages/wallets/src/signers/passkey.ts
@@ -1,5 +1,24 @@
-import { WebAuthnP256 } from "ox";
+import { Hex, WebAuthnP256 } from "ox";
+import { SigningFailedError } from "../utils/errors";
 import type { PasskeyInternalSignerConfig, PasskeySignResult, PasskeySignerLocator, SignerAdapter } from "./types";
+
+const AUTHENTICATOR_DATA_MIN_BYTE_LENGTH = 37;
+const AUTHENTICATOR_DATA_FLAGS_OFFSET = 32;
+const AUTHENTICATOR_DATA_FLAG_USER_VERIFIED = 0x04;
+
+/**
+ * The on-chain WebAuthn verifier requires user verification, so an assertion whose UV flag is unset
+ * is rejected by the bundler as an AA24 signature error. Some credential providers return UV-less
+ * assertions (e.g. 1Password's iOS AutoFill path inside a webview) unless the assertion is
+ * requested with `userVerification: "required"`.
+ */
+function isUserVerified(authenticatorData: Hex.Hex): boolean {
+    const bytes = Hex.toBytes(authenticatorData);
+    if (bytes.length < AUTHENTICATOR_DATA_MIN_BYTE_LENGTH) {
+        return false;
+    }
+    return (bytes[AUTHENTICATOR_DATA_FLAGS_OFFSET] & AUTHENTICATOR_DATA_FLAG_USER_VERIFIED) !== 0;
+}
 
 export class PasskeySigner implements SignerAdapter {
     type = "passkey" as const;
@@ -15,7 +34,13 @@ export class PasskeySigner implements SignerAdapter {
 
     async signMessage(message: string): Promise<PasskeySignResult> {
         if (this.config.onSignWithPasskey) {
-            return await this.config.onSignWithPasskey(message);
+            const result = await this.config.onSignWithPasskey(message);
+            if (!isUserVerified(result.metadata.authenticatorData)) {
+                throw new SigningFailedError(
+                    'The passkey assertion was created without user verification, and the on-chain verifier requires it. Request the assertion with `userVerification: "required"` so the authenticator prompts for biometrics or a PIN.'
+                );
+            }
+            return result;
         }
         const { signature, metadata } = await WebAuthnP256.sign({
             credentialId: this.id,


### PR DESCRIPTION
## Description

Cacao (Ruvo) hit 31 `AA24 signature error` bundler rejections on delegated-passkey transactions. The failing assertions are cryptographically valid but have the WebAuthn UV flag unset (`authenticatorData` flags `0x19`), while every success has it set (`0x1d`); ZeroDev's deployed WebAuthn signer/validator require user verification, so a UV-less assertion can never validate on-chain. The reporter's matrix (1Password inside the iOS app fails, Apple Passwords and 1Password on desktop Chrome succeed) matches providers that return UV-less assertions unless the assertion is requested with `userVerification: "required"`.

`WebAuthnP256.sign` already defaults to `userVerification: "required"`, so the built-in path is unaffected. Hosts that supply their own `onSignWithPasskey` (native/Flutter wrappers) can return a UV-less assertion, and today we hand it to the API and surface an opaque AA24 much later. This checks the flag on the callback's result and fails fast with an actionable message instead.

## Test plan

-   Unit tests for `PasskeySigner.signMessage` covering the callback path: a UV-set assertion (`0x1d`) is returned unchanged, and a UV-less assertion (`0x19` — the flags observed in the production failures) throws.
-   `npx vitest run src/signers/passkey.test.ts` in `packages/wallets`: 2 passed.
-   `pnpm lint` at the repo root passes.

## Package updates

-   `@crossmint/wallets-sdk`: patch (changeset added).


Link to Devin session: https://crossmint.devinenterprise.com/sessions/452061088c1546a987b3cd538e79bcd3
Open in Devin Desktop: https://crossmint.devinenterprise.com/desktop/session/452061088c1546a987b3cd538e79bcd3?variant=devin
Requested by: @maxsch-xmint