### PR TITLE
docs(react-ui): document recovery signer lists in createOnLogin

### DIFF
--- a/.changeset/recovery-list-docs.md
+++ b/.changeset/recovery-list-docs.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+---
+
+Document that `createOnLogin.recovery` accepts a list of up to 10 recovery signers on Solana and Stellar.

--- a/packages/client/ui/react-ui/README.md
+++ b/packages/client/ui/react-ui/README.md
@@ -127,7 +127,7 @@ When `createOnLogin` is set on `CrossmintWalletProvider`, a wallet is automatica
 >
 ```
 
-On Solana and Stellar, `recovery` also accepts a list of up to 10 signers, each able to recover the wallet on its own. EVM chains take a single recovery signer:
+On Solana and Stellar, `recovery` also accepts a list of signers, each able to recover the wallet on its own. EVM chains take a single recovery signer:
 
 ```tsx
 <CrossmintWalletProvider

--- a/packages/client/ui/react-ui/README.md
+++ b/packages/client/ui/react-ui/README.md
@@ -127,6 +127,17 @@ When `createOnLogin` is set on `CrossmintWalletProvider`, a wallet is automatica
 >
 ```
 
+On Solana and Stellar, `recovery` also accepts a list of up to 10 signers, each able to recover the wallet on its own. EVM chains take a single recovery signer:
+
+```tsx
+<CrossmintWalletProvider
+  createOnLogin={{
+    chain: "solana",
+    recovery: [{ type: "email" }, { type: "external-wallet", address: "9WzD..." }],
+  }}
+>
+```
+
 ## Hooks
 
 ### `useWallet()`


### PR DESCRIPTION
## Description

Part 4/4 of splitting #2035 into a reviewable stack (stacked on #2039).

Updates the `react-ui` README's `createOnLogin` docs: Solana and Stellar accept `recovery` as a list of up to 10 recovery signers (with an example using email and external-wallet signers); EVM remains a single signer.

(The provider runtime changes originally in this PR moved into #2039, since they are required for the packages to compile against the widened `recovery` type.)

## Test plan

* Docs-only change; verified the README example matches the API shipped in #2039 and that `pnpm lint` passes.

## Package updates

* `@crossmint/client-sdk-react-ui` (patch) — changeset `recovery-list-docs` added.


Link to Devin session: https://crossmint.devinenterprise.com/sessions/520c831e21b04f9f9d2fbb524107c536
Open in Devin Desktop: https://crossmint.devinenterprise.com/desktop/session/520c831e21b04f9f9d2fbb524107c536?variant=devin
Requested by: @panosinthezone