### PR TITLE
docs(wallets): stop emitting the V1 version banner in generated SDK reference docs

### DIFF
--- a/.changeset/remove-wallets-v1-docs-banner.md
+++ b/.changeset/remove-wallets-v1-docs-banner.md
@@ -1,0 +1,7 @@
+---
+"@crossmint/client-sdk-react-native-ui": patch
+"@crossmint/client-sdk-react-ui": patch
+"@crossmint/wallets-sdk": patch
+---
+
+Remove the Wallets SDK V1 version banner from generated SDK reference docs

--- a/packages/client/ui/react-native/scripts/generate-reference.mjs
+++ b/packages/client/ui/react-native/scripts/generate-reference.mjs
@@ -18,10 +18,6 @@ const PRODUCTS = {
         npmUrl: "https://www.npmjs.com/package/@crossmint/client-sdk-react-native-ui",
         installSnippet: "client-sdk-react-native-ui-installation-cmd.mdx",
         intro: "The Crossmint React Native SDK (`@crossmint/client-sdk-react-native-ui`) provides React Native components and hooks for integrating Crossmint wallets into your mobile application.",
-        versionBanner: `<Note>
-**This page has been updated for Wallets SDK V1.** If you are using the previous version,
-see the [previous version of this page](/sdk-reference/wallets/v0/react-native/{page}) or the [V1 migration guide](/wallets/guides/migrate-to-v1).
-</Note>`,
         exports: [
             "CrossmintProvider",
             "CrossmintWalletProvider",

--- a/packages/client/ui/react-ui/scripts/generate-reference.mjs
+++ b/packages/client/ui/react-ui/scripts/generate-reference.mjs
@@ -18,10 +18,6 @@ const PRODUCTS = {
         npmUrl: "https://www.npmjs.com/package/@crossmint/client-sdk-react-ui",
         installSnippet: "client-sdk-react-ui-installation-cmd.mdx",
         intro: "The Crossmint React SDK (`@crossmint/client-sdk-react-ui`) provides React components and hooks for integrating Crossmint wallets into your application.",
-        versionBanner: `<Note>
-**This page has been updated for Wallets SDK V1.** If you are using the previous version,
-see the [previous version of this page](/sdk-reference/wallets/v0/react/{page}) or the [V1 migration guide](/wallets/guides/migrate-to-v1).
-</Note>`,
         exports: ["CrossmintProvider", "CrossmintWalletProvider", "useWallet", "ExportPrivateKeyButton"],
         descriptions: {
             CrossmintProvider: "SDK initialization (required for all Crossmint features)",

--- a/packages/client/ui/scripts/generate-reference.mjs
+++ b/packages/client/ui/scripts/generate-reference.mjs
@@ -678,12 +678,6 @@ export function generate(config) {
     // Page generators
     // =========================================================================
 
-    function emitBanner(emit, product, pageName) {
-        if (!product.versionBanner) return;
-        emit(product.versionBanner.replaceAll("{page}", pageName));
-        emit("");
-    }
-
     function buildGetStarted(product) {
         const L = [];
         const emit = (...a) => L.push(a.join(""));
@@ -693,7 +687,6 @@ export function generate(config) {
         emit(`description: Installation and setup for the ${product.description}`);
         emit("---");
         emit("");
-        emitBanner(emit, product, "get-started");
 
         // Version shield badge
         if (product.npmUrl && product.packageName) {
@@ -756,7 +749,6 @@ export function generate(config) {
         emit(`description: ${product.title.replace(/ SDK$/, "")} context providers for ${product.description}`);
         emit("---");
         emit("");
-        emitBanner(emit, product, "providers");
 
         const { providers } = classifyExports(product.exports);
 
@@ -814,7 +806,6 @@ export function generate(config) {
         emit(`description: ${product.title.replace(/ SDK$/, "")} hooks for ${product.description}`);
         emit("---");
         emit("");
-        emitBanner(emit, product, "hooks");
 
         const { hooks } = classifyExports(product.exports);
 

--- a/packages/wallets/typedoc-custom-plugin.mjs
+++ b/packages/wallets/typedoc-custom-plugin.mjs
@@ -4,18 +4,6 @@ import { fileURLToPath } from "node:url";
 import { MarkdownPageEvent } from "typedoc-plugin-markdown";
 
 const pkg = JSON.parse(readFileSync(join(dirname(fileURLToPath(import.meta.url)), "package.json"), "utf8"));
-const CURRENT_MAJOR_VERSION = Number.parseInt(pkg.version.split(".")[0], 10);
-const PREVIOUS_MAJOR_VERSION = CURRENT_MAJOR_VERSION - 1;
-
-const PAGE_RENAMES = { "globals.mdx": "reference", "README.mdx": "overview" };
-
-function versionBanner(pageUrl) {
-    const pagePath = PAGE_RENAMES[pageUrl] ?? pageUrl.replace(/\.mdx$/, "");
-    return `<Note>
-**This page has been updated for Wallets SDK V${CURRENT_MAJOR_VERSION}.** If you are using the previous version,
-see the [previous version of this page](/sdk-reference/wallets/v${PREVIOUS_MAJOR_VERSION}/typescript/${pagePath}) or the [V${CURRENT_MAJOR_VERSION} migration guide](/wallets/guides/migrate-to-v${CURRENT_MAJOR_VERSION}).
-</Note>`;
-}
 
 // README.mdx is renamed to overview.mdx in the workflow; its typedoc-derived
 // title is the package name, which collides with reference.mdx in nav. Give
@@ -95,16 +83,6 @@ export function load(app) {
                     "[typedoc-custom-plugin] npm badge insertion failed — README description may have changed"
                 );
             }
-        }
-
-        const banner = versionBanner(page.url);
-        const frontmatterMatch = page.contents.match(/^---\n[\s\S]*?\n---\n/);
-        if (frontmatterMatch) {
-            const idx = frontmatterMatch[0].length;
-            const body = page.contents.slice(idx).replace(/^\n+/, "");
-            page.contents = `${frontmatterMatch[0]}\n${banner}\n\n${body}`;
-        } else {
-            page.contents = `${banner}\n\n${page.contents.replace(/^\n+/, "")}`;
         }
     });
 }


### PR DESCRIPTION
## Description

The "This page has been updated for Wallets SDK V1… see the previous version docs or the V1 migration guide" `<Note>` banner is being removed from docs.crossmint.com. The `sdk-reference/wallets/**` pages are generated from this repo, so the banner has to stop being emitted here or the next sdk-reference sync would put it back.

- `packages/wallets/typedoc-custom-plugin.mjs`: drop `versionBanner()` and the block that prepended it after the frontmatter (`typescript` reference pages).
- `packages/client/ui/react-ui` and `react-native` generators: drop the `versionBanner` product config; the now-unused `emitBanner()` and its call sites are removed from the shared engine.

Companion docs PR removing the already-generated banner: Paella-Labs/crossbit-main#29528.

## Test plan

* Generator-only change with no runtime code touched; verified no `versionBanner`/`emitBanner` references remain and biome reports no new diagnostics on the four touched files.

## Package updates

* Patch changeset for `@crossmint/wallets-sdk`, `@crossmint/client-sdk-react-ui`, `@crossmint/client-sdk-react-native-ui` (doc generation only).


Link to Devin session: https://crossmint.devinenterprise.com/sessions/b56772d84fdb4fc4b9570779bae1d81a
Open in Devin Desktop: https://crossmint.devinenterprise.com/desktop/session/b56772d84fdb4fc4b9570779bae1d81a?variant=devin
Requested by: @albertoelias-crossmint
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/crossmint-sdk/pull/2042" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->