### PR TITLE
feat(wallets): map backend recovery signer error codes to SDK errors

### DIFF
--- a/.changeset/recovery-errors.md
+++ b/.changeset/recovery-errors.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+Add recovery signer error classes (`RecoverySignerLimitExceededError`, `DuplicateRecoverySignerError`, `RecoverySignerConflictError`, `SignerRequiredError`, `RecoveryNotSupportedOnChainError`, `NotSupportedOnApiVersionError`, `RecoveryAdminSignerConflictError`, `InvalidRecoveryConfigError`), the `MAX_RECOVERY_SIGNERS` constant, and mapping of the backend recovery error codes to those errors.

--- a/packages/wallets/src/index.ts
+++ b/packages/wallets/src/index.ts
@@ -3,6 +3,15 @@ export { createCrossmint, CrossmintWallets } from "./sdk";
 
 // Errors
 export {
+    MAX_RECOVERY_SIGNERS,
+    DuplicateRecoverySignerError,
+    InvalidRecoveryConfigError,
+    NotSupportedOnApiVersionError,
+    RecoveryAdminSignerConflictError,
+    RecoveryNotSupportedOnChainError,
+    RecoverySignerConflictError,
+    RecoverySignerLimitExceededError,
+    SignerRequiredError,
     WalletNotAvailableError,
     InvalidTransferAmountError,
     QuorumSignerNotSupportedError,

--- a/packages/wallets/src/utils/errors.test.ts
+++ b/packages/wallets/src/utils/errors.test.ts
@@ -2,12 +2,20 @@ import { CrossmintErrors } from "@crossmint/common-sdk-base";
 import { describe, expect, test } from "vitest";
 
 import {
+    DuplicateRecoverySignerError,
     JWTDecryptionError,
     JWTExpiredError,
     JWTIdentifierError,
     JWTInvalidError,
     NotAuthorizedError,
+    NotSupportedOnApiVersionError,
+    RecoveryAdminSignerConflictError,
+    RecoveryNotSupportedOnChainError,
+    RecoverySignerConflictError,
+    RecoverySignerLimitExceededError,
+    SignerRequiredError,
     throwIfCrossmintApiAuthError,
+    throwIfRecoverySignerApiError,
 } from "./errors";
 
 describe("throwIfCrossmintApiAuthError", () => {
@@ -57,5 +65,45 @@ describe("throwIfCrossmintApiAuthError", () => {
         expect(() => throwIfCrossmintApiAuthError({ error: true, code: "SOME_OTHER_ERROR" })).not.toThrow();
         expect(() => throwIfCrossmintApiAuthError(null)).not.toThrow();
         expect(() => throwIfCrossmintApiAuthError("string")).not.toThrow();
+    });
+});
+
+describe("throwIfRecoverySignerApiError", () => {
+    const recoveryErrorCases = [
+        { code: "SIGNER_LIMIT_EXCEEDED", errorClass: RecoverySignerLimitExceededError },
+        { code: "RECOVERY_DUPLICATE_SIGNER", errorClass: DuplicateRecoverySignerError },
+        { code: "RECOVERY_SIGNER_CONFLICT", errorClass: RecoverySignerConflictError },
+        { code: "SIGNER_REQUIRED", errorClass: SignerRequiredError },
+        { code: "RECOVERY_NOT_SUPPORTED_ON_CHAIN", errorClass: RecoveryNotSupportedOnChainError },
+        { code: "NOT_SUPPORTED_ON_API_VERSION", errorClass: NotSupportedOnApiVersionError },
+        { code: "RECOVERY_ADMIN_SIGNER_CONFLICT", errorClass: RecoveryAdminSignerConflictError },
+    ];
+
+    test.each(recoveryErrorCases)("throws $errorClass.name when the code is $code", ({ code, errorClass }) => {
+        expect(() => throwIfRecoverySignerApiError({ error: true, code })).toThrow(errorClass);
+    });
+
+    test("surfaces the API message and the full response body as details", () => {
+        const body = { error: true, code: "RECOVERY_DUPLICATE_SIGNER", message: "signer already an admin" };
+
+        try {
+            throwIfRecoverySignerApiError(body);
+            expect.fail("Expected throwIfRecoverySignerApiError to throw");
+        } catch (error) {
+            expect((error as DuplicateRecoverySignerError).message).toBe("signer already an admin");
+            expect((error as DuplicateRecoverySignerError).details).toBe(JSON.stringify(body));
+        }
+    });
+
+    test("falls back to a descriptive message when the API sends none", () => {
+        expect(() => throwIfRecoverySignerApiError({ error: true, code: "SIGNER_LIMIT_EXCEEDED" })).toThrow(
+            "A wallet can have at most 10 recovery signers"
+        );
+    });
+
+    test("does not throw for unrelated error bodies", () => {
+        expect(() => throwIfRecoverySignerApiError({ error: true, message: "Wallet not found" })).not.toThrow();
+        expect(() => throwIfRecoverySignerApiError({ error: true, code: "SOME_OTHER_ERROR" })).not.toThrow();
+        expect(() => throwIfRecoverySignerApiError(null)).not.toThrow();
     });
 });

--- a/packages/wallets/src/utils/errors.ts
+++ b/packages/wallets/src/utils/errors.ts
@@ -352,7 +352,7 @@ export function throwIfRecoverySignerApiError(response: unknown): void {
             );
         case "RECOVERY_SIGNER_CONFLICT":
             throw new RecoverySignerConflictError(
-                message ?? "A recovery signer cannot also be registered as a delegated signer",
+                message ?? "A recovery signer cannot also be registered as an operational signer",
                 details
             );
         case "SIGNER_REQUIRED":

--- a/packages/wallets/src/utils/errors.ts
+++ b/packages/wallets/src/utils/errors.ts
@@ -104,6 +104,61 @@ export class QuorumSignerNotSupportedError extends CrossmintSDKError {
 }
 
 /**
+ * Maximum number of recovery signers a wallet can be created with, mirroring the backend's
+ * `SOLANA_MAX_ADMIN_SIGNERS` cap. Requests above it are rejected with `SIGNER_LIMIT_EXCEEDED`.
+ */
+export const MAX_RECOVERY_SIGNERS = 10;
+
+/** Thrown for recovery configurations the SDK can reject before calling the API. */
+export class InvalidRecoveryConfigError extends CrossmintSDKError {
+    constructor(message: string, details?: string) {
+        super(message, WalletErrorCode.SIGNER_INVALID, details);
+    }
+}
+
+export class RecoverySignerLimitExceededError extends CrossmintSDKError {
+    constructor(message: string, details?: string) {
+        super(message, WalletErrorCode.SIGNER_INVALID, details);
+    }
+}
+
+export class DuplicateRecoverySignerError extends CrossmintSDKError {
+    constructor(message: string, details?: string) {
+        super(message, WalletErrorCode.SIGNER_INVALID, details);
+    }
+}
+
+export class RecoverySignerConflictError extends CrossmintSDKError {
+    constructor(message: string, details?: string) {
+        super(message, WalletErrorCode.SIGNER_INVALID, details);
+    }
+}
+
+export class SignerRequiredError extends CrossmintSDKError {
+    constructor(message: string, details?: string) {
+        super(message, WalletErrorCode.SIGNER_INVALID, details);
+    }
+}
+
+export class RecoveryNotSupportedOnChainError extends CrossmintSDKError {
+    constructor(message: string, details?: string) {
+        super(message, WalletErrorCode.SIGNER_INVALID, details);
+    }
+}
+
+export class NotSupportedOnApiVersionError extends CrossmintSDKError {
+    constructor(message: string, details?: string) {
+        super(message, WalletErrorCode.SIGNER_INVALID, details);
+    }
+}
+
+export class RecoveryAdminSignerConflictError extends CrossmintSDKError {
+    constructor(message: string, details?: string) {
+        super(message, WalletErrorCode.SIGNER_INVALID, details);
+    }
+}
+
+/**
  * Thrown when the browser does not support third-party storage partitioning,
  * making it unsafe to store device-signer keys in IndexedDB. Consumers should
  * either prompt the user to upgrade their browser or fall back to a non-device
@@ -272,6 +327,58 @@ export function throwIfCrossmintApiAuthError(response: unknown): void {
     }
 }
 
+/**
+ * Inspects a Crossmint wallets API error response and, when it carries a recognized recovery-signer
+ * error code, throws the corresponding typed error. Returns without throwing for every other
+ * response so callers can fall back to their own contextual error.
+ */
+export function throwIfRecoverySignerApiError(response: unknown): void {
+    if (!isCrossmintApiErrorBody(response) || response.code == null) {
+        return;
+    }
+
+    const details = JSON.stringify(response);
+    const message = response.message;
+    switch (response.code) {
+        case "SIGNER_LIMIT_EXCEEDED":
+            throw new RecoverySignerLimitExceededError(
+                message ?? `A wallet can have at most ${MAX_RECOVERY_SIGNERS} recovery signers`,
+                details
+            );
+        case "RECOVERY_DUPLICATE_SIGNER":
+            throw new DuplicateRecoverySignerError(
+                message ?? "The recovery list contains the same signer more than once",
+                details
+            );
+        case "RECOVERY_SIGNER_CONFLICT":
+            throw new RecoverySignerConflictError(
+                message ?? "A recovery signer cannot also be registered as a delegated signer",
+                details
+            );
+        case "SIGNER_REQUIRED":
+            throw new SignerRequiredError(
+                message ??
+                    "This wallet has multiple recovery signers, so the signer to authorize with must be specified explicitly",
+                details
+            );
+        case "RECOVERY_NOT_SUPPORTED_ON_CHAIN":
+            throw new RecoveryNotSupportedOnChainError(
+                message ?? "Multiple recovery signers are not supported on this chain yet",
+                details
+            );
+        case "NOT_SUPPORTED_ON_API_VERSION":
+            throw new NotSupportedOnApiVersionError(
+                message ?? "Multiple recovery signers are not supported on this API version",
+                details
+            );
+        case "RECOVERY_ADMIN_SIGNER_CONFLICT":
+            throw new RecoveryAdminSignerConflictError(
+                message ?? "Only one of `adminSigner` and `recovery` can be provided",
+                details
+            );
+    }
+}
+
 export type WalletError =
     | InvalidTransferAmountError
     | InvalidApiKeyError
@@ -286,6 +393,14 @@ export type WalletError =
     | InvalidSignerError
     | UnknownSignerTypeError
     | DeviceSignerNotSupportedError
+    | InvalidRecoveryConfigError
+    | RecoverySignerLimitExceededError
+    | DuplicateRecoverySignerError
+    | RecoverySignerConflictError
+    | SignerRequiredError
+    | RecoveryNotSupportedOnChainError
+    | NotSupportedOnApiVersionError
+    | RecoveryAdminSignerConflictError
     | InvalidMessageFormatError
     | InvalidTypedDataError
     | SignatureNotFoundError


### PR DESCRIPTION
## Description

Part 2/4 of splitting #2035 into a reviewable stack (stacked on #2037).

Adds SDK error classes for the backend's stable recovery error codes, plus `throwIfRecoverySignerApiError(response)` which maps an API error body to the right class:

| Backend code | SDK error |
| --- | --- |
| `SIGNER_LIMIT_EXCEEDED` | `RecoverySignerLimitExceededError` |
| `RECOVERY_DUPLICATE_SIGNER` | `DuplicateRecoverySignerError` |
| `RECOVERY_SIGNER_CONFLICT` | `RecoverySignerConflictError` |
| `SIGNER_REQUIRED` | `SignerRequiredError` |
| `RECOVERY_NOT_SUPPORTED_ON_CHAIN` | `RecoveryNotSupportedOnChainError` |
| `NOT_SUPPORTED_ON_API_VERSION` | `NotSupportedOnApiVersionError` |
| `RECOVERY_ADMIN_SIGNER_CONFLICT` | `RecoveryAdminSignerConflictError` |

Also adds `InvalidRecoveryConfigError` and `MAX_RECOVERY_SIGNERS = 10` for client-side validation, and exports everything from the package index. Nothing calls the mapping yet — the wallet factory wires it up in the next PR of the stack.

## Test plan

* New unit tests in `src/utils/errors.test.ts` cover every code above, fallback messages, API error details, and that unrelated API bodies are not swallowed.
* `pnpm --filter @crossmint/wallets-sdk test:vitest` passes.

## Package updates

* `@crossmint/wallets-sdk` (patch) — changeset `recovery-errors` added.


Link to Devin session: https://crossmint.devinenterprise.com/sessions/520c831e21b04f9f9d2fbb524107c536
Open in Devin Desktop: https://crossmint.devinenterprise.com/desktop/session/520c831e21b04f9f9d2fbb524107c536?variant=devin
Requested by: @panosinthezone