### PR TITLE
feat(wallets): accept a list of recovery signers on Solana and Stellar

### DIFF
--- a/.changeset/recovery-signer-list.md
+++ b/.changeset/recovery-signer-list.md
@@ -1,0 +1,7 @@
+---
+"@crossmint/wallets-sdk": minor
+"@crossmint/client-sdk-react-base": patch
+"@crossmint/client-sdk-react-native-ui": patch
+---
+
+Solana and Stellar wallets can now be created with up to 10 recovery signers: `recovery` accepts a list, each entry resolved (passkey creation, server signer derivation) on its own, and `wallet.recoverySigners` exposes all of them. EVM still takes a single recovery signer.

--- a/packages/client/react-base/src/providers/CrossmintWalletBaseProvider.tsx
+++ b/packages/client/react-base/src/providers/CrossmintWalletBaseProvider.tsx
@@ -4,7 +4,7 @@ import {
     CrossmintWallets,
     type Callbacks,
     type ClientSideWalletCreateArgs,
-    type SignerConfigForChain,
+    type RecoverySignerConfigForChain,
     type Wallet,
     type ClientSideWalletArgsFor,
     type WalletCreateArgs,
@@ -13,6 +13,7 @@ import {
     type RegisterSignerPasskeyParams,
     WalletNotAvailableError,
     type DeviceSignerConfig,
+    toRecoverySignerList,
 } from "@crossmint/wallets-sdk";
 import type { HandshakeParent } from "@crossmint/client-sdk-window";
 import type { signerInboundEvents, signerOutboundEvents } from "@crossmint/client-signers";
@@ -229,13 +230,16 @@ export function CrossmintWalletBaseProvider({
         let onWalletCreationStart = callbacks?.onWalletCreationStart;
         let onTransactionStart = callbacks?.onTransactionStart;
 
-        if (createOnLogin?.recovery?.type === "passkey" && showPasskeyHelpers) {
+        const hasPasskeyRecoverySigner = toRecoverySignerList(createOnLogin?.recovery).some(
+            (s) => s.type === "passkey"
+        );
+        if (hasPasskeyRecoverySigner && showPasskeyHelpers) {
             onWalletCreationStart = createPasskeyPrompt("create-wallet");
             onTransactionStart = createPasskeyPrompt("transaction");
         }
 
         return { onWalletCreationStart, onTransactionStart };
-    }, [callbacks, createOnLogin?.recovery?.type, showPasskeyHelpers, createPasskeyPrompt]);
+    }, [callbacks, createOnLogin?.recovery, showPasskeyHelpers, createPasskeyPrompt]);
 
     const wrappedOnAuthRequired = useCallback(
         async (
@@ -259,8 +263,8 @@ export function CrossmintWalletBaseProvider({
     );
 
     const initializeWebViewIfNeeded = useCallback(
-        async (signer: SignerConfigForChain<Chain>) => {
-            if (signer.type === "email" || signer.type === "phone") {
+        async (signers: Array<RecoverySignerConfigForChain<Chain>>) => {
+            if (signers.some((signer) => signer.type === "email" || signer.type === "phone")) {
                 await initializeWebView?.();
             }
         },
@@ -304,7 +308,7 @@ export function CrossmintWalletBaseProvider({
                 setWalletError(null);
                 const wallets = CrossmintWallets.from(crossmint);
 
-                await initializeWebViewIfNeeded(args.recovery);
+                await initializeWebViewIfNeeded(toRecoverySignerList(args.recovery));
 
                 const walletOptions = buildWalletOptions(args.options);
 
@@ -398,7 +402,7 @@ export function CrossmintWalletBaseProvider({
                 setWalletError(null);
                 const wallets = CrossmintWallets.from(crossmint);
 
-                await initializeWebViewIfNeeded(args.recovery);
+                await initializeWebViewIfNeeded(toRecoverySignerList(args.recovery));
 
                 const wallet = await wallets.createWallet<C>({
                     ...args,
@@ -448,8 +452,9 @@ export function CrossmintWalletBaseProvider({
         }
 
         // Check if any email signer (in recovery or signers array) is missing its email value
+        const recoverySigners = toRecoverySignerList(createOnLogin.recovery);
         const hasEmailSignerNeedingPopulation =
-            (createOnLogin.recovery?.type === "email" && createOnLogin.recovery.email == null) ||
+            recoverySigners.some((s) => s.type === "email" && s.email == null) ||
             (createOnLogin.signers?.some((s) => s.type === "email" && s.email == null) ?? false);
 
         if (hasEmailSignerNeedingPopulation) {
@@ -468,10 +473,13 @@ export function CrossmintWalletBaseProvider({
             const userEmail = authBaseContext.user.email;
             const processed = { ...createOnLogin };
 
-            // Populate email on recovery signer if needed
-            if (processed.recovery?.type === "email" && processed.recovery.email == null) {
-                processed.recovery = { ...processed.recovery, email: userEmail };
-            }
+            // Populate email on every recovery signer that needs it
+            const populatedRecoverySigners = recoverySigners.map((s) =>
+                s.type === "email" && s.email == null ? { ...s, email: userEmail } : s
+            );
+            processed.recovery = (
+                Array.isArray(processed.recovery) ? populatedRecoverySigners : populatedRecoverySigners[0]
+            ) as typeof processed.recovery;
 
             // Populate email on each signer in the signers array if needed
             if (processed.signers != null) {
@@ -495,7 +503,7 @@ export function CrossmintWalletBaseProvider({
         if (processedCreateOnLogin != null) {
             // Guard: don't attempt wallet creation if required signer fields are still missing.
             const { recovery, signers } = processedCreateOnLogin;
-            if (recovery?.type === "external-wallet" && recovery.address == null) {
+            if (toRecoverySignerList(recovery).some((s) => s.type === "external-wallet" && s.address == null)) {
                 return;
             }
             if (signers?.some((s) => s.type === "external-wallet" && s.address == null)) {

--- a/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
+++ b/packages/client/ui/react-native/src/providers/CrossmintWalletProvider.tsx
@@ -17,7 +17,7 @@ import {
     type CreateOnLogin,
     useCrossmint,
 } from "@crossmint/client-sdk-react-base";
-import type { DeviceSignerKeyStorage } from "@crossmint/wallets-sdk";
+import { type DeviceSignerKeyStorage, toRecoverySignerList } from "@crossmint/wallets-sdk";
 import { createDeviceSignerKeyStorage } from "@/native/createDeviceSignerKeyStorage";
 
 import { EmailSignersDialog } from "@/components/signers/EmailSignersDialog";
@@ -64,7 +64,7 @@ function hasPasskeySigner(config?: CreateOnLogin): boolean {
     if (config == null) {
         return false;
     }
-    if (config.recovery?.type === "passkey") {
+    if (toRecoverySignerList(config.recovery).some((s) => s.type === "passkey")) {
         return true;
     }
     if (config.signers?.some((s) => s.type === "passkey")) {
@@ -83,7 +83,10 @@ function PasskeyGuard({ children }: { children: ReactNode }) {
 
     const guardedCreateWallet: typeof baseContext.createWallet = useCallback(
         async (args) => {
-            if (args.recovery?.type === "passkey" || args.signers?.some((s) => s.type === "passkey")) {
+            if (
+                toRecoverySignerList(args.recovery).some((s) => s.type === "passkey") ||
+                args.signers?.some((s) => s.type === "passkey")
+            ) {
                 throw new Error(PASSKEY_RN_ERROR);
             }
             return baseContext.createWallet(args);

--- a/packages/client/ui/react-ui/README.md
+++ b/packages/client/ui/react-ui/README.md
@@ -127,6 +127,17 @@ When `createOnLogin` is set on `CrossmintWalletProvider`, a wallet is automatica
 >
 ```
 
+On Solana and Stellar, `recovery` also accepts a list of up to 10 signers, each able to recover the wallet on its own. EVM chains take a single recovery signer:
+
+```tsx
+<CrossmintWalletProvider
+  createOnLogin={{
+    chain: "solana",
+    recovery: [{ type: "email" }, { type: "external-wallet", address: "9WzD..." }],
+  }}
+>
+```
+
 ## Hooks
 
 ### `useWallet()`

--- a/packages/wallets/src/api/types.ts
+++ b/packages/wallets/src/api/types.ts
@@ -42,6 +42,17 @@ export type RecoverySignerConfig = NonNullable<
     Extract<CreateWalletV2025DtoClass, { config: { adminSigner: Record<string, unknown> } }>["config"]
 >["adminSigner"];
 
+/**
+ * Recovery signers accepted by the wallet-creation API under `config.recovery`. Only the chains
+ * whose backend DTO takes a list (Solana, Stellar) are extracted here; EVM still takes a single
+ * signer, so it keeps using {@link RecoverySignerConfig}.
+ */
+export type RecoverySignerListConfig = NonNullable<
+    NonNullable<
+        Extract<CreateWalletV2025DtoClass, { chainType: "solana" | "stellar"; config: object }>["config"]
+    >["recovery"]
+>;
+
 export type CreateTransactionParams = CreateTransactionV2025DtoClass;
 export type CreateTransactionSuccessResponse = WalletsTransactionV2025ResponseDtoClass;
 export type CreateTransactionResponse = CreateTransactionSuccessResponse | WalletV1Alpha2TransactionErrorDto;

--- a/packages/wallets/src/index.ts
+++ b/packages/wallets/src/index.ts
@@ -1,8 +1,20 @@
 // SDK
 export { createCrossmint, CrossmintWallets } from "./sdk";
 
+// Recovery signers
+export { toRecoverySignerList } from "./utils/recovery";
+
 // Errors
 export {
+    MAX_RECOVERY_SIGNERS,
+    DuplicateRecoverySignerError,
+    InvalidRecoveryConfigError,
+    NotSupportedOnApiVersionError,
+    RecoveryAdminSignerConflictError,
+    RecoveryNotSupportedOnChainError,
+    RecoverySignerConflictError,
+    RecoverySignerLimitExceededError,
+    SignerRequiredError,
     WalletNotAvailableError,
     InvalidTransferAmountError,
     QuorumSignerNotSupportedError,
@@ -66,6 +78,7 @@ export type {
     ExternalWalletSignerConfigForChain,
     ServerSignerConfig,
     SignerConfigForChain,
+    RecoverySignerConfigForChain,
     SignerLocator,
     EmailSignerLocator,
     PhoneSignerLocator,

--- a/packages/wallets/src/openapi.json
+++ b/packages/wallets/src/openapi.json
@@ -30941,258 +30941,263 @@
                                         ]
                                     },
                                     "recovery": {
-                                        "description": "The recovery configuration (admin signer) for the wallet. Mutually exclusive with `adminSigner`.",
-                                        "oneOf": [
-                                            {
-                                                "type": "object",
-                                                "properties": {
-                                                    "type": {
-                                                        "type": "string",
-                                                        "description": "Identifier for external wallet signer type",
-                                                        "enum": ["external-wallet"]
-                                                    },
-                                                    "address": {
-                                                        "type": "string",
-                                                        "description": "The blockchain address of the external wallet"
-                                                    }
-                                                },
-                                                "required": ["type", "address"],
-                                                "description": "An external wallet that can be used to sign transactions",
-                                                "title": "External Wallet Signer",
-                                                "example": {
-                                                    "type": "external-wallet",
-                                                    "address": "0x1234567890123456789012345678901234567890"
-                                                }
-                                            },
-                                            {
-                                                "type": "object",
-                                                "properties": {
-                                                    "type": {
-                                                        "type": "string",
-                                                        "description": "Identifier for server signer type",
-                                                        "enum": ["server"]
-                                                    },
-                                                    "address": {
-                                                        "type": "string",
-                                                        "description": "The blockchain address of the server signer"
-                                                    }
-                                                },
-                                                "required": ["type", "address"],
-                                                "description": "A server-managed blockchain signer",
-                                                "title": "Server Signer",
-                                                "example": {
-                                                    "type": "server",
-                                                    "address": "0x1234567890123456789012345678901234567890"
-                                                }
-                                            },
-                                            {
-                                                "type": "object",
-                                                "properties": {
-                                                    "type": {
-                                                        "type": "string",
-                                                        "description": "Identifier for API key signer type",
-                                                        "enum": ["api-key"]
-                                                    }
-                                                },
-                                                "required": ["type"],
-                                                "description": "A custodial signer provided by Crossmint and backed by our secure infrastructure. Contact sales (https://www.crossmint.com/contact/sales) for access.",
-                                                "title": "API Key Signer",
-                                                "example": {
-                                                    "type": "api-key"
-                                                }
-                                            },
-                                            {
-                                                "type": "object",
-                                                "properties": {
-                                                    "type": {
-                                                        "type": "string",
-                                                        "description": "Identifier for email signer type",
-                                                        "enum": ["email"]
-                                                    },
-                                                    "email": {
-                                                        "description": "The email address for the signer",
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                "required": ["type", "email"],
-                                                "description": "An email-based signer that can be used to sign transactions",
-                                                "title": "Email Signer"
-                                            },
-                                            {
-                                                "type": "object",
-                                                "properties": {
-                                                    "type": {
-                                                        "type": "string",
-                                                        "description": "Identifier for phone signer type",
-                                                        "enum": ["phone"]
-                                                    },
-                                                    "phone": {
-                                                        "type": "string",
-                                                        "description": "The phone number for the signer in E164 format"
-                                                    }
-                                                },
-                                                "required": ["type", "phone"],
-                                                "description": "An phone-based signer that can be used to sign transactions",
-                                                "title": "Phone Signer",
-                                                "example": {
-                                                    "type": "phone",
-                                                    "phone": "+1234567890"
-                                                }
-                                            },
-                                            {
-                                                "type": "object",
-                                                "properties": {
-                                                    "type": {
-                                                        "type": "string",
-                                                        "description": "Identifier for quorum (multisig) signer type",
-                                                        "enum": ["quorum"]
-                                                    },
-                                                    "threshold": {
-                                                        "default": 1,
-                                                        "description": "The minimum number of member signatures required to approve. Defaults to 1.",
-                                                        "type": "integer",
-                                                        "minimum": 1,
-                                                        "maximum": 9007199254740991
-                                                    },
-                                                    "signers": {
-                                                        "type": "array",
-                                                        "items": {
-                                                            "oneOf": [
-                                                                {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "type": {
-                                                                            "type": "string",
-                                                                            "description": "Identifier for the Passkey signer type",
-                                                                            "enum": ["passkey"]
-                                                                        },
-                                                                        "id": {
-                                                                            "type": "string",
-                                                                            "description": "Credential ID from the WebAuthn registration response"
-                                                                        },
-                                                                        "name": {
-                                                                            "type": "string",
-                                                                            "description": "Human-readable name for the passkey"
-                                                                        },
-                                                                        "publicKey": {
-                                                                            "type": "object",
-                                                                            "properties": {
-                                                                                "x": {
-                                                                                    "type": "string",
-                                                                                    "description": "S component of the signature as a stringified bigint"
-                                                                                },
-                                                                                "y": {
-                                                                                    "type": "string",
-                                                                                    "description": "S component of the signature as a stringified bigint"
-                                                                                }
-                                                                            },
-                                                                            "required": ["x", "y"],
-                                                                            "description": "The public key coordinates from the WebAuthn credential"
-                                                                        }
-                                                                    },
-                                                                    "required": ["type", "id", "name", "publicKey"],
-                                                                    "description": "Configuration for a WebAuthn/Passkey signer that uses public key credentials for authentication",
-                                                                    "title": "Passkey Signer",
-                                                                    "example": {
-                                                                        "type": "passkey",
-                                                                        "id": "cWtP7gmZbd98HbKUuGXx5Q",
-                                                                        "name": "hgranger",
-                                                                        "publicKey": {
-                                                                            "x": "38035223810536273945556366218149112558607829411547667975304293530457502824247",
-                                                                            "y": "91117823763706733837104303008228095481082989039135234750508288790583476078729"
-                                                                        }
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "type": {
-                                                                            "type": "string",
-                                                                            "description": "Identifier for external wallet signer type",
-                                                                            "enum": ["external-wallet"]
-                                                                        },
-                                                                        "address": {
-                                                                            "type": "string",
-                                                                            "description": "The blockchain address of the external wallet"
-                                                                        }
-                                                                    },
-                                                                    "required": ["type", "address"],
-                                                                    "description": "An external wallet that can be used to sign transactions",
-                                                                    "title": "External Wallet Signer",
-                                                                    "example": {
-                                                                        "type": "external-wallet",
-                                                                        "address": "0x1234567890123456789012345678901234567890"
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "type": {
-                                                                            "type": "string",
-                                                                            "description": "Identifier for server signer type",
-                                                                            "enum": ["server"]
-                                                                        },
-                                                                        "address": {
-                                                                            "type": "string",
-                                                                            "description": "The blockchain address of the server signer"
-                                                                        }
-                                                                    },
-                                                                    "required": ["type", "address"],
-                                                                    "description": "A server-managed blockchain signer",
-                                                                    "title": "Server Signer",
-                                                                    "example": {
-                                                                        "type": "server",
-                                                                        "address": "0x1234567890123456789012345678901234567890"
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "type": {
-                                                                            "type": "string",
-                                                                            "description": "Identifier for email signer type",
-                                                                            "enum": ["email"]
-                                                                        },
-                                                                        "email": {
-                                                                            "description": "The email address for the signer",
-                                                                            "type": "string"
-                                                                        }
-                                                                    },
-                                                                    "required": ["type", "email"],
-                                                                    "description": "An email-based signer that can be used to sign transactions",
-                                                                    "title": "Email Signer"
-                                                                },
-                                                                {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "type": {
-                                                                            "type": "string",
-                                                                            "description": "Identifier for phone signer type",
-                                                                            "enum": ["phone"]
-                                                                        },
-                                                                        "phone": {
-                                                                            "type": "string",
-                                                                            "description": "The phone number for the signer in E164 format"
-                                                                        }
-                                                                    },
-                                                                    "required": ["type", "phone"],
-                                                                    "description": "An phone-based signer that can be used to sign transactions",
-                                                                    "title": "Phone Signer",
-                                                                    "example": {
-                                                                        "type": "phone",
-                                                                        "phone": "+1234567890"
-                                                                    }
-                                                                }
-                                                            ]
+                                        "type": "array",
+                                        "items": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Identifier for external wallet signer type",
+                                                            "enum": ["external-wallet"]
                                                         },
-                                                        "description": "The member signers that make up the quorum (1-10 members, no duplicates). Nested quorums are not allowed."
+                                                        "address": {
+                                                            "type": "string",
+                                                            "description": "The blockchain address of the external wallet"
+                                                        }
+                                                    },
+                                                    "required": ["type", "address"],
+                                                    "description": "An external wallet that can be used to sign transactions",
+                                                    "title": "External Wallet Signer",
+                                                    "example": {
+                                                        "type": "external-wallet",
+                                                        "address": "0x1234567890123456789012345678901234567890"
                                                     }
                                                 },
-                                                "required": ["type", "signers"],
-                                                "description": "A quorum (multisig) signer composed of multiple member signers with an approval threshold",
-                                                "title": "Quorum Signer"
-                                            }
-                                        ]
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Identifier for server signer type",
+                                                            "enum": ["server"]
+                                                        },
+                                                        "address": {
+                                                            "type": "string",
+                                                            "description": "The blockchain address of the server signer"
+                                                        }
+                                                    },
+                                                    "required": ["type", "address"],
+                                                    "description": "A server-managed blockchain signer",
+                                                    "title": "Server Signer",
+                                                    "example": {
+                                                        "type": "server",
+                                                        "address": "0x1234567890123456789012345678901234567890"
+                                                    }
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Identifier for API key signer type",
+                                                            "enum": ["api-key"]
+                                                        }
+                                                    },
+                                                    "required": ["type"],
+                                                    "description": "A custodial signer provided by Crossmint and backed by our secure infrastructure. Contact sales (https://www.crossmint.com/contact/sales) for access.",
+                                                    "title": "API Key Signer",
+                                                    "example": {
+                                                        "type": "api-key"
+                                                    }
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Identifier for email signer type",
+                                                            "enum": ["email"]
+                                                        },
+                                                        "email": {
+                                                            "description": "The email address for the signer",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["type", "email"],
+                                                    "description": "An email-based signer that can be used to sign transactions",
+                                                    "title": "Email Signer"
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Identifier for phone signer type",
+                                                            "enum": ["phone"]
+                                                        },
+                                                        "phone": {
+                                                            "type": "string",
+                                                            "description": "The phone number for the signer in E164 format"
+                                                        }
+                                                    },
+                                                    "required": ["type", "phone"],
+                                                    "description": "An phone-based signer that can be used to sign transactions",
+                                                    "title": "Phone Signer",
+                                                    "example": {
+                                                        "type": "phone",
+                                                        "phone": "+1234567890"
+                                                    }
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Identifier for quorum (multisig) signer type",
+                                                            "enum": ["quorum"]
+                                                        },
+                                                        "threshold": {
+                                                            "default": 1,
+                                                            "description": "The minimum number of member signatures required to approve. Defaults to 1.",
+                                                            "type": "integer",
+                                                            "minimum": 1,
+                                                            "maximum": 9007199254740991
+                                                        },
+                                                        "signers": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "description": "Identifier for the Passkey signer type",
+                                                                                "enum": ["passkey"]
+                                                                            },
+                                                                            "id": {
+                                                                                "type": "string",
+                                                                                "description": "Credential ID from the WebAuthn registration response"
+                                                                            },
+                                                                            "name": {
+                                                                                "type": "string",
+                                                                                "description": "Human-readable name for the passkey"
+                                                                            },
+                                                                            "publicKey": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "x": {
+                                                                                        "type": "string",
+                                                                                        "description": "S component of the signature as a stringified bigint"
+                                                                                    },
+                                                                                    "y": {
+                                                                                        "type": "string",
+                                                                                        "description": "S component of the signature as a stringified bigint"
+                                                                                    }
+                                                                                },
+                                                                                "required": ["x", "y"],
+                                                                                "description": "The public key coordinates from the WebAuthn credential"
+                                                                            }
+                                                                        },
+                                                                        "required": ["type", "id", "name", "publicKey"],
+                                                                        "description": "Configuration for a WebAuthn/Passkey signer that uses public key credentials for authentication",
+                                                                        "title": "Passkey Signer",
+                                                                        "example": {
+                                                                            "type": "passkey",
+                                                                            "id": "cWtP7gmZbd98HbKUuGXx5Q",
+                                                                            "name": "hgranger",
+                                                                            "publicKey": {
+                                                                                "x": "38035223810536273945556366218149112558607829411547667975304293530457502824247",
+                                                                                "y": "91117823763706733837104303008228095481082989039135234750508288790583476078729"
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "description": "Identifier for external wallet signer type",
+                                                                                "enum": ["external-wallet"]
+                                                                            },
+                                                                            "address": {
+                                                                                "type": "string",
+                                                                                "description": "The blockchain address of the external wallet"
+                                                                            }
+                                                                        },
+                                                                        "required": ["type", "address"],
+                                                                        "description": "An external wallet that can be used to sign transactions",
+                                                                        "title": "External Wallet Signer",
+                                                                        "example": {
+                                                                            "type": "external-wallet",
+                                                                            "address": "0x1234567890123456789012345678901234567890"
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "description": "Identifier for server signer type",
+                                                                                "enum": ["server"]
+                                                                            },
+                                                                            "address": {
+                                                                                "type": "string",
+                                                                                "description": "The blockchain address of the server signer"
+                                                                            }
+                                                                        },
+                                                                        "required": ["type", "address"],
+                                                                        "description": "A server-managed blockchain signer",
+                                                                        "title": "Server Signer",
+                                                                        "example": {
+                                                                            "type": "server",
+                                                                            "address": "0x1234567890123456789012345678901234567890"
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "description": "Identifier for email signer type",
+                                                                                "enum": ["email"]
+                                                                            },
+                                                                            "email": {
+                                                                                "description": "The email address for the signer",
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": ["type", "email"],
+                                                                        "description": "An email-based signer that can be used to sign transactions",
+                                                                        "title": "Email Signer"
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "description": "Identifier for phone signer type",
+                                                                                "enum": ["phone"]
+                                                                            },
+                                                                            "phone": {
+                                                                                "type": "string",
+                                                                                "description": "The phone number for the signer in E164 format"
+                                                                            }
+                                                                        },
+                                                                        "required": ["type", "phone"],
+                                                                        "description": "An phone-based signer that can be used to sign transactions",
+                                                                        "title": "Phone Signer",
+                                                                        "example": {
+                                                                            "type": "phone",
+                                                                            "phone": "+1234567890"
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "description": "The member signers that make up the quorum (1-10 members, no duplicates). Nested quorums are not allowed."
+                                                        }
+                                                    },
+                                                    "required": ["type", "signers"],
+                                                    "description": "A quorum (multisig) signer composed of multiple member signers with an approval threshold",
+                                                    "title": "Quorum Signer"
+                                                }
+                                            ]
+                                        },
+                                        "minItems": 1,
+                                        "maxItems": 10,
+                                        "description": "The recovery signers of the wallet: a list of up to 10 recovery signers that can each authorize on their own. Mutually exclusive with `adminSigner`."
                                     },
                                     "delegatedSigners": {
                                         "description": "Optional array of delegated signers to be created for the wallet",
@@ -31815,258 +31820,263 @@
                                         ]
                                     },
                                     "recovery": {
-                                        "description": "The recovery configuration (admin signer) for the wallet. Mutually exclusive with `adminSigner`.",
-                                        "oneOf": [
-                                            {
-                                                "type": "object",
-                                                "properties": {
-                                                    "type": {
-                                                        "type": "string",
-                                                        "description": "Identifier for external wallet signer type",
-                                                        "enum": ["external-wallet"]
-                                                    },
-                                                    "address": {
-                                                        "type": "string",
-                                                        "description": "The blockchain address of the external wallet"
-                                                    }
-                                                },
-                                                "required": ["type", "address"],
-                                                "description": "An external wallet that can be used to sign transactions",
-                                                "title": "External Wallet Signer",
-                                                "example": {
-                                                    "type": "external-wallet",
-                                                    "address": "0x1234567890123456789012345678901234567890"
-                                                }
-                                            },
-                                            {
-                                                "type": "object",
-                                                "properties": {
-                                                    "type": {
-                                                        "type": "string",
-                                                        "description": "Identifier for server signer type",
-                                                        "enum": ["server"]
-                                                    },
-                                                    "address": {
-                                                        "type": "string",
-                                                        "description": "The blockchain address of the server signer"
-                                                    }
-                                                },
-                                                "required": ["type", "address"],
-                                                "description": "A server-managed blockchain signer",
-                                                "title": "Server Signer",
-                                                "example": {
-                                                    "type": "server",
-                                                    "address": "0x1234567890123456789012345678901234567890"
-                                                }
-                                            },
-                                            {
-                                                "type": "object",
-                                                "properties": {
-                                                    "type": {
-                                                        "type": "string",
-                                                        "description": "Identifier for email signer type",
-                                                        "enum": ["email"]
-                                                    },
-                                                    "email": {
-                                                        "description": "The email address for the signer",
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                "required": ["type", "email"],
-                                                "description": "An email-based signer that can be used to sign transactions",
-                                                "title": "Email Signer"
-                                            },
-                                            {
-                                                "type": "object",
-                                                "properties": {
-                                                    "type": {
-                                                        "type": "string",
-                                                        "description": "Identifier for phone signer type",
-                                                        "enum": ["phone"]
-                                                    },
-                                                    "phone": {
-                                                        "type": "string",
-                                                        "description": "The phone number for the signer in E164 format"
-                                                    }
-                                                },
-                                                "required": ["type", "phone"],
-                                                "description": "An phone-based signer that can be used to sign transactions",
-                                                "title": "Phone Signer",
-                                                "example": {
-                                                    "type": "phone",
-                                                    "phone": "+1234567890"
-                                                }
-                                            },
-                                            {
-                                                "type": "object",
-                                                "properties": {
-                                                    "type": {
-                                                        "type": "string",
-                                                        "description": "Identifier for API key signer type",
-                                                        "enum": ["api-key"]
-                                                    }
-                                                },
-                                                "required": ["type"],
-                                                "description": "A custodial signer provided by Crossmint and backed by our secure infrastructure. Contact sales (https://www.crossmint.com/contact/sales) for access.",
-                                                "title": "API Key Signer",
-                                                "example": {
-                                                    "type": "api-key"
-                                                }
-                                            },
-                                            {
-                                                "type": "object",
-                                                "properties": {
-                                                    "type": {
-                                                        "type": "string",
-                                                        "description": "Identifier for quorum (multisig) signer type",
-                                                        "enum": ["quorum"]
-                                                    },
-                                                    "threshold": {
-                                                        "default": 1,
-                                                        "description": "The minimum number of member signatures required to approve. Defaults to 1.",
-                                                        "type": "integer",
-                                                        "minimum": 1,
-                                                        "maximum": 9007199254740991
-                                                    },
-                                                    "signers": {
-                                                        "type": "array",
-                                                        "items": {
-                                                            "oneOf": [
-                                                                {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "type": {
-                                                                            "type": "string",
-                                                                            "description": "Identifier for the Passkey signer type",
-                                                                            "enum": ["passkey"]
-                                                                        },
-                                                                        "id": {
-                                                                            "type": "string",
-                                                                            "description": "Credential ID from the WebAuthn registration response"
-                                                                        },
-                                                                        "name": {
-                                                                            "type": "string",
-                                                                            "description": "Human-readable name for the passkey"
-                                                                        },
-                                                                        "publicKey": {
-                                                                            "type": "object",
-                                                                            "properties": {
-                                                                                "x": {
-                                                                                    "type": "string",
-                                                                                    "description": "S component of the signature as a stringified bigint"
-                                                                                },
-                                                                                "y": {
-                                                                                    "type": "string",
-                                                                                    "description": "S component of the signature as a stringified bigint"
-                                                                                }
-                                                                            },
-                                                                            "required": ["x", "y"],
-                                                                            "description": "The public key coordinates from the WebAuthn credential"
-                                                                        }
-                                                                    },
-                                                                    "required": ["type", "id", "name", "publicKey"],
-                                                                    "description": "Configuration for a WebAuthn/Passkey signer that uses public key credentials for authentication",
-                                                                    "title": "Passkey Signer",
-                                                                    "example": {
-                                                                        "type": "passkey",
-                                                                        "id": "cWtP7gmZbd98HbKUuGXx5Q",
-                                                                        "name": "hgranger",
-                                                                        "publicKey": {
-                                                                            "x": "38035223810536273945556366218149112558607829411547667975304293530457502824247",
-                                                                            "y": "91117823763706733837104303008228095481082989039135234750508288790583476078729"
-                                                                        }
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "type": {
-                                                                            "type": "string",
-                                                                            "description": "Identifier for external wallet signer type",
-                                                                            "enum": ["external-wallet"]
-                                                                        },
-                                                                        "address": {
-                                                                            "type": "string",
-                                                                            "description": "The blockchain address of the external wallet"
-                                                                        }
-                                                                    },
-                                                                    "required": ["type", "address"],
-                                                                    "description": "An external wallet that can be used to sign transactions",
-                                                                    "title": "External Wallet Signer",
-                                                                    "example": {
-                                                                        "type": "external-wallet",
-                                                                        "address": "0x1234567890123456789012345678901234567890"
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "type": {
-                                                                            "type": "string",
-                                                                            "description": "Identifier for server signer type",
-                                                                            "enum": ["server"]
-                                                                        },
-                                                                        "address": {
-                                                                            "type": "string",
-                                                                            "description": "The blockchain address of the server signer"
-                                                                        }
-                                                                    },
-                                                                    "required": ["type", "address"],
-                                                                    "description": "A server-managed blockchain signer",
-                                                                    "title": "Server Signer",
-                                                                    "example": {
-                                                                        "type": "server",
-                                                                        "address": "0x1234567890123456789012345678901234567890"
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "type": {
-                                                                            "type": "string",
-                                                                            "description": "Identifier for email signer type",
-                                                                            "enum": ["email"]
-                                                                        },
-                                                                        "email": {
-                                                                            "description": "The email address for the signer",
-                                                                            "type": "string"
-                                                                        }
-                                                                    },
-                                                                    "required": ["type", "email"],
-                                                                    "description": "An email-based signer that can be used to sign transactions",
-                                                                    "title": "Email Signer"
-                                                                },
-                                                                {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "type": {
-                                                                            "type": "string",
-                                                                            "description": "Identifier for phone signer type",
-                                                                            "enum": ["phone"]
-                                                                        },
-                                                                        "phone": {
-                                                                            "type": "string",
-                                                                            "description": "The phone number for the signer in E164 format"
-                                                                        }
-                                                                    },
-                                                                    "required": ["type", "phone"],
-                                                                    "description": "An phone-based signer that can be used to sign transactions",
-                                                                    "title": "Phone Signer",
-                                                                    "example": {
-                                                                        "type": "phone",
-                                                                        "phone": "+1234567890"
-                                                                    }
-                                                                }
-                                                            ]
+                                        "type": "array",
+                                        "items": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Identifier for external wallet signer type",
+                                                            "enum": ["external-wallet"]
                                                         },
-                                                        "description": "The member signers that make up the quorum (1-10 members, no duplicates). Nested quorums are not allowed."
+                                                        "address": {
+                                                            "type": "string",
+                                                            "description": "The blockchain address of the external wallet"
+                                                        }
+                                                    },
+                                                    "required": ["type", "address"],
+                                                    "description": "An external wallet that can be used to sign transactions",
+                                                    "title": "External Wallet Signer",
+                                                    "example": {
+                                                        "type": "external-wallet",
+                                                        "address": "0x1234567890123456789012345678901234567890"
                                                     }
                                                 },
-                                                "required": ["type", "signers"],
-                                                "description": "A quorum (multisig) signer composed of multiple member signers with an approval threshold",
-                                                "title": "Quorum Signer"
-                                            }
-                                        ]
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Identifier for server signer type",
+                                                            "enum": ["server"]
+                                                        },
+                                                        "address": {
+                                                            "type": "string",
+                                                            "description": "The blockchain address of the server signer"
+                                                        }
+                                                    },
+                                                    "required": ["type", "address"],
+                                                    "description": "A server-managed blockchain signer",
+                                                    "title": "Server Signer",
+                                                    "example": {
+                                                        "type": "server",
+                                                        "address": "0x1234567890123456789012345678901234567890"
+                                                    }
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Identifier for email signer type",
+                                                            "enum": ["email"]
+                                                        },
+                                                        "email": {
+                                                            "description": "The email address for the signer",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["type", "email"],
+                                                    "description": "An email-based signer that can be used to sign transactions",
+                                                    "title": "Email Signer"
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Identifier for phone signer type",
+                                                            "enum": ["phone"]
+                                                        },
+                                                        "phone": {
+                                                            "type": "string",
+                                                            "description": "The phone number for the signer in E164 format"
+                                                        }
+                                                    },
+                                                    "required": ["type", "phone"],
+                                                    "description": "An phone-based signer that can be used to sign transactions",
+                                                    "title": "Phone Signer",
+                                                    "example": {
+                                                        "type": "phone",
+                                                        "phone": "+1234567890"
+                                                    }
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Identifier for API key signer type",
+                                                            "enum": ["api-key"]
+                                                        }
+                                                    },
+                                                    "required": ["type"],
+                                                    "description": "A custodial signer provided by Crossmint and backed by our secure infrastructure. Contact sales (https://www.crossmint.com/contact/sales) for access.",
+                                                    "title": "API Key Signer",
+                                                    "example": {
+                                                        "type": "api-key"
+                                                    }
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Identifier for quorum (multisig) signer type",
+                                                            "enum": ["quorum"]
+                                                        },
+                                                        "threshold": {
+                                                            "default": 1,
+                                                            "description": "The minimum number of member signatures required to approve. Defaults to 1.",
+                                                            "type": "integer",
+                                                            "minimum": 1,
+                                                            "maximum": 9007199254740991
+                                                        },
+                                                        "signers": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "description": "Identifier for the Passkey signer type",
+                                                                                "enum": ["passkey"]
+                                                                            },
+                                                                            "id": {
+                                                                                "type": "string",
+                                                                                "description": "Credential ID from the WebAuthn registration response"
+                                                                            },
+                                                                            "name": {
+                                                                                "type": "string",
+                                                                                "description": "Human-readable name for the passkey"
+                                                                            },
+                                                                            "publicKey": {
+                                                                                "type": "object",
+                                                                                "properties": {
+                                                                                    "x": {
+                                                                                        "type": "string",
+                                                                                        "description": "S component of the signature as a stringified bigint"
+                                                                                    },
+                                                                                    "y": {
+                                                                                        "type": "string",
+                                                                                        "description": "S component of the signature as a stringified bigint"
+                                                                                    }
+                                                                                },
+                                                                                "required": ["x", "y"],
+                                                                                "description": "The public key coordinates from the WebAuthn credential"
+                                                                            }
+                                                                        },
+                                                                        "required": ["type", "id", "name", "publicKey"],
+                                                                        "description": "Configuration for a WebAuthn/Passkey signer that uses public key credentials for authentication",
+                                                                        "title": "Passkey Signer",
+                                                                        "example": {
+                                                                            "type": "passkey",
+                                                                            "id": "cWtP7gmZbd98HbKUuGXx5Q",
+                                                                            "name": "hgranger",
+                                                                            "publicKey": {
+                                                                                "x": "38035223810536273945556366218149112558607829411547667975304293530457502824247",
+                                                                                "y": "91117823763706733837104303008228095481082989039135234750508288790583476078729"
+                                                                            }
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "description": "Identifier for external wallet signer type",
+                                                                                "enum": ["external-wallet"]
+                                                                            },
+                                                                            "address": {
+                                                                                "type": "string",
+                                                                                "description": "The blockchain address of the external wallet"
+                                                                            }
+                                                                        },
+                                                                        "required": ["type", "address"],
+                                                                        "description": "An external wallet that can be used to sign transactions",
+                                                                        "title": "External Wallet Signer",
+                                                                        "example": {
+                                                                            "type": "external-wallet",
+                                                                            "address": "0x1234567890123456789012345678901234567890"
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "description": "Identifier for server signer type",
+                                                                                "enum": ["server"]
+                                                                            },
+                                                                            "address": {
+                                                                                "type": "string",
+                                                                                "description": "The blockchain address of the server signer"
+                                                                            }
+                                                                        },
+                                                                        "required": ["type", "address"],
+                                                                        "description": "A server-managed blockchain signer",
+                                                                        "title": "Server Signer",
+                                                                        "example": {
+                                                                            "type": "server",
+                                                                            "address": "0x1234567890123456789012345678901234567890"
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "description": "Identifier for email signer type",
+                                                                                "enum": ["email"]
+                                                                            },
+                                                                            "email": {
+                                                                                "description": "The email address for the signer",
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": ["type", "email"],
+                                                                        "description": "An email-based signer that can be used to sign transactions",
+                                                                        "title": "Email Signer"
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "description": "Identifier for phone signer type",
+                                                                                "enum": ["phone"]
+                                                                            },
+                                                                            "phone": {
+                                                                                "type": "string",
+                                                                                "description": "The phone number for the signer in E164 format"
+                                                                            }
+                                                                        },
+                                                                        "required": ["type", "phone"],
+                                                                        "description": "An phone-based signer that can be used to sign transactions",
+                                                                        "title": "Phone Signer",
+                                                                        "example": {
+                                                                            "type": "phone",
+                                                                            "phone": "+1234567890"
+                                                                        }
+                                                                    }
+                                                                ]
+                                                            },
+                                                            "description": "The member signers that make up the quorum (1-10 members, no duplicates). Nested quorums are not allowed."
+                                                        }
+                                                    },
+                                                    "required": ["type", "signers"],
+                                                    "description": "A quorum (multisig) signer composed of multiple member signers with an approval threshold",
+                                                    "title": "Quorum Signer"
+                                                }
+                                            ]
+                                        },
+                                        "minItems": 1,
+                                        "maxItems": 10,
+                                        "description": "The recovery signers of the wallet: a list of up to 10 recovery signers that can each authorize on their own. Mutually exclusive with `adminSigner`."
                                     },
                                     "delegatedSigners": {
                                         "description": "Optional array of delegated signers to be created for the wallet",
@@ -79419,7 +79429,303 @@
                                                 "required": ["type", "threshold", "locator", "signers"],
                                                 "description": "Quorum (m-of-n multisig) admin signer"
                                             }
-                                        ]
+                                        ],
+                                        "description": "@deprecated Use `recovery` instead. The wallet's first admin signer."
+                                    },
+                                    "recovery": {
+                                        "type": "array",
+                                        "items": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Identifier for external wallet signer type",
+                                                            "enum": ["external-wallet"]
+                                                        },
+                                                        "address": {
+                                                            "type": "string",
+                                                            "description": "The blockchain address of the external wallet"
+                                                        },
+                                                        "locator": {
+                                                            "description": "The locator of the signer",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["type", "address", "locator"],
+                                                    "title": "External Wallet Signer",
+                                                    "description": "Configuration for an external wallet signer"
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Identifier for server signer type",
+                                                            "enum": ["server"]
+                                                        },
+                                                        "address": {
+                                                            "type": "string",
+                                                            "description": "The blockchain address of the server signer"
+                                                        },
+                                                        "locator": {
+                                                            "description": "The locator of the signer",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["type", "address", "locator"],
+                                                    "title": "Server Signer",
+                                                    "description": "Configuration for a server signer"
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Identifier for API key signer type",
+                                                            "enum": ["api-key"]
+                                                        },
+                                                        "address": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string",
+                                                                    "description": "The recipient address for this transaction call"
+                                                                },
+                                                                {
+                                                                    "type": "string",
+                                                                    "description": "The Solana address of the signer"
+                                                                },
+                                                                {
+                                                                    "type": "string"
+                                                                }
+                                                            ],
+                                                            "description": "The blockchain address of the custodial signer"
+                                                        },
+                                                        "locator": {
+                                                            "description": "The locator of the signer",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["type", "address", "locator"],
+                                                    "title": "API Key Signer",
+                                                    "description": "Configuration for a custodial signer managed by Crossmint. Contact sales (https://www.crossmint.com/contact/sales) for access."
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Identifier for email signer type",
+                                                            "enum": ["email"]
+                                                        },
+                                                        "email": {
+                                                            "description": "The email address for the signer",
+                                                            "type": "string"
+                                                        },
+                                                        "locator": {
+                                                            "description": "The locator of the signer",
+                                                            "type": "string"
+                                                        },
+                                                        "address": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string",
+                                                                    "description": "The recipient address for this transaction call"
+                                                                },
+                                                                {
+                                                                    "type": "string"
+                                                                }
+                                                            ],
+                                                            "description": "The address of the signer"
+                                                        }
+                                                    },
+                                                    "required": ["type", "email", "locator", "address"],
+                                                    "title": "Email Signer",
+                                                    "description": "Configuration for an email signer"
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Identifier for phone signer type",
+                                                            "enum": ["phone"]
+                                                        },
+                                                        "phone": {
+                                                            "type": "string",
+                                                            "description": "The phone number for the signer in E164 format"
+                                                        },
+                                                        "locator": {
+                                                            "description": "The locator of the signer",
+                                                            "type": "string"
+                                                        },
+                                                        "address": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string",
+                                                                    "description": "The recipient address for this transaction call"
+                                                                },
+                                                                {
+                                                                    "type": "string"
+                                                                }
+                                                            ],
+                                                            "description": "The address of the signer"
+                                                        }
+                                                    },
+                                                    "required": ["type", "phone", "locator", "address"],
+                                                    "title": "Phone Signer",
+                                                    "description": "Configuration for a phone signer"
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": ["quorum"]
+                                                        },
+                                                        "threshold": {
+                                                            "type": "integer",
+                                                            "minimum": 1,
+                                                            "maximum": 9007199254740991
+                                                        },
+                                                        "locator": {
+                                                            "type": "string",
+                                                            "pattern": "^quorum:[0-9a-f]{8}-[0-9a-f]{4}-8[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+                                                            "description": "The locator of the quorum signer (read-only, derived from threshold + members)"
+                                                        },
+                                                        "signers": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "description": "Identifier for external wallet signer type",
+                                                                                "enum": ["external-wallet"]
+                                                                            },
+                                                                            "address": {
+                                                                                "type": "string",
+                                                                                "description": "The blockchain address of the external wallet"
+                                                                            },
+                                                                            "locator": {
+                                                                                "description": "The locator of the signer",
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": ["type", "address", "locator"],
+                                                                        "title": "External Wallet Signer",
+                                                                        "description": "Configuration for an external wallet signer"
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "description": "Identifier for server signer type",
+                                                                                "enum": ["server"]
+                                                                            },
+                                                                            "address": {
+                                                                                "type": "string",
+                                                                                "description": "The blockchain address of the server signer"
+                                                                            },
+                                                                            "locator": {
+                                                                                "description": "The locator of the signer",
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": ["type", "address", "locator"],
+                                                                        "title": "Server Signer",
+                                                                        "description": "Configuration for a server signer"
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "description": "Identifier for email signer type",
+                                                                                "enum": ["email"]
+                                                                            },
+                                                                            "email": {
+                                                                                "description": "The email address for the signer",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "locator": {
+                                                                                "description": "The locator of the signer",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "address": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "string",
+                                                                                        "description": "The recipient address for this transaction call"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                ],
+                                                                                "description": "The address of the signer"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "type",
+                                                                            "email",
+                                                                            "locator",
+                                                                            "address"
+                                                                        ],
+                                                                        "title": "Email Signer",
+                                                                        "description": "Configuration for an email signer"
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "description": "Identifier for phone signer type",
+                                                                                "enum": ["phone"]
+                                                                            },
+                                                                            "phone": {
+                                                                                "type": "string",
+                                                                                "description": "The phone number for the signer in E164 format"
+                                                                            },
+                                                                            "locator": {
+                                                                                "description": "The locator of the signer",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "address": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "string",
+                                                                                        "description": "The recipient address for this transaction call"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                ],
+                                                                                "description": "The address of the signer"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "type",
+                                                                            "phone",
+                                                                            "locator",
+                                                                            "address"
+                                                                        ],
+                                                                        "title": "Phone Signer",
+                                                                        "description": "Configuration for a phone signer"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        }
+                                                    },
+                                                    "required": ["type", "threshold", "locator", "signers"],
+                                                    "description": "Quorum (m-of-n multisig) admin signer"
+                                                }
+                                            ]
+                                        },
+                                        "description": "Every admin signer of the wallet; each of them can authorize on its own."
                                     },
                                     "delegatedSigners": {
                                         "description": "Optional array of additional signers for the wallet",
@@ -81482,7 +81788,7 @@
                                         }
                                     }
                                 },
-                                "required": ["adminSigner"]
+                                "required": ["adminSigner", "recovery"]
                             },
                             "address": {
                                 "type": "string",
@@ -81908,7 +82214,303 @@
                                                 "required": ["type", "threshold", "locator", "signers"],
                                                 "description": "Quorum (m-of-n multisig) admin signer"
                                             }
-                                        ]
+                                        ],
+                                        "description": "@deprecated Use `recovery` instead. The wallet's first admin signer."
+                                    },
+                                    "recovery": {
+                                        "type": "array",
+                                        "items": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Identifier for external wallet signer type",
+                                                            "enum": ["external-wallet"]
+                                                        },
+                                                        "address": {
+                                                            "type": "string",
+                                                            "description": "The blockchain address of the external wallet"
+                                                        },
+                                                        "locator": {
+                                                            "description": "The locator of the signer",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["type", "address", "locator"],
+                                                    "title": "External Wallet Signer",
+                                                    "description": "Configuration for an external wallet signer"
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Identifier for server signer type",
+                                                            "enum": ["server"]
+                                                        },
+                                                        "address": {
+                                                            "type": "string",
+                                                            "description": "The blockchain address of the server signer"
+                                                        },
+                                                        "locator": {
+                                                            "description": "The locator of the signer",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["type", "address", "locator"],
+                                                    "title": "Server Signer",
+                                                    "description": "Configuration for a server signer"
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Identifier for email signer type",
+                                                            "enum": ["email"]
+                                                        },
+                                                        "email": {
+                                                            "description": "The email address for the signer",
+                                                            "type": "string"
+                                                        },
+                                                        "locator": {
+                                                            "description": "The locator of the signer",
+                                                            "type": "string"
+                                                        },
+                                                        "address": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string",
+                                                                    "description": "The recipient address for this transaction call"
+                                                                },
+                                                                {
+                                                                    "type": "string"
+                                                                }
+                                                            ],
+                                                            "description": "The address of the signer"
+                                                        }
+                                                    },
+                                                    "required": ["type", "email", "locator", "address"],
+                                                    "title": "Email Signer",
+                                                    "description": "Configuration for an email signer"
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Identifier for phone signer type",
+                                                            "enum": ["phone"]
+                                                        },
+                                                        "phone": {
+                                                            "type": "string",
+                                                            "description": "The phone number for the signer in E164 format"
+                                                        },
+                                                        "locator": {
+                                                            "description": "The locator of the signer",
+                                                            "type": "string"
+                                                        },
+                                                        "address": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string",
+                                                                    "description": "The recipient address for this transaction call"
+                                                                },
+                                                                {
+                                                                    "type": "string"
+                                                                }
+                                                            ],
+                                                            "description": "The address of the signer"
+                                                        }
+                                                    },
+                                                    "required": ["type", "phone", "locator", "address"],
+                                                    "title": "Phone Signer",
+                                                    "description": "Configuration for a phone signer"
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "description": "Identifier for API key signer type",
+                                                            "enum": ["api-key"]
+                                                        },
+                                                        "address": {
+                                                            "anyOf": [
+                                                                {
+                                                                    "type": "string",
+                                                                    "description": "The recipient address for this transaction call"
+                                                                },
+                                                                {
+                                                                    "type": "string",
+                                                                    "description": "The Solana address of the signer"
+                                                                },
+                                                                {
+                                                                    "type": "string"
+                                                                }
+                                                            ],
+                                                            "description": "The blockchain address of the custodial signer"
+                                                        },
+                                                        "locator": {
+                                                            "description": "The locator of the signer",
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["type", "address", "locator"],
+                                                    "title": "API Key Signer",
+                                                    "description": "Configuration for a custodial signer managed by Crossmint. Contact sales (https://www.crossmint.com/contact/sales) for access."
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {
+                                                            "type": "string",
+                                                            "enum": ["quorum"]
+                                                        },
+                                                        "threshold": {
+                                                            "type": "integer",
+                                                            "minimum": 1,
+                                                            "maximum": 9007199254740991
+                                                        },
+                                                        "locator": {
+                                                            "type": "string",
+                                                            "pattern": "^quorum:[0-9a-f]{8}-[0-9a-f]{4}-8[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+                                                            "description": "The locator of the quorum signer (read-only, derived from threshold + members)"
+                                                        },
+                                                        "signers": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "oneOf": [
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "description": "Identifier for external wallet signer type",
+                                                                                "enum": ["external-wallet"]
+                                                                            },
+                                                                            "address": {
+                                                                                "type": "string",
+                                                                                "description": "The blockchain address of the external wallet"
+                                                                            },
+                                                                            "locator": {
+                                                                                "description": "The locator of the signer",
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": ["type", "address", "locator"],
+                                                                        "title": "External Wallet Signer",
+                                                                        "description": "Configuration for an external wallet signer"
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "description": "Identifier for server signer type",
+                                                                                "enum": ["server"]
+                                                                            },
+                                                                            "address": {
+                                                                                "type": "string",
+                                                                                "description": "The blockchain address of the server signer"
+                                                                            },
+                                                                            "locator": {
+                                                                                "description": "The locator of the signer",
+                                                                                "type": "string"
+                                                                            }
+                                                                        },
+                                                                        "required": ["type", "address", "locator"],
+                                                                        "title": "Server Signer",
+                                                                        "description": "Configuration for a server signer"
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "description": "Identifier for email signer type",
+                                                                                "enum": ["email"]
+                                                                            },
+                                                                            "email": {
+                                                                                "description": "The email address for the signer",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "locator": {
+                                                                                "description": "The locator of the signer",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "address": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "string",
+                                                                                        "description": "The recipient address for this transaction call"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                ],
+                                                                                "description": "The address of the signer"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "type",
+                                                                            "email",
+                                                                            "locator",
+                                                                            "address"
+                                                                        ],
+                                                                        "title": "Email Signer",
+                                                                        "description": "Configuration for an email signer"
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "properties": {
+                                                                            "type": {
+                                                                                "type": "string",
+                                                                                "description": "Identifier for phone signer type",
+                                                                                "enum": ["phone"]
+                                                                            },
+                                                                            "phone": {
+                                                                                "type": "string",
+                                                                                "description": "The phone number for the signer in E164 format"
+                                                                            },
+                                                                            "locator": {
+                                                                                "description": "The locator of the signer",
+                                                                                "type": "string"
+                                                                            },
+                                                                            "address": {
+                                                                                "anyOf": [
+                                                                                    {
+                                                                                        "type": "string",
+                                                                                        "description": "The recipient address for this transaction call"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "string"
+                                                                                    }
+                                                                                ],
+                                                                                "description": "The address of the signer"
+                                                                            }
+                                                                        },
+                                                                        "required": [
+                                                                            "type",
+                                                                            "phone",
+                                                                            "locator",
+                                                                            "address"
+                                                                        ],
+                                                                        "title": "Phone Signer",
+                                                                        "description": "Configuration for a phone signer"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        }
+                                                    },
+                                                    "required": ["type", "threshold", "locator", "signers"],
+                                                    "description": "Quorum (m-of-n multisig) admin signer"
+                                                }
+                                            ]
+                                        },
+                                        "description": "Every admin signer of the wallet; each of them can authorize on its own."
                                     },
                                     "delegatedSigners": {
                                         "description": "Optional array of additional signers for the wallet",
@@ -83997,7 +84599,7 @@
                                         "example": "CA3SGE76PWYAM4OVKETY47GASUGYDF3Y3QFFSPIWFCNKQLUOO4SOIT2W"
                                     }
                                 },
-                                "required": ["adminSigner"]
+                                "required": ["adminSigner", "recovery"]
                             },
                             "address": {
                                 "type": "string",

--- a/packages/wallets/src/utils/errors.test.ts
+++ b/packages/wallets/src/utils/errors.test.ts
@@ -2,12 +2,20 @@ import { CrossmintErrors } from "@crossmint/common-sdk-base";
 import { describe, expect, test } from "vitest";
 
 import {
+    DuplicateRecoverySignerError,
     JWTDecryptionError,
     JWTExpiredError,
     JWTIdentifierError,
     JWTInvalidError,
     NotAuthorizedError,
+    NotSupportedOnApiVersionError,
+    RecoveryAdminSignerConflictError,
+    RecoveryNotSupportedOnChainError,
+    RecoverySignerConflictError,
+    RecoverySignerLimitExceededError,
+    SignerRequiredError,
     throwIfCrossmintApiAuthError,
+    throwIfRecoverySignerApiError,
 } from "./errors";
 
 describe("throwIfCrossmintApiAuthError", () => {
@@ -57,5 +65,45 @@ describe("throwIfCrossmintApiAuthError", () => {
         expect(() => throwIfCrossmintApiAuthError({ error: true, code: "SOME_OTHER_ERROR" })).not.toThrow();
         expect(() => throwIfCrossmintApiAuthError(null)).not.toThrow();
         expect(() => throwIfCrossmintApiAuthError("string")).not.toThrow();
+    });
+});
+
+describe("throwIfRecoverySignerApiError", () => {
+    const recoveryErrorCases = [
+        { code: "SIGNER_LIMIT_EXCEEDED", errorClass: RecoverySignerLimitExceededError },
+        { code: "RECOVERY_DUPLICATE_SIGNER", errorClass: DuplicateRecoverySignerError },
+        { code: "RECOVERY_SIGNER_CONFLICT", errorClass: RecoverySignerConflictError },
+        { code: "SIGNER_REQUIRED", errorClass: SignerRequiredError },
+        { code: "RECOVERY_NOT_SUPPORTED_ON_CHAIN", errorClass: RecoveryNotSupportedOnChainError },
+        { code: "NOT_SUPPORTED_ON_API_VERSION", errorClass: NotSupportedOnApiVersionError },
+        { code: "RECOVERY_ADMIN_SIGNER_CONFLICT", errorClass: RecoveryAdminSignerConflictError },
+    ];
+
+    test.each(recoveryErrorCases)("throws $errorClass.name when the code is $code", ({ code, errorClass }) => {
+        expect(() => throwIfRecoverySignerApiError({ error: true, code })).toThrow(errorClass);
+    });
+
+    test("surfaces the API message and the full response body as details", () => {
+        const body = { error: true, code: "RECOVERY_DUPLICATE_SIGNER", message: "signer already an admin" };
+
+        try {
+            throwIfRecoverySignerApiError(body);
+            expect.fail("Expected throwIfRecoverySignerApiError to throw");
+        } catch (error) {
+            expect((error as DuplicateRecoverySignerError).message).toBe("signer already an admin");
+            expect((error as DuplicateRecoverySignerError).details).toBe(JSON.stringify(body));
+        }
+    });
+
+    test("falls back to a descriptive message when the API sends none", () => {
+        expect(() => throwIfRecoverySignerApiError({ error: true, code: "SIGNER_LIMIT_EXCEEDED" })).toThrow(
+            "A wallet can have at most 10 recovery signers"
+        );
+    });
+
+    test("does not throw for unrelated error bodies", () => {
+        expect(() => throwIfRecoverySignerApiError({ error: true, message: "Wallet not found" })).not.toThrow();
+        expect(() => throwIfRecoverySignerApiError({ error: true, code: "SOME_OTHER_ERROR" })).not.toThrow();
+        expect(() => throwIfRecoverySignerApiError(null)).not.toThrow();
     });
 });

--- a/packages/wallets/src/utils/errors.ts
+++ b/packages/wallets/src/utils/errors.ts
@@ -104,6 +104,61 @@ export class QuorumSignerNotSupportedError extends CrossmintSDKError {
 }
 
 /**
+ * Maximum number of recovery signers a wallet can be created with, mirroring the backend's
+ * `SOLANA_MAX_ADMIN_SIGNERS` cap. Requests above it are rejected with `SIGNER_LIMIT_EXCEEDED`.
+ */
+export const MAX_RECOVERY_SIGNERS = 10;
+
+/** Thrown for recovery configurations the SDK can reject before calling the API. */
+export class InvalidRecoveryConfigError extends CrossmintSDKError {
+    constructor(message: string, details?: string) {
+        super(message, WalletErrorCode.SIGNER_INVALID, details);
+    }
+}
+
+export class RecoverySignerLimitExceededError extends CrossmintSDKError {
+    constructor(message: string, details?: string) {
+        super(message, WalletErrorCode.SIGNER_INVALID, details);
+    }
+}
+
+export class DuplicateRecoverySignerError extends CrossmintSDKError {
+    constructor(message: string, details?: string) {
+        super(message, WalletErrorCode.SIGNER_INVALID, details);
+    }
+}
+
+export class RecoverySignerConflictError extends CrossmintSDKError {
+    constructor(message: string, details?: string) {
+        super(message, WalletErrorCode.SIGNER_INVALID, details);
+    }
+}
+
+export class SignerRequiredError extends CrossmintSDKError {
+    constructor(message: string, details?: string) {
+        super(message, WalletErrorCode.SIGNER_INVALID, details);
+    }
+}
+
+export class RecoveryNotSupportedOnChainError extends CrossmintSDKError {
+    constructor(message: string, details?: string) {
+        super(message, WalletErrorCode.SIGNER_INVALID, details);
+    }
+}
+
+export class NotSupportedOnApiVersionError extends CrossmintSDKError {
+    constructor(message: string, details?: string) {
+        super(message, WalletErrorCode.SIGNER_INVALID, details);
+    }
+}
+
+export class RecoveryAdminSignerConflictError extends CrossmintSDKError {
+    constructor(message: string, details?: string) {
+        super(message, WalletErrorCode.SIGNER_INVALID, details);
+    }
+}
+
+/**
  * Thrown when the browser does not support third-party storage partitioning,
  * making it unsafe to store device-signer keys in IndexedDB. Consumers should
  * either prompt the user to upgrade their browser or fall back to a non-device
@@ -272,6 +327,58 @@ export function throwIfCrossmintApiAuthError(response: unknown): void {
     }
 }
 
+/**
+ * Inspects a Crossmint wallets API error response and, when it carries a recognized recovery-signer
+ * error code, throws the corresponding typed error. Returns without throwing for every other
+ * response so callers can fall back to their own contextual error.
+ */
+export function throwIfRecoverySignerApiError(response: unknown): void {
+    if (!isCrossmintApiErrorBody(response) || response.code == null) {
+        return;
+    }
+
+    const details = JSON.stringify(response);
+    const message = response.message;
+    switch (response.code) {
+        case "SIGNER_LIMIT_EXCEEDED":
+            throw new RecoverySignerLimitExceededError(
+                message ?? `A wallet can have at most ${MAX_RECOVERY_SIGNERS} recovery signers`,
+                details
+            );
+        case "RECOVERY_DUPLICATE_SIGNER":
+            throw new DuplicateRecoverySignerError(
+                message ?? "The recovery list contains the same signer more than once",
+                details
+            );
+        case "RECOVERY_SIGNER_CONFLICT":
+            throw new RecoverySignerConflictError(
+                message ?? "A recovery signer cannot also be registered as a delegated signer",
+                details
+            );
+        case "SIGNER_REQUIRED":
+            throw new SignerRequiredError(
+                message ??
+                    "This wallet has multiple recovery signers, so the signer to authorize with must be specified explicitly",
+                details
+            );
+        case "RECOVERY_NOT_SUPPORTED_ON_CHAIN":
+            throw new RecoveryNotSupportedOnChainError(
+                message ?? "Multiple recovery signers are not supported on this chain yet",
+                details
+            );
+        case "NOT_SUPPORTED_ON_API_VERSION":
+            throw new NotSupportedOnApiVersionError(
+                message ?? "Multiple recovery signers are not supported on this API version",
+                details
+            );
+        case "RECOVERY_ADMIN_SIGNER_CONFLICT":
+            throw new RecoveryAdminSignerConflictError(
+                message ?? "Only one of `adminSigner` and `recovery` can be provided",
+                details
+            );
+    }
+}
+
 export type WalletError =
     | InvalidTransferAmountError
     | InvalidApiKeyError
@@ -286,6 +393,14 @@ export type WalletError =
     | InvalidSignerError
     | UnknownSignerTypeError
     | DeviceSignerNotSupportedError
+    | InvalidRecoveryConfigError
+    | RecoverySignerLimitExceededError
+    | DuplicateRecoverySignerError
+    | RecoverySignerConflictError
+    | SignerRequiredError
+    | RecoveryNotSupportedOnChainError
+    | NotSupportedOnApiVersionError
+    | RecoveryAdminSignerConflictError
     | InvalidMessageFormatError
     | InvalidTypedDataError
     | SignatureNotFoundError

--- a/packages/wallets/src/utils/recovery.ts
+++ b/packages/wallets/src/utils/recovery.ts
@@ -1,0 +1,13 @@
+import type { Chain } from "../chains/chains";
+import type { RecoverySignerConfigForChain } from "../signers/types";
+import type { WalletCreateArgs } from "../wallets/types";
+
+/** Normalizes the single-or-list `recovery` wallet creation argument into a list. */
+export function toRecoverySignerList<C extends Chain>(
+    recovery?: WalletCreateArgs<C>["recovery"]
+): Array<RecoverySignerConfigForChain<C>> {
+    if (recovery == null) {
+        return [];
+    }
+    return (Array.isArray(recovery) ? recovery : [recovery]) as Array<RecoverySignerConfigForChain<C>>;
+}

--- a/packages/wallets/src/wallets/__tests__/test-helpers.ts
+++ b/packages/wallets/src/wallets/__tests__/test-helpers.ts
@@ -3,7 +3,7 @@ import { APIKeyEnvironmentPrefix } from "@crossmint/common-sdk-base";
 import { Wallet } from "../wallet";
 import type { ApiClient } from "../../api";
 import type { Chain } from "../../chains/chains";
-import type { SignerConfigForChain, SignerLocator } from "../../signers/types";
+import type { RecoverySignerConfigForChain, SignerConfigForChain, SignerLocator } from "../../signers/types";
 
 export type MockedApiClient = {
     isServerSide: boolean;
@@ -66,14 +66,16 @@ export const createMockSigner = <C extends Chain>(
 export const createMockWallet = async <C extends Chain>(
     chain: C,
     mockApiClient: MockedApiClient,
-    signerType: "api-key" | "external-wallet" = "api-key"
+    signerType: "api-key" | "external-wallet" = "api-key",
+    recoverySigners?: Array<RecoverySignerConfigForChain<C>>
 ): Promise<Wallet<C>> => {
     const signer = createMockSigner(signerType, chain);
     const wallet = new Wallet(
         {
             chain,
             address: getChainAddress(chain),
-            recovery: { type: "api-key" } as SignerConfigForChain<C>,
+            recovery: (recoverySigners?.[0] ?? { type: "api-key" }) as SignerConfigForChain<C>,
+            recoverySigners,
         },
         mockApiClient as unknown as ApiClient
     );

--- a/packages/wallets/src/wallets/evm.ts
+++ b/packages/wallets/src/wallets/evm.ts
@@ -28,6 +28,7 @@ export class EVMWallet extends Wallet<EVMChain> {
                 options: Wallet.getOptions(wallet),
                 alias: wallet.alias,
                 recovery: Wallet.getRecovery(wallet),
+                recoverySigners: Wallet.getRecoverySigners(wallet),
                 apiRecoveryServerSignerAddress: Wallet.getApiRecoveryServerSignerAddress(wallet),
                 apiDelegatedServerSignerAddresses: Wallet.getApiDelegatedServerSignerAddresses(wallet),
                 signer: wallet.signer,

--- a/packages/wallets/src/wallets/solana.test.ts
+++ b/packages/wallets/src/wallets/solana.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SolanaWallet } from "./solana";
+import type { SolanaChain } from "../chains/chains";
+import type { RecoverySignerConfigForChain } from "../signers/types";
 import type { CreateTransactionSuccessResponse } from "../api";
 import { TransactionNotCreatedError } from "../utils/errors";
 import {
@@ -289,6 +291,18 @@ describe("SolanaWallet - from()", () => {
 
         expect(solanaWallet).toBeInstanceOf(SolanaWallet);
         expect(solanaWallet.chain).toBe("solana");
+    });
+
+    it("keeps every recovery signer of the source wallet", async () => {
+        const recoverySigners: Array<RecoverySignerConfigForChain<SolanaChain>> = [
+            { type: "email", email: "one@test.com" },
+            { type: "api-key" },
+        ];
+        const wallet = await createMockWallet("solana", mockApiClient, "api-key", recoverySigners);
+
+        const solanaWallet = SolanaWallet.from(wallet);
+
+        expect(solanaWallet.recoverySigners).toEqual(recoverySigners);
     });
 
     it("throws error when wallet is not Solana", async () => {

--- a/packages/wallets/src/wallets/solana.ts
+++ b/packages/wallets/src/wallets/solana.ts
@@ -24,6 +24,7 @@ export class SolanaWallet extends Wallet<SolanaChain> {
                 options: Wallet.getOptions(wallet),
                 alias: wallet.alias,
                 recovery: Wallet.getRecovery(wallet),
+                recoverySigners: Wallet.getRecoverySigners(wallet),
                 apiRecoveryServerSignerAddress: Wallet.getApiRecoveryServerSignerAddress(wallet),
                 apiDelegatedServerSignerAddresses: Wallet.getApiDelegatedServerSignerAddresses(wallet),
                 signer: wallet.signer,

--- a/packages/wallets/src/wallets/stellar.test.ts
+++ b/packages/wallets/src/wallets/stellar.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { StellarWallet } from "./stellar";
+import type { StellarChain } from "../chains/chains";
+import type { RecoverySignerConfigForChain } from "../signers/types";
 import type { CreateTransactionSuccessResponse } from "../api";
 import { TransactionNotCreatedError } from "../utils/errors";
 import {
@@ -610,6 +612,18 @@ describe("StellarWallet - from()", () => {
 
         expect(stellarWallet).toBeInstanceOf(StellarWallet);
         expect(stellarWallet.chain).toBe("stellar");
+    });
+
+    it("keeps every recovery signer of the source wallet", async () => {
+        const recoverySigners: Array<RecoverySignerConfigForChain<StellarChain>> = [
+            { type: "email", email: "one@test.com" },
+            { type: "api-key" },
+        ];
+        const wallet = await createMockWallet("stellar", mockApiClient, "api-key", recoverySigners);
+
+        const stellarWallet = StellarWallet.from(wallet);
+
+        expect(stellarWallet.recoverySigners).toEqual(recoverySigners);
     });
 
     it("throws error when wallet is not Stellar", async () => {

--- a/packages/wallets/src/wallets/stellar.ts
+++ b/packages/wallets/src/wallets/stellar.ts
@@ -27,6 +27,7 @@ export class StellarWallet extends Wallet<StellarChain> {
                 options: Wallet.getOptions(wallet),
                 alias: wallet.alias,
                 recovery: Wallet.getRecovery(wallet),
+                recoverySigners: Wallet.getRecoverySigners(wallet),
                 apiRecoveryServerSignerAddress: Wallet.getApiRecoveryServerSignerAddress(wallet),
                 apiDelegatedServerSignerAddresses: Wallet.getApiDelegatedServerSignerAddresses(wallet),
                 signer: wallet.signer,

--- a/packages/wallets/src/wallets/types.ts
+++ b/packages/wallets/src/wallets/types.ts
@@ -4,7 +4,7 @@ import type { signerInboundEvents, signerOutboundEvents } from "@crossmint/clien
 import type { TypedData, TypedDataDefinition } from "viem";
 import type { Abi } from "abitype";
 import type { CreateTransactionSuccessResponse, Scope } from "../api";
-import type { Chain, EVMSmartWalletChain, StellarChain } from "../chains/chains";
+import type { Chain, EVMSmartWalletChain, SolanaChain, StellarChain } from "../chains/chains";
 import type {
     SignerConfigForChain,
     ExternalWalletRegistrationConfig,
@@ -233,9 +233,20 @@ export type WalletArgsFor<C extends Chain> = {
     alias?: string;
 };
 
+/** A signer that can be used as a recovery signer. Device signers cannot be recovery signers. */
+export type RecoverySignerConfigFor<C extends Chain> = Exclude<SignerConfigForChain<C>, DeviceSignerConfig>;
+
+/**
+ * Solana and Stellar accept a list of recovery signers, each able to authorize on its own.
+ * Other chains accept a single recovery signer until their backend DTO supports a list.
+ */
+export type RecoveryCreateArg<C extends Chain> = C extends SolanaChain | StellarChain
+    ? RecoverySignerConfigFor<C> | Array<RecoverySignerConfigFor<C>>
+    : RecoverySignerConfigFor<C>;
+
 export type WalletCreateArgs<C extends Chain> = WalletArgsFor<C> & {
-    /** Recovery signer for wallet creation. Device signers cannot be recovery signers. */
-    recovery: Exclude<SignerConfigForChain<C>, DeviceSignerConfig>;
+    /** Recovery signer, or list of recovery signers on Solana and Stellar. */
+    recovery: RecoveryCreateArg<C>;
     /** Signers to register on the wallet during creation. */
     signers?: Array<SignerConfigForChain<C> | ExternalWalletRegistrationConfig>;
     alias?: string;

--- a/packages/wallets/src/wallets/wallet-factory.test.ts
+++ b/packages/wallets/src/wallets/wallet-factory.test.ts
@@ -1,6 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi, type MockedFunction } from "vitest";
 import { WalletFactory } from "./wallet-factory";
-import { InvalidChainError, InvalidEnvironmentError, WalletCreationError } from "../utils/errors";
+import {
+    DuplicateRecoverySignerError,
+    InvalidChainError,
+    InvalidEnvironmentError,
+    InvalidRecoveryConfigError,
+    MAX_RECOVERY_SIGNERS,
+    RecoveryNotSupportedOnChainError,
+    RecoverySignerLimitExceededError,
+    WalletCreationError,
+} from "../utils/errors";
 import { walletsLogger } from "../logger";
 import type { ApiClient, GetWalletSuccessResponse } from "../api";
 import type { WalletArgsFor, WalletCreateArgs } from "./types";
@@ -982,6 +991,274 @@ describe("WalletFactory - Server Signer", () => {
             };
 
             await expect(walletFactory.getWallet(mockServerWalletResponse.address, args)).resolves.toBeDefined();
+        });
+    });
+});
+
+describe("WalletFactory - recovery signer lists", () => {
+    let walletFactory: WalletFactory;
+    let mockApiClient: MockedApiClient;
+
+    const PROJECT_ID = "test-project";
+    const ENVIRONMENT = APIKeyEnvironmentPrefix.STAGING;
+    const FIRST_SERVER_SECRET = "a".repeat(64);
+    const SECOND_SERVER_SECRET = "b".repeat(64);
+    const SOLANA_ADDRESS = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
+    const STELLAR_ADDRESS = "GA6HCMBLTZS5VYYBCATRBRZ3BZJMAFUDKYYF6RBM4CFTJKZUZWFRTIYT";
+    const EXTERNAL_WALLET_ADDRESS = "ExternalWalletRecoveryAddress123";
+
+    const derivedServerAddress = (secret: string, chain: "solana" | "stellar") =>
+        deriveServerSignerDetails({ type: "server", secret }, chain, PROJECT_ID, ENVIRONMENT).derivedAddress;
+
+    const walletResponseWithRecovery = (
+        chainType: "solana" | "stellar",
+        address: string,
+        recovery: Array<Record<string, unknown>>
+    ) =>
+        ({
+            chainType,
+            type: "smart" as const,
+            address,
+            owner: "test-owner",
+            config: { adminSigner: recovery[0], recovery },
+            createdAt: Date.now(),
+        }) as unknown as GetWalletSuccessResponse;
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+
+        mockApiClient = {
+            isServerSide: true,
+            crossmint: { projectId: PROJECT_ID },
+            projectId: PROJECT_ID,
+            environment: ENVIRONMENT,
+            getWallet: vi.fn(),
+            createWallet: vi.fn(),
+        };
+
+        walletFactory = new WalletFactory(mockApiClient as unknown as ApiClient);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe("createWallet request", () => {
+        it("sends a Solana recovery list under config.recovery and never alongside adminSigner", async () => {
+            const recovery = [
+                { type: "email" as const, email: "recovery@example.com" },
+                { type: "external-wallet" as const, address: EXTERNAL_WALLET_ADDRESS },
+            ];
+            mockApiClient.createWallet.mockResolvedValue(
+                walletResponseWithRecovery("solana", SOLANA_ADDRESS, recovery)
+            );
+
+            await walletFactory.createWallet({ chain: "solana", recovery });
+
+            const createWalletParams = mockApiClient.createWallet.mock.calls[0][0];
+            expect(createWalletParams.config).toEqual(expect.objectContaining({ recovery }));
+            expect(createWalletParams.config).not.toHaveProperty("adminSigner");
+        });
+
+        it("sends a Stellar recovery list under config.recovery", async () => {
+            const recovery = [
+                { type: "api-key" as const },
+                { type: "phone" as const, phone: "+15550000001", channel: "sms" as const },
+            ];
+            mockApiClient.createWallet.mockResolvedValue(
+                walletResponseWithRecovery("stellar", STELLAR_ADDRESS, recovery)
+            );
+
+            await walletFactory.createWallet({ chain: "stellar", recovery });
+
+            expect(mockApiClient.createWallet).toHaveBeenCalledWith(
+                expect.objectContaining({ config: expect.objectContaining({ recovery }) })
+            );
+        });
+
+        it("keeps sending a single recovery signer under the deprecated adminSigner field", async () => {
+            const recovery = { type: "email" as const, email: "recovery@example.com" };
+            mockApiClient.createWallet.mockResolvedValue(
+                walletResponseWithRecovery("solana", SOLANA_ADDRESS, [recovery])
+            );
+
+            await walletFactory.createWallet({ chain: "solana", recovery });
+
+            const createWalletParams = mockApiClient.createWallet.mock.calls[0][0];
+            expect(createWalletParams.config).toEqual(expect.objectContaining({ adminSigner: recovery }));
+            expect(createWalletParams.config).not.toHaveProperty("recovery");
+        });
+
+        it("derives an address for every server signer in the list", async () => {
+            const firstAddress = derivedServerAddress(FIRST_SERVER_SECRET, "solana");
+            const secondAddress = derivedServerAddress(SECOND_SERVER_SECRET, "solana");
+            mockApiClient.createWallet.mockResolvedValue(
+                walletResponseWithRecovery("solana", SOLANA_ADDRESS, [
+                    { type: "server", address: firstAddress, locator: `server:${firstAddress}` },
+                    { type: "server", address: secondAddress, locator: `server:${secondAddress}` },
+                ])
+            );
+
+            await walletFactory.createWallet({
+                chain: "solana",
+                recovery: [
+                    { type: "server", secret: FIRST_SERVER_SECRET },
+                    { type: "server", secret: SECOND_SERVER_SECRET },
+                ],
+            });
+
+            expect(mockApiClient.createWallet).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    config: expect.objectContaining({
+                        recovery: [
+                            { type: "server", address: firstAddress },
+                            { type: "server", address: secondAddress },
+                        ],
+                    }),
+                })
+            );
+        });
+
+        it("creates a credential for every passkey signer in the list that has no id", async () => {
+            const onCreatePasskey = vi.fn().mockImplementation(async (name: string) => ({
+                id: `credential-for-${name}`,
+                publicKey: { x: 1n, y: 2n },
+            }));
+            // Passkeys are only a valid signer type on EVM, which is still single-recovery, so the list is cast:
+            // this asserts the factory resolves every entry rather than only the first one.
+            const recovery = [
+                { type: "passkey", name: "first", onCreatePasskey },
+                { type: "passkey", name: "second", onCreatePasskey },
+            ] as unknown as WalletCreateArgs<"solana">["recovery"];
+            mockApiClient.createWallet.mockResolvedValue(
+                walletResponseWithRecovery("solana", SOLANA_ADDRESS, [
+                    { type: "passkey", id: "credential-for-first" },
+                    { type: "passkey", id: "credential-for-second" },
+                ])
+            );
+
+            await walletFactory.createWallet({ chain: "solana", recovery });
+
+            expect(onCreatePasskey).toHaveBeenCalledTimes(2);
+            expect(mockApiClient.createWallet).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    config: expect.objectContaining({
+                        recovery: [
+                            expect.objectContaining({ type: "passkey", id: "credential-for-first", name: "first" }),
+                            expect.objectContaining({ type: "passkey", id: "credential-for-second", name: "second" }),
+                        ],
+                    }),
+                })
+            );
+        });
+    });
+
+    describe("createWallet validation", () => {
+        it("rejects a recovery list on a chain that only supports one recovery signer", async () => {
+            const recovery = [{ type: "api-key" as const }, { type: "api-key" as const }];
+
+            await expect(
+                walletFactory.createWallet({
+                    chain: "base-sepolia",
+                    recovery: recovery as unknown as WalletCreateArgs<"base-sepolia">["recovery"],
+                })
+            ).rejects.toBeInstanceOf(RecoveryNotSupportedOnChainError);
+            expect(mockApiClient.createWallet).not.toHaveBeenCalled();
+        });
+
+        it("rejects an empty recovery list without calling the API", async () => {
+            await expect(walletFactory.createWallet({ chain: "solana", recovery: [] })).rejects.toBeInstanceOf(
+                InvalidRecoveryConfigError
+            );
+            expect(mockApiClient.createWallet).not.toHaveBeenCalled();
+        });
+
+        it("rejects a recovery list above the signer cap without calling the API", async () => {
+            const recovery = Array.from({ length: MAX_RECOVERY_SIGNERS + 1 }, (_, index) => ({
+                type: "email" as const,
+                email: `recovery-${index}@example.com`,
+            }));
+
+            await expect(walletFactory.createWallet({ chain: "solana", recovery })).rejects.toBeInstanceOf(
+                RecoverySignerLimitExceededError
+            );
+            expect(mockApiClient.createWallet).not.toHaveBeenCalled();
+        });
+
+        it("maps recovery error codes returned by the API to typed SDK errors", async () => {
+            mockApiClient.createWallet.mockResolvedValue({
+                error: true,
+                code: "RECOVERY_DUPLICATE_SIGNER",
+                message: "duplicate admin signer",
+            } as unknown as GetWalletSuccessResponse);
+
+            await expect(
+                walletFactory.createWallet({
+                    chain: "solana",
+                    recovery: [
+                        { type: "email", email: "recovery@example.com" },
+                        { type: "email", email: "recovery@example.com" },
+                    ],
+                })
+            ).rejects.toBeInstanceOf(DuplicateRecoverySignerError);
+        });
+    });
+
+    describe("createWallet response", () => {
+        it("exposes every recovery signer from the response, the first one as wallet.recovery", async () => {
+            const recovery = [
+                { type: "email" as const, email: "recovery@example.com" },
+                { type: "external-wallet" as const, address: EXTERNAL_WALLET_ADDRESS },
+            ];
+            mockApiClient.createWallet.mockResolvedValue(
+                walletResponseWithRecovery("solana", SOLANA_ADDRESS, [
+                    { ...recovery[0], locator: "email:recovery@example.com" },
+                    { ...recovery[1], locator: `external-wallet:${EXTERNAL_WALLET_ADDRESS}` },
+                ])
+            );
+
+            const wallet = await walletFactory.createWallet({ chain: "solana", recovery });
+
+            expect(wallet.recoverySigners).toHaveLength(2);
+            expect(wallet.recoverySigners.map((signer) => signer.type)).toEqual(["email", "external-wallet"]);
+            expect(wallet.recovery).toBe(wallet.recoverySigners[0]);
+        });
+
+        it("keeps the caller's server signer config for the matching entry of the recovery list", async () => {
+            const firstAddress = derivedServerAddress(FIRST_SERVER_SECRET, "solana");
+            mockApiClient.createWallet.mockResolvedValue(
+                walletResponseWithRecovery("solana", SOLANA_ADDRESS, [
+                    { type: "api-key" },
+                    { type: "server", address: firstAddress, locator: `server:${firstAddress}` },
+                ])
+            );
+
+            const wallet = await walletFactory.createWallet({
+                chain: "solana",
+                recovery: [{ type: "api-key" }, { type: "server", secret: FIRST_SERVER_SECRET }],
+            });
+
+            expect(wallet.recoverySigners[1]).toEqual({ type: "server", secret: FIRST_SERVER_SECRET });
+        });
+
+        it("falls back to the deprecated adminSigner for responses without a recovery list", async () => {
+            const adminSigner = {
+                type: "external-wallet" as const,
+                address: EXTERNAL_WALLET_ADDRESS,
+                locator: `external-wallet:${EXTERNAL_WALLET_ADDRESS}`,
+            };
+            mockApiClient.getWallet.mockResolvedValue({
+                chainType: "solana" as const,
+                type: "smart" as const,
+                address: SOLANA_ADDRESS,
+                owner: "test-owner",
+                config: { adminSigner },
+                createdAt: Date.now(),
+            } as unknown as GetWalletSuccessResponse);
+
+            const wallet = await walletFactory.getWallet(SOLANA_ADDRESS, { chain: "solana" });
+
+            expect(wallet.recoverySigners).toEqual([adminSigner]);
         });
     });
 });

--- a/packages/wallets/src/wallets/wallet-factory.ts
+++ b/packages/wallets/src/wallets/wallet-factory.ts
@@ -12,7 +12,16 @@ import type {
     Signer as SignerResponse,
     RegisterSignerParams,
 } from "../api";
-import { DEVICE_SIGNER_NOT_SUPPORTED_ERROR_CODE, WalletCreationError, WalletNotAvailableError } from "../utils/errors";
+import {
+    DEVICE_SIGNER_NOT_SUPPORTED_ERROR_CODE,
+    InvalidRecoveryConfigError,
+    MAX_RECOVERY_SIGNERS,
+    RecoveryNotSupportedOnChainError,
+    RecoverySignerLimitExceededError,
+    WalletCreationError,
+    WalletNotAvailableError,
+    throwIfRecoverySignerApiError,
+} from "../utils/errors";
 import { type Chain, validateChainForEnvironment } from "../chains/chains";
 import type {
     ExternalWalletRegistrationConfig,
@@ -21,7 +30,8 @@ import type {
     SignerConfigForChain,
 } from "../signers/types";
 import { Wallet } from "./wallet";
-import type { WalletArgsFor, WalletCreateArgs } from "./types";
+import type { RecoverySignerConfigFor, WalletArgsFor, WalletCreateArgs } from "./types";
+import { toRecoverySignerList } from "../utils/recovery";
 import { compareSignerConfigs, normalizeValueForComparison } from "../utils/signer-validation";
 import { getSignerLocator } from "../utils/signer-locator";
 import { deriveServerSignerDetails, deriveServerSignerCandidates } from "../signers/server";
@@ -32,9 +42,21 @@ const SIGNER_MISMATCH_ERROR =
     "When 'signers' is provided to a method that may fetch an existing wallet, each specified signer must exist in that wallet's configuration.";
 
 type SmartWalletConfig = {
+    /** @deprecated The API still returns the first admin signer here; `recovery` holds all of them. */
     adminSigner: RecoverySignerConfig | PasskeySignerConfig;
+    recovery?: Array<RecoverySignerConfig | PasskeySignerConfig>;
     delegatedSigners?: SignerResponse[];
 };
+
+/** A recovery signer once passkey creation and server signer derivation have been resolved. */
+type ResolvedRecoverySigner = RecoverySignerConfig | RegisterSignerPasskeyParams | { type: "server"; address: string };
+
+/**
+ * The recovery half of a wallet-creation request. The API rejects requests carrying both fields
+ * (`RECOVERY_ADMIN_SIGNER_CONFLICT`), so a list goes under `recovery` while a single signer keeps
+ * using the deprecated `adminSigner` field.
+ */
+type RecoveryRequestConfig = { adminSigner: ResolvedRecoverySigner } | { recovery: ResolvedRecoverySigner[] };
 
 export class WalletFactory {
     constructor(private readonly apiClient: ApiClient) {}
@@ -140,24 +162,19 @@ export class WalletFactory {
             validatedArgs.options?.deviceSignerKeyStorage
         );
 
-        let adminSigner;
-        if (validatedArgs.recovery.type === "passkey" && validatedArgs.recovery.id == null) {
-            adminSigner = await this.createPasskeySigner(validatedArgs.recovery);
-        } else if (validatedArgs.recovery.type === "server") {
-            const { derivedAddress } = deriveServerSignerDetails(
-                validatedArgs.recovery,
-                validatedArgs.chain,
-                this.apiClient.projectId,
-                this.apiClient.environment
-            );
-            adminSigner = { type: "server", address: derivedAddress };
-        } else {
-            adminSigner = validatedArgs.recovery;
+        const recoverySigners = this.validatedRecoverySignerList(validatedArgs.recovery, validatedArgs.chain);
+        const resolvedRecoverySigners: ResolvedRecoverySigner[] = [];
+        // Sequential: resolving a passkey signer prompts the user, and browsers reject concurrent WebAuthn calls.
+        for (const recoverySigner of recoverySigners) {
+            resolvedRecoverySigners.push(await this.resolveRecoverySigner(recoverySigner, validatedArgs.chain));
         }
+        const recoveryRequestConfig: RecoveryRequestConfig = Array.isArray(validatedArgs.recovery)
+            ? { recovery: resolvedRecoverySigners }
+            : { adminSigner: resolvedRecoverySigners[0] };
 
         const walletResponse = await this.createSmartWallet(
             validatedArgs,
-            adminSigner,
+            recoveryRequestConfig,
             builtSigners,
             didAutoInjectDeviceSigner
         );
@@ -166,6 +183,7 @@ export class WalletFactory {
             walletsLogger.error("walletFactory.createWallet.error", {
                 error: walletResponse.error,
             });
+            throwIfRecoverySignerApiError(walletResponse);
             throw new WalletCreationError(JSON.stringify(walletResponse));
         }
 
@@ -179,7 +197,7 @@ export class WalletFactory {
     /** Creates the smart wallet, retrying once without the auto-injected device signer if the provider rejects it. */
     private async createSmartWallet<C extends Chain>(
         args: WalletCreateArgs<C>,
-        adminSigner: unknown,
+        recoveryRequestConfig: RecoveryRequestConfig,
         builtSigners: Array<{ signer: string } | RegisterSignerParams | { signer: PasskeySignerConfig }>,
         didAutoInjectDeviceSigner: boolean
     ): Promise<CreateWalletResponse> {
@@ -188,7 +206,7 @@ export class WalletFactory {
                 type: "smart",
                 chainType: this.getChainType(args.chain),
                 config: {
-                    adminSigner,
+                    ...recoveryRequestConfig,
                     ...(args.plugins ? { plugins: args.plugins } : {}),
                     ...(delegatedSigners != null ? { delegatedSigners } : {}),
                 },
@@ -211,6 +229,54 @@ export class WalletFactory {
         });
         const signersWithoutDeviceSigner = builtSigners.filter((s) => !this.isBuiltDeviceSigner(s));
         return await this.apiClient.createWallet(buildParams(signersWithoutDeviceSigner));
+    }
+
+    /**
+     * Normalizes the caller's recovery config into a list, rejecting locally what the API would reject
+     * anyway so callers fail fast and without a round trip.
+     */
+    private validatedRecoverySignerList<C extends Chain>(
+        recovery: WalletCreateArgs<C>["recovery"],
+        chain: C
+    ): Array<RecoverySignerConfigFor<C>> {
+        const recoverySigners = toRecoverySignerList(recovery) as Array<RecoverySignerConfigFor<C>>;
+        if (!Array.isArray(recovery)) {
+            return recoverySigners;
+        }
+        if (chain !== "solana" && chain !== "stellar") {
+            throw new RecoveryNotSupportedOnChainError(
+                `Multiple recovery signers are not supported on ${chain} yet. Pass a single recovery signer.`
+            );
+        }
+        if (recoverySigners.length === 0) {
+            throw new InvalidRecoveryConfigError("At least one recovery signer is required");
+        }
+        if (recoverySigners.length > MAX_RECOVERY_SIGNERS) {
+            throw new RecoverySignerLimitExceededError(
+                `A wallet can have at most ${MAX_RECOVERY_SIGNERS} recovery signers, but ${recoverySigners.length} were provided`
+            );
+        }
+        return recoverySigners;
+    }
+
+    /** Creates the passkey / derives the server signer address a recovery signer needs to be sent to the API. */
+    private async resolveRecoverySigner<C extends Chain>(
+        recovery: RecoverySignerConfigFor<C>,
+        chain: C
+    ): Promise<ResolvedRecoverySigner> {
+        if (recovery.type === "passkey" && recovery.id == null) {
+            return await this.createPasskeySigner(recovery as SignerConfigForChain<C>);
+        }
+        if (recovery.type === "server") {
+            const { derivedAddress } = deriveServerSignerDetails(
+                recovery,
+                chain,
+                this.apiClient.projectId,
+                this.apiClient.environment
+            );
+            return { type: "server", address: derivedAddress };
+        }
+        return recovery as ResolvedRecoverySigner;
     }
 
     // Matches a device signer in object form. Callers only run this when didAutoInjectDeviceSigner is
@@ -246,13 +312,20 @@ export class WalletFactory {
         // For all other types (passkey, device, etc.), use the API response which contains the full
         // signer details (e.g. passkey credential ID).
         const createArgs = args as WalletCreateArgs<C>;
-        const apiRecovery = (walletResponse.config as SmartWalletConfig).adminSigner as RecoverySignerConfigForChain<C>;
-        const recovery =
-            createArgs.recovery?.type === "server" || createArgs.recovery?.type === "external-wallet"
-                ? createArgs.recovery
-                : this.mergePhoneChannel(apiRecovery, createArgs.recovery);
+        const walletConfig = walletResponse.config as SmartWalletConfig;
+        // `recovery` holds every admin signer; older responses (and wallets created with a single
+        // signer) only carry the deprecated singular `adminSigner`.
+        const apiRecoverySigners = (walletConfig.recovery ?? [walletConfig.adminSigner]) as Array<
+            RecoverySignerConfigForChain<C>
+        >;
+        const recoverySigners = this.mergeRecoverySigners(
+            apiRecoverySigners,
+            toRecoverySignerList<C>(createArgs.recovery),
+            args.chain
+        );
+        const recovery = recoverySigners[0];
 
-        const apiDelegatedSigners = (walletResponse.config as SmartWalletConfig).delegatedSigners;
+        const apiDelegatedSigners = walletConfig.delegatedSigners;
         let signers = apiDelegatedSigners;
         if (
             signers != null &&
@@ -277,10 +350,9 @@ export class WalletFactory {
 
         // Preserve the API-sourced server signer recovery address so the wallet can identify
         // legacy derivations even when the user-provided config replaces the API one.
-        const apiRecoveryServerSignerAddress =
-            apiRecovery.type === "server" && "address" in apiRecovery && !("secret" in apiRecovery)
-                ? (apiRecovery as { address: string }).address
-                : undefined;
+        const apiRecoveryServerSignerAddress = apiRecoverySigners
+            .filter((s) => s.type === "server" && "address" in s && !("secret" in s))
+            .map((s) => (s as { address: string }).address)[0];
 
         // Preserve the API-sourced server signer delegated addresses so the wallet can identify
         // legacy derivations even when the user-provided config replaces the API one.
@@ -296,6 +368,7 @@ export class WalletFactory {
                 options: args.options,
                 alias: args.alias,
                 recovery,
+                recoverySigners,
                 apiRecoveryServerSignerAddress,
                 apiDelegatedServerSignerAddresses,
                 signers: (signers ?? []) as SignerConfigForChain<C>[],
@@ -308,6 +381,93 @@ export class WalletFactory {
         await wallet.waitForInit();
 
         return wallet;
+    }
+
+    /**
+     * Pairs each recovery signer returned by the API with the caller's config for the same signer, keeping the
+     * caller's config for server and external-wallet signers (it carries the secret / onSign callback the
+     * API cannot store) and the API's config otherwise (it carries e.g. the passkey credential ID).
+     */
+    private mergeRecoverySigners<C extends Chain>(
+        apiRecoverySigners: Array<RecoverySignerConfigForChain<C>>,
+        inputRecoverySigners: Array<RecoverySignerConfigForChain<C>>,
+        chain: C
+    ): Array<RecoverySignerConfigForChain<C>> {
+        const unmatchedInputSigners = [...inputRecoverySigners];
+        const pairedInputSigners = new Map<number, RecoverySignerConfigForChain<C>>();
+        // Pair on signer identity first and only then on type alone, so that a server signer whose API-reported
+        // address comes from a legacy derivation still keeps the caller's config (and its secret).
+        const matchers = [
+            (input: RecoverySignerConfigForChain<C>, api: RecoverySignerConfigForChain<C>) =>
+                this.matchesRecoverySigner(input, api, chain),
+            (input: RecoverySignerConfigForChain<C>, api: RecoverySignerConfigForChain<C>) => input.type === api.type,
+        ];
+        for (const matches of matchers) {
+            apiRecoverySigners.forEach((apiRecoverySigner, index) => {
+                if (pairedInputSigners.has(index)) {
+                    return;
+                }
+                const inputIndex = unmatchedInputSigners.findIndex((input) => matches(input, apiRecoverySigner));
+                if (inputIndex === -1) {
+                    return;
+                }
+                pairedInputSigners.set(index, unmatchedInputSigners.splice(inputIndex, 1)[0]);
+            });
+        }
+
+        return apiRecoverySigners.map((apiRecoverySigner, index) => {
+            const inputRecoverySigner = pairedInputSigners.get(index);
+            if (inputRecoverySigner == null) {
+                return apiRecoverySigner;
+            }
+            if (inputRecoverySigner.type === "server" || inputRecoverySigner.type === "external-wallet") {
+                return inputRecoverySigner;
+            }
+            return this.mergePhoneChannel(apiRecoverySigner, inputRecoverySigner);
+        });
+    }
+
+    /**
+     * Whether a caller-provided recovery signer config denotes the same signer as one the API returned.
+     * Wallets can have several recovery signers of the same type, so the identifying field is compared too:
+     * for server signers that means deriving the address the caller's secret maps to.
+     */
+    private matchesRecoverySigner<C extends Chain>(
+        inputRecoverySigner: RecoverySignerConfigForChain<C>,
+        apiRecoverySigner: RecoverySignerConfig | PasskeySignerConfig | RecoverySignerConfigForChain<C>,
+        chain: C
+    ): boolean {
+        if (inputRecoverySigner.type !== apiRecoverySigner.type) {
+            return false;
+        }
+        if (inputRecoverySigner.type === "email" && "email" in apiRecoverySigner) {
+            return (
+                normalizeValueForComparison(inputRecoverySigner.email) ===
+                normalizeValueForComparison(apiRecoverySigner.email)
+            );
+        }
+        if (inputRecoverySigner.type === "phone" && "phone" in apiRecoverySigner) {
+            return inputRecoverySigner.phone === apiRecoverySigner.phone;
+        }
+        if (inputRecoverySigner.type === "external-wallet" && "address" in apiRecoverySigner) {
+            return inputRecoverySigner.address === apiRecoverySigner.address;
+        }
+        if (inputRecoverySigner.type === "server" && "address" in apiRecoverySigner) {
+            if (!("secret" in inputRecoverySigner)) {
+                return inputRecoverySigner.address === apiRecoverySigner.address;
+            }
+            const { primary, legacy } = deriveServerSignerCandidates(
+                inputRecoverySigner,
+                chain,
+                this.apiClient.projectId,
+                this.apiClient.environment
+            );
+            return (
+                primary.derivedAddress === apiRecoverySigner.address ||
+                legacy?.derivedAddress === apiRecoverySigner.address
+            );
+        }
+        return true;
     }
 
     private getWalletLocator<C extends Chain>(args: WalletArgsFor<C>): string {
@@ -365,15 +525,29 @@ export class WalletFactory {
         const createArgs = args as WalletCreateArgs<C>;
         if (createArgs.recovery != null || createArgs.signers != null) {
             const config = existingWallet.config as SmartWalletConfig;
-            const existingWalletSigner = config?.adminSigner;
+            const existingWalletSigners = config?.recovery ?? (config?.adminSigner != null ? [config.adminSigner] : []);
 
-            if (createArgs.recovery != null && existingWalletSigner != null) {
-                if (createArgs.recovery.type !== existingWalletSigner.type) {
+            const unmatchedExistingSigners = [...existingWalletSigners] as Array<RecoverySignerConfigForChain<C>>;
+            for (const inputRecoverySigner of toRecoverySignerList<C>(createArgs.recovery)) {
+                if (existingWalletSigners.length === 0) {
+                    break;
+                }
+                const matchIndex = unmatchedExistingSigners.findIndex((existingWalletSigner) =>
+                    this.matchesRecoverySigner(inputRecoverySigner, existingWalletSigner, args.chain)
+                );
+                const existingWalletSigner =
+                    matchIndex === -1
+                        ? unmatchedExistingSigners.find((s) => s.type === inputRecoverySigner.type)
+                        : unmatchedExistingSigners[matchIndex];
+                if (existingWalletSigner == null) {
                     throw new WalletCreationError(
                         "The wallet recovery signer type does not match the existing wallet's recovery signer type"
                     );
                 }
-                compareSignerConfigs(createArgs.recovery, existingWalletSigner);
+                compareSignerConfigs(inputRecoverySigner, existingWalletSigner);
+                if (matchIndex !== -1) {
+                    unmatchedExistingSigners.splice(matchIndex, 1);
+                }
             }
 
             const inputSigners = createArgs.signers;

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -78,6 +78,8 @@ type WalletContructorType<C extends Chain> = {
     alias?: string;
     options?: WalletOptions;
     recovery: RecoverySignerConfigForChain<C>;
+    /** Every recovery signer of the wallet, `recovery` being the first. Defaults to `[recovery]`. */
+    recoverySigners?: Array<RecoverySignerConfigForChain<C>>;
     apiRecoveryServerSignerAddress?: string;
     apiDelegatedServerSignerAddresses?: string[];
     signers?: SignerConfigForChain<C>[];
@@ -96,6 +98,7 @@ export class Wallet<C extends Chain> {
     #signerManager: SignerManager<C>;
     #deviceRecovery: DeviceRecoveryService<C>;
     #apiDelegatedServerSignerAddresses: string[] = [];
+    #recoverySigners: Array<RecoverySignerConfigForChain<C>>;
     #signerInitialization: Promise<void>;
     #recovering: Promise<void> | null = null;
 
@@ -107,6 +110,7 @@ export class Wallet<C extends Chain> {
             options,
             alias,
             recovery,
+            recoverySigners,
             apiRecoveryServerSignerAddress,
             apiDelegatedServerSignerAddresses,
             signers,
@@ -124,6 +128,7 @@ export class Wallet<C extends Chain> {
         } else if (recovery.type === "server" && isApiSourcedServerSignerConfig(recovery)) {
             apiRecoveryAddress = recovery.address;
         }
+        this.#recoverySigners = recoverySigners ?? [recovery];
         this.#apiDelegatedServerSignerAddresses = apiDelegatedServerSignerAddresses ?? [];
         this.#initialSigners = signers ?? [];
         this.#serverSignerResolver = new ServerSignerResolver({
@@ -291,6 +296,16 @@ export class Wallet<C extends Chain> {
      */
     public get recovery(): SignerConfigForChain<C> {
         return this.#signerManager.recovery;
+    }
+
+    /**
+     * Get every recovery signer config of the wallet. Wallets on chains that support a single recovery
+     * signer always return one entry.
+     * @returns The recovery signer configs, the first one being {@link Wallet.recovery}
+     * @experimental This API is experimental and may change in the future
+     */
+    public get recoverySigners(): Array<RecoverySignerConfigForChain<C>> {
+        return this.#recoverySigners;
     }
 
     /**

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -258,6 +258,10 @@ export class Wallet<C extends Chain> {
         return wallet.#signerManager.recovery as RecoverySignerConfigForChain<C>;
     }
 
+    protected static getRecoverySigners<C extends Chain>(wallet: Wallet<C>): Array<RecoverySignerConfigForChain<C>> {
+        return wallet.#recoverySigners;
+    }
+
     protected static getInitialSigners<C extends Chain>(wallet: Wallet<C>): SignerConfigForChain<C>[] {
         return wallet.#initialSigners;
     }


### PR DESCRIPTION
## Description

The backend already accepts `config.recovery` as a list of up to 10 admin signers on Solana and Stellar (EVM's DTO still takes a single one), but the SDK only ever sent one signer, under the deprecated singular `config.adminSigner`. This makes the list reachable from `@crossmint/wallets-sdk`.

```ts
await wallets.createWallet({
  chain: "solana",
  recovery: [{ type: "email", email }, { type: "external-wallet", address }], // or a single signer, as before
});
wallet.recoverySigners; // every recovery signer; wallet.recovery stays the first one
```

- `WalletCreateArgs.recovery` is `RecoverySignerConfigFor<C> | Array<...>` on Solana/Stellar and stays scalar elsewhere, so passing a list on EVM is a type error (and is rejected at runtime with `RecoveryNotSupportedOnChainError`).
- Request path: every entry is resolved independently (passkey credential created when it has no `id`, server signer address derived), sequentially so concurrent WebAuthn prompts can't collide. A list is sent as `config.recovery`, a single signer keeps using `config.adminSigner` — never both, which the backend rejects with `RECOVERY_ADMIN_SIGNER_CONFLICT`.
- Response path: reads `config.recovery` when present, falling back to `[config.adminSigner]`. Each returned signer is paired with the caller's config for the same signer (matching on identity — derived address for server signers — before type), so caller-only data (server secrets, external-wallet `onSign`, phone `channel`) survives the round trip while API-only data (passkey credential id) is kept.
- `packages/wallets/src/openapi.json`: Solana/Stellar `config.recovery` becomes an array (`minItems: 1`, `maxItems: 10`) on the request and is added to their responses, mirroring the backend DTO. EVM is untouched. The diff is large because wrapping the `oneOf` in `items` re-indents it.
- Errors: `SIGNER_LIMIT_EXCEEDED`, `RECOVERY_DUPLICATE_SIGNER`, `RECOVERY_SIGNER_CONFLICT`, `SIGNER_REQUIRED`, `RECOVERY_NOT_SUPPORTED_ON_CHAIN`, `NOT_SUPPORTED_ON_API_VERSION` and `RECOVERY_ADMIN_SIGNER_CONFLICT` map to dedicated SDK error classes; empty lists and lists over 10 fail client-side without a round trip.
- The react-base and react-native providers now iterate the recovery signers instead of assuming a single one (email backfill on `createOnLogin`, external-wallet readiness gate, passkey prompt/rejection), so `createOnLogin` behaves the same whether one signer or a list is configured.

## Test plan

* Unit tests in `packages/wallets/src/wallets/wallet-factory.test.ts`: Solana and Stellar list creation sent under `config.recovery` (and never alongside `adminSigner`), per-entry passkey creation and server signer derivation, response parsing of the `recovery` array, legacy `adminSigner`-only responses, preservation of caller-only secrets/callbacks/phone channel, empty-list and >10 validation, and the EVM single-signer restriction.
* Unit tests in `packages/wallets/src/utils/errors.test.ts` for each recovery error code mapping and the fallback when the body carries an unrelated code.
* `pnpm lint`, `pnpm build` and the wallets + react-base test suites pass locally. Not exercised against a live backend.

## Package updates

* `@crossmint/wallets-sdk`: minor
* `@crossmint/client-sdk-react-base`, `@crossmint/client-sdk-react-native-ui`: patch
* Changeset added in `.changeset/recovery-signer-list.md`.


Link to Devin session: https://crossmint.devinenterprise.com/sessions/520c831e21b04f9f9d2fbb524107c536
Open in Devin Desktop: https://crossmint.devinenterprise.com/desktop/session/520c831e21b04f9f9d2fbb524107c536?variant=devin
Requested by: @panosinthezone