### PR TITLE
Recovery: make the recovery methods list the single source of truth

### DIFF
--- a/.changeset/recovery-list-hardening.md
+++ b/.changeset/recovery-list-hardening.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+Harden `wallet.useSigner` for recovery signer lists: server secrets are stripped from every entry of `wallet.recoveryMethods` (not only the primary), each server recovery signer resolves its own primary/legacy derivation and cached secret, and a passkey only matches a recovery signer with the same credential id when both are known. Constructing a wallet with an empty recovery list now throws `InvalidRecoveryConfigError`.

--- a/packages/wallets/src/signers/descriptors/descriptors.test.ts
+++ b/packages/wallets/src/signers/descriptors/descriptors.test.ts
@@ -152,6 +152,11 @@ it.each<[name: string, config: Config, expected: object]>([
         cfg({ type: "passkey", id: "cred-1" }),
         { type: "passkey", id: "cred-1", locator: "passkey:cred-1" },
     ],
+    [
+        "missing id is taken from a passkey:{id} locator",
+        cfg({ type: "passkey", locator: "passkey:cred-2" }),
+        { type: "passkey", id: "cred-2", locator: "passkey:cred-2" },
+    ],
 ])("buildInternalConfig: passkey %s", (_name, config, expected) => {
     expect(getSignerDescriptor("passkey").buildInternalConfig(config as never, makeCtx())).toMatchObject(expected);
 });

--- a/packages/wallets/src/signers/descriptors/descriptors.test.ts
+++ b/packages/wallets/src/signers/descriptors/descriptors.test.ts
@@ -34,7 +34,7 @@ function makeCtx(
         deviceSignerKeyStorage: overrides.deviceSignerKeyStorage,
         serverSigners: {
             keyMaterialForAssembly: vi.fn(() => SERVER_KEY_MATERIAL),
-            hasRecoveryResolution: overrides.hasRecoveryResolution ?? false,
+            hasRecoveryResolutionFor: vi.fn(() => overrides.hasRecoveryResolution ?? false),
             apiLocator: overrides.apiLocator ?? vi.fn(() => "server:0xDerivedServer"),
             candidateAddresses: overrides.candidateAddresses ?? vi.fn(() => []),
         } as unknown as ServerSignerResolver,
@@ -233,14 +233,33 @@ it("matchesRecovery: device is always false", () => {
     ).toBe(false);
 });
 
-it("matchesRecovery: passkey is true even with differing ids", () => {
-    expect(
-        getSignerDescriptor("passkey").matchesRecovery(
-            cfg({ type: "passkey", id: "cred-1" }) as never,
-            cfg({ type: "passkey" }) as never,
-            makeCtx()
-        )
-    ).toBe(true);
+it.each<[name: string, config: Config, recovery: Config, expected: boolean]>([
+    ["recovery has no credential id", cfg({ type: "passkey", id: "cred-1" }), cfg({ type: "passkey" }), true],
+    ["config has no credential id", cfg({ type: "passkey" }), cfg({ type: "passkey", id: "cred-1" }), true],
+    ["both ids match", cfg({ type: "passkey", id: "cred-1" }), cfg({ type: "passkey", id: "cred-1" }), true],
+    ["ids differ", cfg({ type: "passkey", id: "cred-1" }), cfg({ type: "passkey", id: "cred-2" }), false],
+    [
+        "id matches the recovery locator",
+        cfg({ type: "passkey", id: "cred-1" }),
+        cfg({ type: "passkey", locator: "passkey:cred-1" }),
+        true,
+    ],
+    [
+        "id differs from the recovery locator",
+        cfg({ type: "passkey", id: "cred-1" }),
+        cfg({ type: "passkey", locator: "passkey:cred-2" }),
+        false,
+    ],
+    [
+        "recovery locator has no id",
+        cfg({ type: "passkey", id: "cred-1" }),
+        cfg({ type: "passkey", locator: "passkey:" }),
+        true,
+    ],
+])("matchesRecovery: passkey when %s", (_name, config, recovery, expected) => {
+    expect(getSignerDescriptor("passkey").matchesRecovery(config as never, recovery as never, makeCtx())).toBe(
+        expected
+    );
 });
 
 it.each<[name: string, signerAddrs: string[], recoveryAddrs: string[], expected: boolean]>([

--- a/packages/wallets/src/signers/descriptors/passkey.ts
+++ b/packages/wallets/src/signers/descriptors/passkey.ts
@@ -10,6 +10,20 @@ import type {
 } from "../types";
 import type { SignerDescriptor } from "./types";
 
+const PASSKEY_LOCATOR_PREFIX = "passkey:";
+
+/** The credential id from `id` or a `passkey:{id}` locator, or null when the config carries neither. */
+function passkeyCredentialId(config: PasskeySignerConfig): string | null {
+    if (config.id != null && config.id !== "") {
+        return config.id;
+    }
+    if (config.locator != null && config.locator.startsWith(PASSKEY_LOCATOR_PREFIX)) {
+        const id = config.locator.slice(PASSKEY_LOCATOR_PREFIX.length);
+        return id === "" ? null : id;
+    }
+    return null;
+}
+
 export const passkeySignerDescriptor: SignerDescriptor = {
     type: "passkey",
     validateConfig(): void {},
@@ -34,11 +48,17 @@ export const passkeySignerDescriptor: SignerDescriptor = {
     addSignerPayload(config: SignerConfigForChain<Chain>): RegisterSignerParams["signer"] {
         return config as RegisterSignerParams["signer"];
     },
-    matchesRecovery(_config: SignerConfigForChain<Chain>, _recovery: RecoverySignerConfigForChain<Chain>): boolean {
-        // Compare by type only: the api-sourced recovery config has {type:"passkey"} without a
-        // credential id, so locator comparison ("passkey" vs "passkey:{id}") would fail. Type
-        // already matches by the time this is called.
-        return true;
+    matchesRecovery(config: SignerConfigForChain<Chain>, recovery: RecoverySignerConfigForChain<Chain>): boolean {
+        // The api-sourced recovery config is often {type:"passkey"} without a credential id, in
+        // which case type (already matched by the caller) is all there is to compare. When both
+        // sides carry a credential id they must agree, so a supplied passkey does not match an
+        // unrelated passkey recovery signer.
+        const configId = passkeyCredentialId(config as PasskeySignerConfig);
+        const recoveryId = passkeyCredentialId(recovery as PasskeySignerConfig);
+        if (configId == null || recoveryId == null) {
+            return true;
+        }
+        return configId === recoveryId;
     },
     adoptsRecoveryConfigOnMatch: false,
     signerUnavailableReason: () => null,

--- a/packages/wallets/src/signers/descriptors/passkey.ts
+++ b/packages/wallets/src/signers/descriptors/passkey.ts
@@ -8,21 +8,8 @@ import type {
     SignerConfigForChain,
     SignerLocator,
 } from "../types";
+import { passkeyCredentialId } from "../../utils/signer-locator";
 import type { SignerDescriptor } from "./types";
-
-const PASSKEY_LOCATOR_PREFIX = "passkey:";
-
-/** The credential id from `id` or a `passkey:{id}` locator, or null when the config carries neither. */
-function passkeyCredentialId(config: PasskeySignerConfig): string | null {
-    if (config.id != null && config.id !== "") {
-        return config.id;
-    }
-    if (config.locator != null && config.locator.startsWith(PASSKEY_LOCATOR_PREFIX)) {
-        const id = config.locator.slice(PASSKEY_LOCATOR_PREFIX.length);
-        return id === "" ? null : id;
-    }
-    return null;
-}
 
 export const passkeySignerDescriptor: SignerDescriptor = {
     type: "passkey",
@@ -31,7 +18,7 @@ export const passkeySignerDescriptor: SignerDescriptor = {
         config: SignerConfigForChain<C> | ApiSourcedServerSignerConfig
     ): InternalSignerConfig<C> {
         const passkeyConfig = config as PasskeySignerConfig;
-        const id = "id" in passkeyConfig && passkeyConfig.id ? passkeyConfig.id : "";
+        const id = passkeyCredentialId(passkeyConfig) ?? "";
         return {
             type: "passkey",
             id,

--- a/packages/wallets/src/signers/descriptors/server.ts
+++ b/packages/wallets/src/signers/descriptors/server.ts
@@ -39,7 +39,7 @@ export const serverSignerDescriptor: SignerDescriptor = {
         config: SignerConfigForChain<C> | ApiSourcedServerSignerConfig,
         ctx: SignerDescriptorContext<C>
     ): boolean {
-        return !isApiSourcedServerSignerConfig(config) || ctx.serverSigners.hasRecoveryResolution;
+        return !isApiSourcedServerSignerConfig(config) || ctx.serverSigners.hasRecoveryResolutionFor(config.address);
     },
 
     addSignerPayload<C extends Chain>(

--- a/packages/wallets/src/signers/server/resolver.test.ts
+++ b/packages/wallets/src/signers/server/resolver.test.ts
@@ -38,7 +38,7 @@ const expectWipedAndKept = (rec: RecordedCandidates, wiped: Slot, survivor: Slot
 const fullConfig = (secret: string): ServerSignerConfig => ({ type: "server", secret });
 const apiConfig = (address: string): ApiSourcedServerSignerConfig => ({ type: "server", address });
 const makeResolver = (overrides?: {
-    apiRecoveryAddress?: string | null;
+    apiRecoveryAddresses?: string[];
     apiDelegatedAddresses?: string[];
     knownOnChainAddresses?: string[];
 }): ServerSignerResolver =>
@@ -46,12 +46,12 @@ const makeResolver = (overrides?: {
         chain: "base-sepolia",
         projectId: "proj_test_123",
         environment: "staging",
-        apiRecoveryAddress: overrides?.apiRecoveryAddress ?? null,
+        apiRecoveryAddresses: overrides?.apiRecoveryAddresses ?? [],
         apiDelegatedAddresses: overrides?.apiDelegatedAddresses ?? [],
         knownOnChainAddresses: () => overrides?.knownOnChainAddresses ?? [],
     });
-const cacheRecovery = (r: ServerSignerResolver, rec: RecordedCandidates[], secret: string) => {
-    expect(r.resolveForUseSigner(fullConfig(secret), [], () => true)).toEqual({ kind: "recovery" });
+const cacheRecovery = (r: ServerSignerResolver, rec: RecordedCandidates[], secret: string, address: string) => {
+    expect(r.resolveForUseSigner(fullConfig(secret), [], () => true)).toEqual({ kind: "recovery", address });
     return rec[rec.length - 1];
 };
 const cacheDelegated = (r: ServerSignerResolver, rec: RecordedCandidates[], secret: string, loc: string) => {
@@ -73,11 +73,32 @@ describe("ServerSignerResolver", () => {
     describe("resolveDerivation", () => {
         it("returns the cached recovery resolution for api-sourced config", () => {
             const recorded = installCandidates({ rec: { primary: { address: "0xRec", fill: 5 }, legacy: null } });
-            const resolver = makeResolver({ apiRecoveryAddress: "0xRec" });
-            cacheRecovery(resolver, recorded, "rec");
+            const resolver = makeResolver({ apiRecoveryAddresses: ["0xRec"] });
+            cacheRecovery(resolver, recorded, "rec", "0xRec");
             const resolved = resolver.resolveDerivation(apiConfig("0xRec"));
             expect(resolved.derivedAddress).toBe("0xRec");
             expect(everyByteIs(resolved.derivedKeyBytes, 5)).toBe(true);
+        });
+        it("returns the recovery resolution matching each api-sourced address when several recovery secrets are cached", () => {
+            const recorded = installCandidates({
+                a: { primary: { address: "0xRecA", fill: 5 }, legacy: null },
+                b: { primary: { address: "0xRecB", fill: 6 }, legacy: null },
+            });
+            const resolver = makeResolver({ apiRecoveryAddresses: ["0xRecA", "0xRecB"] });
+            const cachedA = cacheRecovery(resolver, recorded, "a", "0xRecA").primary;
+            const cachedB = cacheRecovery(resolver, recorded, "b", "0xRecB").primary;
+            expect(resolver.resolveDerivation(apiConfig("0xRecA"))).toBe(cachedA);
+            expect(resolver.resolveDerivation(apiConfig("0xRecB"))).toBe(cachedB);
+            expect(everyByteIs(cachedA.derivedKeyBytes, 5)).toBe(true);
+            expect(everyByteIs(cachedB.derivedKeyBytes, 6)).toBe(true);
+        });
+        it("throws for an api-sourced address whose secret has not been provided even when another recovery is cached", () => {
+            const recorded = installCandidates({ a: { primary: { address: "0xRecA", fill: 5 }, legacy: null } });
+            const resolver = makeResolver({ apiRecoveryAddresses: ["0xRecA", "0xRecB"] });
+            cacheRecovery(resolver, recorded, "a", "0xRecA");
+            expect(() => resolver.resolveDerivation(apiConfig("0xRecB"))).toThrow(
+                "Cannot resolve server signer derivation: no secret available and no cached recovery resolution."
+            );
         });
         it("throws the exact message when api-sourced config has no cached recovery resolution", () => {
             expect(() => makeResolver().resolveDerivation(apiConfig("0xSome"))).toThrow(
@@ -86,21 +107,21 @@ describe("ServerSignerResolver", () => {
             );
         });
         it("returns the cache hit and wipes both fresh candidates", () => {
-            const resolver = makeResolver({ apiRecoveryAddress: "0xRecPrimary" });
+            const resolver = makeResolver({ apiRecoveryAddresses: ["0xRecPrimary"] });
             const recorded = installCandidates({
                 rec: { primary: { address: "0xRecPrimary", fill: 7 }, legacy: { address: "0xRecLegacy", fill: 9 } },
             });
-            cacheRecovery(resolver, recorded, "rec");
+            cacheRecovery(resolver, recorded, "rec", "0xRecPrimary");
             const cached = recorded[0].primary;
             expect(resolver.resolveDerivation(fullConfig("rec"))).toBe(cached);
             expect(isZeroed(recorded[1].primary.derivedKeyBytes)).toBe(true);
             expect(isZeroed(recorded[1].legacy!.derivedKeyBytes)).toBe(true);
             expect(everyByteIs(cached.derivedKeyBytes, 7)).toBe(true);
         });
-        it.each([
-            ["legacy matches apiRecoveryAddress", { apiRecoveryAddress: "0xLegacy" }],
+        it.each<[string, Parameters<typeof makeResolver>[0]]>([
+            ["legacy matches an api recovery address", { apiRecoveryAddresses: ["0xLegacy"] }],
             ["legacy is a known on-chain address", { knownOnChainAddresses: ["0xLegacy"] }],
-        ] as const)("picks legacy and wipes primary when %s", (_t, o) => {
+        ])("picks legacy and wipes primary when %s", (_t, o) => {
             const recorded = installDual();
             expect(makeResolver(o).resolveDerivation(fullConfig("s")).derivedAddress).toBe("0xLegacy");
             expectWipedAndKept(recorded[0], "primary", "legacy", 9);
@@ -143,11 +164,14 @@ describe("ServerSignerResolver", () => {
             installCandidates({ s: { primary: { address: "0xPrimary", fill: 7 }, legacy: null } });
             expect(resolver.resolveDerivation(fullConfig("s"))).toBe(cached);
         });
-        it("returns recovery and caches the recovery slot when not registered but isRecovery is true", () => {
+        it("returns recovery with the selected address and caches it when not registered but isRecovery is true", () => {
             installCandidates({ s: { primary: { address: "0xPrimary", fill: 7 }, legacy: null } });
             const resolver = makeResolver();
-            expect(resolver.resolveForUseSigner(fullConfig("s"), [], () => true)).toEqual({ kind: "recovery" });
-            expect(resolver.hasRecoveryResolution).toBe(true);
+            expect(resolver.resolveForUseSigner(fullConfig("s"), [], () => true)).toEqual({
+                kind: "recovery",
+                address: "0xPrimary",
+            });
+            expect(resolver.hasRecoveryResolutionFor("0xPrimary")).toBe(true);
         });
         it("returns the dual-locator unregistered message and wipes both candidates", () => {
             const recorded = installCandidates({
@@ -173,20 +197,46 @@ describe("ServerSignerResolver", () => {
             expect(isRecovery).not.toHaveBeenCalled();
         });
         it.each([
-            ["legacy matches apiRecoveryAddress", "0xLegacy", "primary", "legacy", 9],
+            ["legacy matches an api recovery address", "0xLegacy", "primary", "legacy", 9],
             ["primary otherwise", "0xPrimary", "legacy", "primary", 7],
         ] as const)("caches the recovery slot and wipes the non-selected candidate (%s)", (_t, rec, w, s, f) => {
             const recorded = installDual();
-            const resolver = makeResolver({ apiRecoveryAddress: rec });
-            expect(resolver.resolveForUseSigner(fullConfig("s"), [], () => true)).toEqual({ kind: "recovery" });
-            expect(resolver.resolvedRecoveryAddress).toBe(rec);
+            const resolver = makeResolver({ apiRecoveryAddresses: [rec] });
+            expect(resolver.resolveForUseSigner(fullConfig("s"), [], () => true)).toEqual({
+                kind: "recovery",
+                address: rec,
+            });
+            expect(resolver.hasRecoveryResolutionFor(rec)).toBe(true);
             expectWipedAndKept(recorded[0], w, s, f);
+        });
+        it("selects the legacy derivation for a secondary recovery signer whose api address is the legacy one", () => {
+            const recorded = installCandidates({
+                a: { primary: { address: "0xRecA", fill: 5 }, legacy: null },
+                b: { primary: { address: "0xRecBPrimary", fill: 7 }, legacy: { address: "0xRecBLegacy", fill: 9 } },
+            });
+            const resolver = makeResolver({ apiRecoveryAddresses: ["0xRecA", "0xRecBLegacy"] });
+            cacheRecovery(resolver, recorded, "a", "0xRecA");
+            expect(resolver.resolveForUseSigner(fullConfig("b"), [], () => true)).toEqual({
+                kind: "recovery",
+                address: "0xRecBLegacy",
+            });
+            expectWipedAndKept(recorded[1], "primary", "legacy", 9);
+            expect(resolver.hasRecoveryResolutionFor("0xRecA")).toBe(true);
+            expect(resolver.hasRecoveryResolutionFor("0xRecBLegacy")).toBe(true);
+        });
+        it("re-resolving the same recovery secret replaces and wipes the previously cached derivation", () => {
+            const recorded = installCandidates({ s: { primary: { address: "0xRec", fill: 5 }, legacy: null } });
+            const resolver = makeResolver({ apiRecoveryAddresses: ["0xRec"] });
+            const first = cacheRecovery(resolver, recorded, "s", "0xRec").primary;
+            const second = cacheRecovery(resolver, recorded, "s", "0xRec").primary;
+            expect(isZeroed(first.derivedKeyBytes)).toBe(true);
+            expect(resolver.resolveDerivation(apiConfig("0xRec"))).toBe(second);
         });
     });
     it("keyMaterialForAssembly returns a copy of cached bytes the caller can wipe without corrupting the cache", () => {
         const recorded = installCandidates({ rec: { primary: { address: "0xRec", fill: 5 }, legacy: null } });
-        const resolver = makeResolver({ apiRecoveryAddress: "0xRec" });
-        const cached = cacheRecovery(resolver, recorded, "rec").primary;
+        const resolver = makeResolver({ apiRecoveryAddresses: ["0xRec"] });
+        const cached = cacheRecovery(resolver, recorded, "rec", "0xRec").primary;
         installCandidates({ rec: { primary: { address: "0xRec", fill: 5 }, legacy: null } });
         const first = resolver.keyMaterialForAssembly(fullConfig("rec"));
         expect(first.derivedKeyBytes).not.toBe(cached.derivedKeyBytes);
@@ -222,35 +272,32 @@ describe("ServerSignerResolver", () => {
     });
     it("resetDelegatedCache wipes and clears the delegated cache while preserving the recovery cache", () => {
         const recorded = installCandidates({ rec: { primary: { address: "0xRec", fill: 5 }, legacy: null } });
-        const resolver = makeResolver({ apiRecoveryAddress: "0xRec" });
-        const recoveryCached = cacheRecovery(resolver, recorded, "rec").primary;
+        const resolver = makeResolver({ apiRecoveryAddresses: ["0xRec"] });
+        const recoveryCached = cacheRecovery(resolver, recorded, "rec", "0xRec").primary;
         const dRec = installCandidates({ del: { primary: { address: "0xDel", fill: 3 }, legacy: null } });
         expect(everyByteIs(cacheDelegated(resolver, dRec, "del", "server:0xDel").primary.derivedKeyBytes, 3)).toBe(
             true
         );
         resolver.resetDelegatedCache();
         expect(isZeroed(dRec[0].primary.derivedKeyBytes)).toBe(true);
-        expect(resolver.hasRecoveryResolution).toBe(true);
+        expect(resolver.hasRecoveryResolutionFor("0xRec")).toBe(true);
         expect(everyByteIs(recoveryCached.derivedKeyBytes, 5)).toBe(true);
         expect(resolver.resolveDerivation(apiConfig("0xRec"))).toBe(recoveryCached);
     });
-    it("hasRecoveryResolution reflects whether the recovery cache is populated", () => {
+    it("hasRecoveryResolutionFor reflects whether the recovery cache holds that address", () => {
         const recorded = installCandidates({ rec: { primary: { address: "0xRec", fill: 5 }, legacy: null } });
-        const resolver = makeResolver({ apiRecoveryAddress: "0xRec" });
-        expect(resolver.hasRecoveryResolution).toBe(false);
-        cacheRecovery(resolver, recorded, "rec");
-        expect(resolver.hasRecoveryResolution).toBe(true);
-    });
-    it("resolvedRecoveryAddress is null until cached, then exposes the resolved derived address", () => {
-        const recorded = installCandidates({ rec: { primary: { address: "0xRec", fill: 5 }, legacy: null } });
-        const resolver = makeResolver({ apiRecoveryAddress: "0xRec" });
-        expect(resolver.resolvedRecoveryAddress).toBeNull();
-        cacheRecovery(resolver, recorded, "rec");
-        expect(resolver.resolvedRecoveryAddress).toBe("0xRec");
+        const resolver = makeResolver({ apiRecoveryAddresses: ["0xRec", "0xOther"] });
+        expect(resolver.hasRecoveryResolutionFor("0xRec")).toBe(false);
+        cacheRecovery(resolver, recorded, "rec", "0xRec");
+        expect(resolver.hasRecoveryResolutionFor("0xRec")).toBe(true);
+        expect(resolver.hasRecoveryResolutionFor("0xOther")).toBe(false);
     });
     it("exposes the constructor-provided api recovery and delegated addresses", () => {
-        const resolver = makeResolver({ apiRecoveryAddress: "0xRec", apiDelegatedAddresses: ["0xDelA", "0xDelB"] });
-        expect(resolver.apiRecoveryAddress).toBe("0xRec");
+        const resolver = makeResolver({
+            apiRecoveryAddresses: ["0xRecA", "0xRecB"],
+            apiDelegatedAddresses: ["0xDelA", "0xDelB"],
+        });
+        expect(resolver.apiRecoveryAddresses).toEqual(["0xRecA", "0xRecB"]);
         expect(resolver.apiDelegatedAddresses).toEqual(["0xDelA", "0xDelB"]);
     });
 });

--- a/packages/wallets/src/signers/server/resolver.ts
+++ b/packages/wallets/src/signers/server/resolver.ts
@@ -13,25 +13,26 @@ export class ServerSignerResolver {
     readonly #chain: Chain;
     readonly #projectId: string;
     readonly #environment: string;
-    readonly #apiRecoveryAddress: string | null;
+    readonly #apiRecoveryAddresses: string[];
     readonly #apiDelegatedAddresses: string[];
     readonly #knownOnChainAddresses: () => string[];
 
     #resolvedServerSigner: DerivedServerSigner | null = null;
-    #resolvedRecoveryServerSigner: DerivedServerSigner | null = null;
+    /** One entry per recovery server signer whose secret has been provided, keyed by derived address. */
+    #resolvedRecoveryServerSigners: DerivedServerSigner[] = [];
 
     constructor(params: {
         chain: Chain;
         projectId: string;
         environment: string;
-        apiRecoveryAddress: string | null;
+        apiRecoveryAddresses: string[];
         apiDelegatedAddresses: string[];
         knownOnChainAddresses: () => string[];
     }) {
         this.#chain = params.chain;
         this.#projectId = params.projectId;
         this.#environment = params.environment;
-        this.#apiRecoveryAddress = params.apiRecoveryAddress;
+        this.#apiRecoveryAddresses = params.apiRecoveryAddresses;
         this.#apiDelegatedAddresses = params.apiDelegatedAddresses;
         this.#knownOnChainAddresses = params.knownOnChainAddresses;
     }
@@ -42,8 +43,9 @@ export class ServerSignerResolver {
 
     resolveDerivation(config: ServerSignerConfig | ApiSourcedServerSignerConfig): DerivedServerSigner {
         if (isApiSourcedServerSignerConfig(config)) {
-            if (this.#resolvedRecoveryServerSigner != null) {
-                return this.#resolvedRecoveryServerSigner;
+            const resolved = this.#resolvedRecoveryFor(config.address);
+            if (resolved != null) {
+                return resolved;
             }
             throw new Error(
                 "Cannot resolve server signer derivation: no secret available and no cached recovery resolution. " +
@@ -52,17 +54,18 @@ export class ServerSignerResolver {
         }
 
         const { primary, legacy } = this.deriveCandidates(config);
-        const cached = this.#resolvedServerSigner ?? this.#resolvedRecoveryServerSigner;
+        const candidateAddresses = [primary.derivedAddress, legacy?.derivedAddress];
+        const cached =
+            [this.#resolvedServerSigner, ...this.#resolvedRecoveryServerSigners].find(
+                (c) => c != null && candidateAddresses.includes(c.derivedAddress)
+            ) ?? null;
         if (cached != null) {
-            const cachedAddr = cached.derivedAddress;
-            if (cachedAddr === primary.derivedAddress || (legacy != null && cachedAddr === legacy.derivedAddress)) {
-                secureWipe(primary.derivedKeyBytes, legacy?.derivedKeyBytes);
-                return cached;
-            }
+            secureWipe(primary.derivedKeyBytes, legacy?.derivedKeyBytes);
+            return cached;
         }
 
         if (legacy != null) {
-            if (legacy.derivedAddress === this.#apiRecoveryAddress) {
+            if (this.#apiRecoveryAddresses.includes(legacy.derivedAddress)) {
                 secureWipe(primary.derivedKeyBytes);
                 return legacy;
             }
@@ -78,7 +81,7 @@ export class ServerSignerResolver {
     apiLocator(config: ServerSignerConfig | ApiSourcedServerSignerConfig): ServerSignerLocator {
         const resolved = this.resolveDerivation(config);
         // Only the address is needed here — wipe the selected candidate's key bytes (never the cached slots).
-        if (resolved !== this.#resolvedServerSigner && resolved !== this.#resolvedRecoveryServerSigner) {
+        if (!this.#isCached(resolved)) {
             secureWipe(resolved.derivedKeyBytes);
         }
         return `server:${resolved.derivedAddress}`;
@@ -88,19 +91,20 @@ export class ServerSignerResolver {
      * Resolves a server signer with a SINGLE candidate derivation: the same derivation drives the
      * registered check, the recovery selection, and the unregistered wipe, so key material is
      * derived (and wiped) exactly once. `isRecovery` is consulted only after the registered check fails.
+     * A recovery resolution reports the derived address that was selected so callers can replace the
+     * secret-carrying config with an address-only one.
      */
     resolveForUseSigner(
         config: ServerSignerConfig,
         registeredLocators: string[],
         isRecovery: () => boolean
-    ): { kind: "delegated" } | { kind: "recovery" } | { kind: "unregistered"; message: string } {
+    ): { kind: "delegated" } | { kind: "recovery"; address: string } | { kind: "unregistered"; message: string } {
         const { primary, legacy } = this.deriveCandidates(config);
         if (this.#selectRegistered(primary, legacy, registeredLocators) != null) {
             return { kind: "delegated" };
         }
         if (isRecovery()) {
-            this.#selectRecovery(primary, legacy);
-            return { kind: "recovery" };
+            return { kind: "recovery", address: this.#selectRecovery(primary, legacy).derivedAddress };
         }
         const tried =
             legacy != null
@@ -129,14 +133,24 @@ export class ServerSignerResolver {
     }
 
     #selectRecovery(primary: DerivedServerSigner, legacy: DerivedServerSigner | null): DerivedServerSigner {
-        if (this.#apiRecoveryAddress != null && legacy != null && legacy.derivedAddress === this.#apiRecoveryAddress) {
-            this.#resolvedRecoveryServerSigner = legacy;
-            this.#wipeNonSelectedCandidate(legacy, primary);
-            return legacy;
+        const selected =
+            legacy != null && this.#apiRecoveryAddresses.includes(legacy.derivedAddress) ? legacy : primary;
+        this.#wipeNonSelectedCandidate(selected, selected === legacy ? primary : legacy);
+        const previous = this.#resolvedRecoveryFor(selected.derivedAddress);
+        if (previous != null) {
+            secureWipe(previous.derivedKeyBytes);
+            this.#resolvedRecoveryServerSigners = this.#resolvedRecoveryServerSigners.filter((c) => c !== previous);
         }
-        this.#resolvedRecoveryServerSigner = primary;
-        this.#wipeNonSelectedCandidate(primary, legacy);
-        return primary;
+        this.#resolvedRecoveryServerSigners.push(selected);
+        return selected;
+    }
+
+    #resolvedRecoveryFor(address: string): DerivedServerSigner | null {
+        return this.#resolvedRecoveryServerSigners.find((c) => c.derivedAddress === address) ?? null;
+    }
+
+    #isCached(candidate: DerivedServerSigner): boolean {
+        return candidate === this.#resolvedServerSigner || this.#resolvedRecoveryServerSigners.includes(candidate);
     }
 
     keyMaterialForAssembly(config: ServerSignerConfig | ApiSourcedServerSignerConfig): {
@@ -145,7 +159,7 @@ export class ServerSignerResolver {
     } {
         const resolved = this.resolveDerivation(config);
         const keyBytesCopy = new Uint8Array(resolved.derivedKeyBytes);
-        if (resolved !== this.#resolvedServerSigner && resolved !== this.#resolvedRecoveryServerSigner) {
+        if (!this.#isCached(resolved)) {
             secureWipe(resolved.derivedKeyBytes);
         }
         return { derivedKeyBytes: keyBytesCopy, derivedAddress: resolved.derivedAddress };
@@ -169,16 +183,13 @@ export class ServerSignerResolver {
         this.#resolvedServerSigner = null;
     }
 
-    get hasRecoveryResolution(): boolean {
-        return this.#resolvedRecoveryServerSigner != null;
+    /** Whether the secret behind the recovery server signer at `address` has been provided via useSigner. */
+    hasRecoveryResolutionFor(address: string): boolean {
+        return this.#resolvedRecoveryFor(address) != null;
     }
 
-    get resolvedRecoveryAddress(): string | null {
-        return this.#resolvedRecoveryServerSigner?.derivedAddress ?? null;
-    }
-
-    get apiRecoveryAddress(): string | null {
-        return this.#apiRecoveryAddress;
+    get apiRecoveryAddresses(): string[] {
+        return this.#apiRecoveryAddresses;
     }
 
     get apiDelegatedAddresses(): string[] {

--- a/packages/wallets/src/utils/signer-locator.ts
+++ b/packages/wallets/src/utils/signer-locator.ts
@@ -1,7 +1,26 @@
 import type { Chain } from "../chains/chains";
-import type { SignerLocator, SignerConfigForChain, ExternalWalletRegistrationConfig } from "../signers/types";
+import type {
+    SignerLocator,
+    SignerConfigForChain,
+    ExternalWalletRegistrationConfig,
+    PasskeySignerConfig,
+} from "../signers/types";
 import type { RegisterSignerPasskeyParams } from "../api";
 import { normalizeEmail } from "./signer-validation";
+
+const PASSKEY_LOCATOR_PREFIX = "passkey:";
+
+/** The credential id from `id` or a `passkey:{id}` locator, or null when the config carries neither. */
+export function passkeyCredentialId(config: Pick<PasskeySignerConfig, "id" | "locator">): string | null {
+    if (config.id != null && config.id !== "") {
+        return config.id;
+    }
+    if (config.locator != null && config.locator.startsWith(PASSKEY_LOCATOR_PREFIX)) {
+        const id = config.locator.slice(PASSKEY_LOCATOR_PREFIX.length);
+        return id === "" ? null : id;
+    }
+    return null;
+}
 
 /**
  * Converts a signer config to its locator string representation.
@@ -19,8 +38,14 @@ export function getSignerLocator<C extends Chain>(
     if (signer.type === "phone" && signer.phone) {
         return `phone:${signer.phone}`;
     }
-    if (signer.type === "passkey" && "id" in signer) {
-        return `passkey:${signer.id}`;
+    if (signer.type === "passkey") {
+        const credentialId = passkeyCredentialId(signer);
+        if (credentialId != null) {
+            return `passkey:${credentialId}`;
+        }
+        if ("id" in signer) {
+            return `passkey:${signer.id}`;
+        }
     }
     if (signer.type === "api-key") {
         return "api-key";

--- a/packages/wallets/src/wallets/evm.ts
+++ b/packages/wallets/src/wallets/evm.ts
@@ -28,7 +28,7 @@ export class EVMWallet extends Wallet<EVMChain> {
                 options: Wallet.getOptions(wallet),
                 alias: wallet.alias,
                 recovery: Wallet.getRecoverySigners(wallet),
-                apiRecoveryServerSignerAddress: Wallet.getApiRecoveryServerSignerAddress(wallet),
+                apiRecoveryServerSignerAddresses: Wallet.getApiRecoveryServerSignerAddresses(wallet),
                 apiDelegatedServerSignerAddresses: Wallet.getApiDelegatedServerSignerAddresses(wallet),
                 signer: wallet.signer,
                 signers: Wallet.getInitialSigners(wallet),

--- a/packages/wallets/src/wallets/services/device-recovery-service.test.ts
+++ b/packages/wallets/src/wallets/services/device-recovery-service.test.ts
@@ -73,7 +73,9 @@ function setup(overrides: SetupOverrides = {}) {
     const storage = overrides.storage === null ? undefined : overrides.storage ?? makeStorage();
     const options = storage == null ? undefined : ({ deviceSignerKeyStorage: storage } as Record<string, unknown>);
     const signerManager = makeSignerManager(overrides.signerManager);
-    const serverSignerResolver = { hasRecoveryResolution: overrides.hasRecoveryResolution ?? false };
+    const serverSignerResolver = {
+        hasRecoveryResolutionFor: (_address: string) => overrides.hasRecoveryResolution ?? false,
+    };
     const signers = overrides.signers ?? vi.fn().mockResolvedValue([]);
     const addSigner = overrides.addSigner ?? vi.fn().mockResolvedValue(undefined);
     const removeSigner = overrides.removeSigner ?? vi.fn().mockResolvedValue(undefined);

--- a/packages/wallets/src/wallets/services/device-recovery-service.ts
+++ b/packages/wallets/src/wallets/services/device-recovery-service.ts
@@ -311,7 +311,10 @@ export class DeviceRecoveryService<C extends Chain> {
     ): Promise<void> {
         const originalSigner = this.#signerManager.activeSigner;
         const recovery = this.#signerManager.recovery;
-        if (isApiSourcedServerSignerConfig(recovery) && !this.#serverSignerResolver.hasRecoveryResolution) {
+        if (
+            isApiSourcedServerSignerConfig(recovery) &&
+            !this.#serverSignerResolver.hasRecoveryResolutionFor(recovery.address)
+        ) {
             throw new Error(
                 "Cannot resume pending approval: no secret available. " +
                     'Call wallet.useSigner({ type: "server", secret: ... }) first with the recovery server secret.'

--- a/packages/wallets/src/wallets/services/signer-manager.test.ts
+++ b/packages/wallets/src/wallets/services/signer-manager.test.ts
@@ -2,8 +2,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiClientError } from "@crossmint/common-sdk-base";
 import type { ApiClient } from "../../api";
 import type { Chain } from "../../chains/chains";
-import type { RecoverySignerConfigForChain, SignerAdapter, SignerLocator } from "../../signers/types";
+import type {
+    RecoverySignerConfigForChain,
+    SignerAdapter,
+    SignerConfigForChain,
+    SignerLocator,
+} from "../../signers/types";
 import type { ServerSignerResolver } from "../../signers/server/resolver";
+import { InvalidRecoveryConfigError } from "../../utils/errors";
 import type { WalletOptions } from "../types";
 import { SignerManager, type SignerManagerParams } from "./signer-manager";
 import { assembleSigner } from "../../signers";
@@ -29,11 +35,10 @@ function makeApiClient(overrides: Partial<ApiClient> = {}): ApiClient {
     return { crossmint: {}, getSigner: vi.fn(), ...overrides } as unknown as ApiClient;
 }
 
-function makeResolver(overrides: Partial<ServerSignerResolver> = {}): ServerSignerResolver {
+function makeResolver(overrides: { resolvedRecoveryAddresses?: string[] } = {}): ServerSignerResolver {
+    const resolved = overrides.resolvedRecoveryAddresses ?? [];
     return {
-        hasRecoveryResolution: false,
-        resolvedRecoveryAddress: null,
-        ...overrides,
+        hasRecoveryResolutionFor: (address: string) => resolved.includes(address),
     } as unknown as ServerSignerResolver;
 }
 
@@ -48,7 +53,7 @@ function makeManager<C extends Chain>(
         walletAddress: WALLET_ADDRESS,
         walletLocator: () => WALLET_ADDRESS,
         serverSignerResolver: makeResolver(),
-        recovery: { type: "api-key" } as RecoverySignerConfigForChain<C>,
+        recoverySigners: [{ type: "api-key" } as RecoverySignerConfigForChain<C>],
         initialSigners: [],
         signers: async () => [],
         ...overrides,
@@ -82,20 +87,20 @@ describe("SignerManager", () => {
             { initialSigners: [apiKeyConfig, apiKeyConfig] },
             /multiple signers configured/,
         ],
-        ["a server recovery signer", { recovery: { type: "server", address: "0xServer" } }, /server secret/],
+        ["a server recovery signer", { recoverySigners: [{ type: "server", address: "0xServer" }] }, /server secret/],
         [
             "an external-wallet recovery signer",
-            { recovery: asRecoveryConfig({ type: "external-wallet", address: "0xExt" }) },
+            { recoverySigners: [asRecoveryConfig({ type: "external-wallet", address: "0xExt" })] },
             /External wallet signers require/,
         ],
         [
             "a non-auto-assemblable recovery signer",
-            { recovery: asRecoveryConfig({ type: "device" }) },
+            { recoverySigners: [asRecoveryConfig({ type: "device" })] },
             /requires calling wallet\.useSigner\(\)/,
         ],
-        ["a read-only wallet", { recovery: apiKeyConfig }, /read-only/],
+        ["a read-only wallet", { recoverySigners: [apiKeyConfig] }, /read-only/],
     ] as const)("require() with no active signer reports %s", async (_name, overrides, branchKeyword) => {
-        await expectThrowsMatching(() => makeManager(overrides as Overrides).require(), branchKeyword);
+        await expectThrowsMatching(() => makeManager(overrides as unknown as Overrides).require(), branchKeyword);
     });
 
     it.each([
@@ -113,7 +118,7 @@ describe("SignerManager", () => {
             const original = makeSigner("original");
             const recoverySigner = makeSigner("recovery");
             mockedAssembleSigner.mockReturnValue(recoverySigner);
-            const manager = makeManager({ signer: original, recovery: { type: "api-key" } });
+            const manager = makeManager({ signer: original, recoverySigners: [{ type: "api-key" }] });
             const failure = new Error("operation failed");
             let signerDuringOperation: SignerAdapter | undefined;
 
@@ -136,46 +141,78 @@ describe("SignerManager", () => {
         [
             "the recovery server secret is unavailable",
             {
-                recovery: { type: "server", address: "0xServer" },
-                serverSignerResolver: makeResolver({ hasRecoveryResolution: false }),
+                recoverySigners: [{ type: "server", address: "0xServer" }],
+                serverSignerResolver: makeResolver({ resolvedRecoveryAddresses: ["0xOtherServer"] }),
             },
             /Cannot assemble server signer/,
         ],
         [
             "the recovery external wallet has no onSign callback",
-            { recovery: asRecoveryConfig({ type: "external-wallet", address: "0xExt" }) },
+            { recoverySigners: [asRecoveryConfig({ type: "external-wallet", address: "0xExt" })] },
             /Cannot assemble external wallet signer/,
         ],
     ] as const)("withRecoverySigner() throws when %s", async (_name, overrides, branchKeyword) => {
         await expectThrowsMatching(
-            () => makeManager(overrides as Overrides).withRecoverySigner(async () => "unused"),
+            () => makeManager(overrides as unknown as Overrides).withRecoverySigner(async () => "unused"),
             branchKeyword
         );
     });
 
-    it("stripSecretFromRecovery() replaces a secret-bearing server recovery with an address-only config", () => {
-        const manager = makeManager({
-            recovery: asRecoveryConfig({ type: "server", secret: "topsecret" }),
-            serverSignerResolver: makeResolver({ resolvedRecoveryAddress: "0xResolved" }),
-        });
-        manager.stripSecretFromRecovery();
-        expect(manager.recovery).toEqual({ type: "server", address: "0xResolved" });
+    it("constructor rejects an empty recovery signer list", () => {
+        expect(() => makeManager({ recoverySigners: [] })).toThrow(InvalidRecoveryConfigError);
     });
 
-    it.each([
-        [
-            "there is no resolved recovery address",
-            asRecoveryConfig({ type: "server", secret: "topsecret" }),
-            { resolvedRecoveryAddress: null },
-        ],
-        [
-            "the recovery is already api-sourced",
-            asRecoveryConfig({ type: "server", address: "0xExisting" }),
-            { resolvedRecoveryAddress: "0xResolved" },
-        ],
-    ])("stripSecretFromRecovery() leaves recovery untouched when %s", (_name, recovery, resolver) => {
-        const manager = makeManager({ recovery, serverSignerResolver: makeResolver(resolver) });
-        manager.stripSecretFromRecovery();
+    it("recovery is the first entry of recoverySigners", () => {
+        const primary = asRecoveryConfig({ type: "external-wallet", address: "0xPrimary" });
+        const secondary = asRecoveryConfig({ type: "server", address: "0xSecondary" });
+        const manager = makeManager({ recoverySigners: [primary, secondary] });
+        expect(manager.recovery).toBe(primary);
+        expect(manager.recoverySigners).toEqual([primary, secondary]);
+    });
+
+    it("recoverySigners returns a copy that does not expose internal state", () => {
+        const manager = makeManager({ recoverySigners: [apiKeyConfig] });
+        manager.recoverySigners.push(asRecoveryConfig({ type: "device" }));
+        expect(manager.recoverySigners).toEqual([apiKeyConfig]);
+    });
+
+    it("adoptRecoveryConfig() replaces only the entry at the given index", () => {
+        const primary = asRecoveryConfig({ type: "external-wallet", address: "0xPrimary" });
+        const secondary = asRecoveryConfig({ type: "external-wallet", address: "0xSecondary" });
+        const adopted = {
+            type: "external-wallet",
+            address: "0xSecondary",
+            onSign: vi.fn(),
+        } as SignerConfigForChain<Chain>;
+        const manager = makeManager({ recoverySigners: [primary, secondary] });
+        manager.adoptRecoveryConfig(1, adopted);
+        expect(manager.recoverySigners).toEqual([primary, adopted]);
+    });
+
+    it.each([-1, 2])("adoptRecoveryConfig() rejects the out-of-range index %s", (index) => {
+        const manager = makeManager({ recoverySigners: [apiKeyConfig, asRecoveryConfig({ type: "device" })] });
+        expect(() => manager.adoptRecoveryConfig(index, apiKeyConfig)).toThrow(/out of range/);
+    });
+
+    it.each([0, 1])(
+        "stripSecretFromRecovery() replaces the secret-bearing server recovery at index %s with an address-only config",
+        (index) => {
+            const recoverySigners = [
+                asRecoveryConfig({ type: "external-wallet", address: "0xExt" }),
+                asRecoveryConfig({ type: "external-wallet", address: "0xExt2" }),
+            ];
+            recoverySigners[index] = asRecoveryConfig({ type: "server", secret: "topsecret" });
+            const manager = makeManager({ recoverySigners });
+            manager.stripSecretFromRecovery(index, "0xResolved");
+            expect(manager.recoverySigners[index]).toEqual({ type: "server", address: "0xResolved" });
+            expect(JSON.stringify(manager.recoverySigners)).not.toContain("topsecret");
+        }
+    );
+
+    it("stripSecretFromRecovery() leaves an api-sourced server recovery untouched", () => {
+        const recovery = asRecoveryConfig({ type: "server", address: "0xExisting" });
+        const manager = makeManager({ recoverySigners: [recovery] });
+        manager.stripSecretFromRecovery(0, "0xResolved");
         expect(manager.recovery).toBe(recovery);
     });
 

--- a/packages/wallets/src/wallets/services/signer-manager.ts
+++ b/packages/wallets/src/wallets/services/signer-manager.ts
@@ -13,6 +13,7 @@ import {
     type SignerConfigForChain,
     type SignerLocator,
 } from "../../signers/types";
+import { InvalidRecoveryConfigError } from "../../utils/errors";
 import { getPendingSignerOperation, mapApiSignerToSigner } from "../../utils/signer-mapping";
 import { walletsLogger } from "../../logger";
 import type { PendingSignerOperation, Signer as WalletSigner, SignerStatus, WalletOptions } from "../types";
@@ -24,7 +25,8 @@ export type SignerManagerParams<C extends Chain> = {
     walletAddress: string;
     walletLocator: () => WalletLocator;
     serverSignerResolver: ServerSignerResolver;
-    recovery: RecoverySignerConfigForChain<C>;
+    /** The wallet's recovery signers; the first entry is the primary one. Must not be empty. */
+    recoverySigners: Array<RecoverySignerConfigForChain<C>>;
     initialSigners: SignerConfigForChain<C>[];
     signers: () => Promise<WalletSigner[]>;
     signer?: SignerAdapter;
@@ -32,7 +34,7 @@ export type SignerManagerParams<C extends Chain> = {
 
 export class SignerManager<C extends Chain> {
     #activeSigner: SignerAdapter | undefined;
-    #recovery: RecoverySignerConfigForChain<C>;
+    #recoverySigners: Array<RecoverySignerConfigForChain<C>>;
     #apiClient: ApiClient;
     #options: WalletOptions | undefined;
     #chain: C;
@@ -49,7 +51,10 @@ export class SignerManager<C extends Chain> {
         this.#walletAddress = params.walletAddress;
         this.#walletLocator = params.walletLocator;
         this.#serverSignerResolver = params.serverSignerResolver;
-        this.#recovery = params.recovery;
+        if (params.recoverySigners.length === 0) {
+            throw new InvalidRecoveryConfigError("At least one recovery signer is required");
+        }
+        this.#recoverySigners = [...params.recoverySigners];
         this.#initialSigners = params.initialSigners;
         this.#signers = params.signers;
         this.#activeSigner = params.signer;
@@ -63,8 +68,13 @@ export class SignerManager<C extends Chain> {
         this.#activeSigner = signer;
     }
 
+    /** The primary recovery signer, i.e. `recoverySigners[0]`. */
     get recovery(): SignerConfigForChain<C> {
-        return this.#recovery as SignerConfigForChain<C>;
+        return this.#recoverySigners[0] as SignerConfigForChain<C>;
+    }
+
+    get recoverySigners(): Array<RecoverySignerConfigForChain<C>> {
+        return [...this.#recoverySigners];
     }
 
     descriptorContext(): SignerDescriptorContext<C> {
@@ -80,22 +90,30 @@ export class SignerManager<C extends Chain> {
         };
     }
 
-    adoptRecoveryConfig(config: SignerConfigForChain<C>): void {
-        this.#recovery = config as RecoverySignerConfigForChain<C>;
+    /** Replace the recovery signer at `index` with the caller's (typically fuller) config for the same signer. */
+    adoptRecoveryConfig(index: number, config: SignerConfigForChain<C>): void {
+        this.#assertRecoveryIndex(index);
+        this.#recoverySigners[index] = config as RecoverySignerConfigForChain<C>;
     }
 
-    stripSecretFromRecovery(): void {
-        const resolvedRecoveryAddress = this.#serverSignerResolver.resolvedRecoveryAddress;
-        if (
-            this.#recovery != null &&
-            this.#recovery.type === "server" &&
-            !isApiSourcedServerSignerConfig(this.#recovery) &&
-            resolvedRecoveryAddress != null
-        ) {
-            this.#recovery = {
+    /**
+     * Replace a secret-carrying server recovery config with its address-only form, so the secret is
+     * never retained (or exposed through `recoverySigners`) once the derivation has been resolved.
+     */
+    stripSecretFromRecovery(index: number, resolvedAddress: string): void {
+        this.#assertRecoveryIndex(index);
+        const recovery = this.#recoverySigners[index];
+        if (recovery.type === "server" && !isApiSourcedServerSignerConfig(recovery)) {
+            this.#recoverySigners[index] = {
                 type: "server",
-                address: resolvedRecoveryAddress,
+                address: resolvedAddress,
             } as RecoverySignerConfigForChain<C>;
+        }
+    }
+
+    #assertRecoveryIndex(index: number): void {
+        if (index < 0 || index >= this.#recoverySigners.length) {
+            throw new Error(`Recovery signer index ${index} is out of range`);
         }
     }
 
@@ -123,12 +141,13 @@ export class SignerManager<C extends Chain> {
                         "Call wallet.useSigner() to select which signer to use before signing operations."
                 );
             }
-            const descriptor = getSignerDescriptor<C>(this.#recovery.type);
+            const recovery = this.recovery;
+            const descriptor = getSignerDescriptor<C>(recovery.type);
             const typeReason = descriptor.signerUnavailableReason();
             if (typeReason != null) {
                 throw new Error(typeReason);
             }
-            if (!descriptor.canAutoAssemble(this.#recovery, this.descriptorContext())) {
+            if (!descriptor.canAutoAssemble(recovery, this.descriptorContext())) {
                 throw new Error(
                     "No signer is set. This wallet requires calling wallet.useSigner() before signing operations."
                 );
@@ -142,25 +161,28 @@ export class SignerManager<C extends Chain> {
 
     async withRecoverySigner<T>(operation: () => Promise<T>): Promise<T> {
         const originalSigner = this.#activeSigner;
-        if (isApiSourcedServerSignerConfig(this.#recovery) && !this.#serverSignerResolver.hasRecoveryResolution) {
+        const recovery = this.recovery;
+        if (
+            isApiSourcedServerSignerConfig(recovery) &&
+            !this.#serverSignerResolver.hasRecoveryResolutionFor(recovery.address)
+        ) {
             throw new Error(
                 "Cannot assemble server signer: no secret available. " +
                     'Call wallet.useSigner({ type: "server", secret: ... }) first with the recovery server secret.'
             );
         }
-        const signerDescriptor = getSignerDescriptor<C>(this.#recovery.type);
+        const signerDescriptor = getSignerDescriptor<C>(recovery.type);
         const signerDescriptorContext = this.descriptorContext();
         if (
-            this.#recovery != null &&
-            this.#recovery.type === "external-wallet" &&
-            !signerDescriptor.canAutoAssemble(this.#recovery, signerDescriptorContext)
+            recovery.type === "external-wallet" &&
+            !signerDescriptor.canAutoAssemble(recovery, signerDescriptorContext)
         ) {
             throw new Error(
                 "Cannot assemble external wallet signer: no onSign callback available. " +
                     'Call wallet.useSigner({ type: "external-wallet", address: "0x...", onSign: async (tx) => ... }) first.'
             );
         }
-        const recoveryInternalConfig = signerDescriptor.buildInternalConfig(this.#recovery, signerDescriptorContext);
+        const recoveryInternalConfig = signerDescriptor.buildInternalConfig(recovery, signerDescriptorContext);
         this.#activeSigner = assembleSigner(this.#chain, recoveryInternalConfig, this.#options?.deviceSignerKeyStorage);
 
         try {

--- a/packages/wallets/src/wallets/solana.ts
+++ b/packages/wallets/src/wallets/solana.ts
@@ -24,7 +24,7 @@ export class SolanaWallet extends Wallet<SolanaChain> {
                 options: Wallet.getOptions(wallet),
                 alias: wallet.alias,
                 recovery: Wallet.getRecoverySigners(wallet),
-                apiRecoveryServerSignerAddress: Wallet.getApiRecoveryServerSignerAddress(wallet),
+                apiRecoveryServerSignerAddresses: Wallet.getApiRecoveryServerSignerAddresses(wallet),
                 apiDelegatedServerSignerAddresses: Wallet.getApiDelegatedServerSignerAddresses(wallet),
                 signer: wallet.signer,
                 signers: Wallet.getInitialSigners(wallet),

--- a/packages/wallets/src/wallets/stellar.ts
+++ b/packages/wallets/src/wallets/stellar.ts
@@ -27,7 +27,7 @@ export class StellarWallet extends Wallet<StellarChain> {
                 options: Wallet.getOptions(wallet),
                 alias: wallet.alias,
                 recovery: Wallet.getRecoverySigners(wallet),
-                apiRecoveryServerSignerAddress: Wallet.getApiRecoveryServerSignerAddress(wallet),
+                apiRecoveryServerSignerAddresses: Wallet.getApiRecoveryServerSignerAddresses(wallet),
                 apiDelegatedServerSignerAddresses: Wallet.getApiDelegatedServerSignerAddresses(wallet),
                 signer: wallet.signer,
                 signers: Wallet.getInitialSigners(wallet),

--- a/packages/wallets/src/wallets/wallet-factory.ts
+++ b/packages/wallets/src/wallets/wallet-factory.ts
@@ -340,11 +340,11 @@ export class WalletFactory {
             ) as SignerResponse[];
         }
 
-        // Preserve the API-sourced server signer recovery address so the wallet can identify
+        // Preserve the API-sourced server signer recovery addresses so the wallet can identify
         // legacy derivations even when the user-provided config replaces the API one.
-        const apiRecoveryServerSignerAddress = apiRecoverySigners
+        const apiRecoveryServerSignerAddresses = apiRecoverySigners
             .filter((s) => s.type === "server" && "address" in s && !("secret" in s))
-            .map((s) => (s as { address: string }).address)[0];
+            .map((s) => (s as { address: string }).address);
 
         // Preserve the API-sourced server signer delegated addresses so the wallet can identify
         // legacy derivations even when the user-provided config replaces the API one.
@@ -360,7 +360,7 @@ export class WalletFactory {
                 options: args.options,
                 alias: args.alias,
                 recovery: recoverySigners,
-                apiRecoveryServerSignerAddress,
+                apiRecoveryServerSignerAddresses,
                 apiDelegatedServerSignerAddresses,
                 signers: (signers ?? []) as SignerConfigForChain<C>[],
             },

--- a/packages/wallets/src/wallets/wallet.test.ts
+++ b/packages/wallets/src/wallets/wallet.test.ts
@@ -2561,6 +2561,25 @@ describe("Wallet - useSigner()", () => {
             expect(mockApiClient.getSigner).not.toHaveBeenCalled();
         });
 
+        it("useSigner keeps the credential id of a locator-only passkey that matches a recovery signer", async () => {
+            mockApiClient = createMockApiClient();
+            const wallet = new Wallet(
+                {
+                    chain: "base-sepolia" as const,
+                    address: "0x1234567890123456789012345678901234567890",
+                    recovery: [{ type: "api-key" }, { type: "passkey", id: "recovery-credential" }] as any,
+                },
+                mockApiClient as unknown as ApiClient
+            );
+            vi.spyOn(wallet, "signers").mockResolvedValue([]);
+
+            await wallet.useSigner({ type: "passkey", locator: "passkey:recovery-credential" });
+
+            expect(wallet.signer?.locator()).toBe("passkey:recovery-credential");
+            expect(wallet.signer?.status).toBe("active");
+            expect(mockApiClient.getSigner).not.toHaveBeenCalled();
+        });
+
         it("constructor rejects an empty recovery signer list", () => {
             mockApiClient = createMockApiClient();
             expect(

--- a/packages/wallets/src/wallets/wallet.test.ts
+++ b/packages/wallets/src/wallets/wallet.test.ts
@@ -6,6 +6,7 @@ import type { ApiSourcedServerSignerConfig, SignerAdapter, SignerConfigForChain 
 import { AuthRejectedError, OtpValidationError } from "../signers/types";
 import {
     InvalidAddressError,
+    InvalidRecoveryConfigError,
     InvalidSignerError,
     InvalidTransferAmountError,
     TransactionNotCreatedError,
@@ -2476,6 +2477,103 @@ describe("Wallet - useSigner()", () => {
                     onSign: vi.fn(),
                 } as unknown as SignerConfigForChain<"solana">)
             ).rejects.toThrow('Signer "external-wallet:NotARecoverySigner333" is not registered in this wallet.');
+        });
+
+        it("useSigner resolves a secondary server recovery signer with its own (legacy) derivation and never exposes the secret", async () => {
+            const { deriveServerSignerCandidates, assembleServerSigner } = await import("@/signers/server");
+            vi.mocked(deriveServerSignerCandidates).mockReturnValue({
+                primary: { derivedKeyBytes: new Uint8Array(32), derivedAddress: "SecondaryPrimaryDerivation" },
+                legacy: { derivedKeyBytes: new Uint8Array(32).fill(1), derivedAddress: "SecondaryLegacyDerivation" },
+            });
+            const mockedAssemble = vi.mocked(assembleServerSigner);
+            mockedAssemble.mockReturnValue({
+                type: "server",
+                locator: () => "server:SecondaryLegacyDerivation",
+                address: () => "SecondaryLegacyDerivation",
+                status: undefined,
+                signMessage: vi.fn(),
+                signTransaction: vi.fn(),
+            } as any);
+
+            mockApiClient = createMockApiClient();
+            mockApiClient.getWallet.mockResolvedValue({
+                chainType: "solana",
+                type: "smart",
+                address: "5FHwkrdxntdK24hgQU8qgBjn35Y1zwhz1GZwCkP2UJnM",
+                config: {
+                    recovery: [
+                        { type: "external-wallet", address: "PrimaryRecovery111" },
+                        { type: "server", address: "SecondaryLegacyDerivation" },
+                    ],
+                    delegatedSigners: [],
+                },
+                createdAt: Date.now(),
+            } as unknown as GetWalletSuccessResponse);
+            const walletFactory = new WalletFactory(mockApiClient as unknown as ApiClient);
+            const wallet = await walletFactory.getWallet({ chain: "solana" });
+            vi.spyOn(wallet, "signers").mockResolvedValue([]);
+
+            await wallet.useSigner({ type: "server", secret: "super-secret" } as any);
+
+            expect(wallet.signer?.status).toBe("active");
+            expect(mockedAssemble).toHaveBeenCalledWith(
+                "solana",
+                expect.objectContaining({ address: "SecondaryLegacyDerivation" })
+            );
+            expect(wallet.recovery).toEqual({ type: "external-wallet", address: "PrimaryRecovery111" });
+            expect(wallet.recoveryMethods[1]).toEqual({ type: "server", address: "SecondaryLegacyDerivation" });
+            expect(JSON.stringify(wallet.recoveryMethods)).not.toContain("super-secret");
+        });
+
+        it("useSigner rejects a passkey whose credential id matches no passkey recovery signer", async () => {
+            mockApiClient = createMockApiClient();
+            const wallet = new Wallet(
+                {
+                    chain: "base-sepolia" as const,
+                    address: "0x1234567890123456789012345678901234567890",
+                    recovery: [{ type: "api-key" }, { type: "passkey", id: "recovery-credential" }] as any,
+                },
+                mockApiClient as unknown as ApiClient
+            );
+            vi.spyOn(wallet, "signers").mockResolvedValue([]);
+
+            await expect(wallet.useSigner({ type: "passkey", id: "unrelated-credential" })).rejects.toThrow(
+                'Signer "passkey:unrelated-credential" is not registered in this wallet.'
+            );
+        });
+
+        it("useSigner resolves a secondary passkey recovery signer by credential id as an admin signer", async () => {
+            mockApiClient = createMockApiClient();
+            const wallet = new Wallet(
+                {
+                    chain: "base-sepolia" as const,
+                    address: "0x1234567890123456789012345678901234567890",
+                    recovery: [{ type: "api-key" }, { type: "passkey", id: "recovery-credential" }] as any,
+                },
+                mockApiClient as unknown as ApiClient
+            );
+            vi.spyOn(wallet, "signers").mockResolvedValue([]);
+
+            await wallet.useSigner({ type: "passkey", id: "recovery-credential" });
+
+            expect(wallet.signer?.locator()).toBe("passkey:recovery-credential");
+            expect(wallet.signer?.status).toBe("active");
+            expect(mockApiClient.getSigner).not.toHaveBeenCalled();
+        });
+
+        it("constructor rejects an empty recovery signer list", () => {
+            mockApiClient = createMockApiClient();
+            expect(
+                () =>
+                    new Wallet(
+                        {
+                            chain: "solana" as const,
+                            address: "5FHwkrdxntdK24hgQU8qgBjn35Y1zwhz1GZwCkP2UJnM",
+                            recovery: [],
+                        },
+                        mockApiClient as unknown as ApiClient
+                    )
+            ).toThrow(InvalidRecoveryConfigError);
         });
 
         it("addSigner should throw when recovery is external-wallet but useSigner was never called (no onSign)", async () => {

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -79,7 +79,8 @@ type WalletContructorType<C extends Chain> = {
     options?: WalletOptions;
     /** The wallet's recovery signer(s). Wallets on chains that support a single recovery signer take one entry. */
     recovery: RecoverySignerConfigForChain<C> | Array<RecoverySignerConfigForChain<C>>;
-    apiRecoveryServerSignerAddress?: string;
+    /** Addresses of the API-sourced server recovery signers, so legacy derivations can be recognised. */
+    apiRecoveryServerSignerAddresses?: string[];
     apiDelegatedServerSignerAddresses?: string[];
     signers?: SignerConfigForChain<C>[];
     signer?: SignerAdapter;
@@ -97,7 +98,6 @@ export class Wallet<C extends Chain> {
     #signerManager: SignerManager<C>;
     #deviceRecovery: DeviceRecoveryService<C>;
     #apiDelegatedServerSignerAddresses: string[] = [];
-    #recoverySigners: Array<RecoverySignerConfigForChain<C>>;
     #signerInitialization: Promise<void>;
     #recovering: Promise<void> | null = null;
 
@@ -109,7 +109,7 @@ export class Wallet<C extends Chain> {
             options,
             alias,
             recovery,
-            apiRecoveryServerSignerAddress,
+            apiRecoveryServerSignerAddresses,
             apiDelegatedServerSignerAddresses,
             signers,
             signer,
@@ -121,21 +121,21 @@ export class Wallet<C extends Chain> {
         this.#options = options;
         this.alias = alias;
         const recoverySigners = Array.isArray(recovery) ? recovery : [recovery];
-        const primaryRecovery = recoverySigners[0];
-        let apiRecoveryAddress: string | null = null;
-        if (apiRecoveryServerSignerAddress != null) {
-            apiRecoveryAddress = apiRecoveryServerSignerAddress;
-        } else if (primaryRecovery.type === "server" && isApiSourcedServerSignerConfig(primaryRecovery)) {
-            apiRecoveryAddress = primaryRecovery.address;
-        }
-        this.#recoverySigners = recoverySigners;
+        const apiRecoveryAddresses =
+            apiRecoveryServerSignerAddresses ??
+            recoverySigners
+                .filter(
+                    (s): s is RecoverySignerConfigForChain<C> & ApiSourcedServerSignerConfig =>
+                        s.type === "server" && isApiSourcedServerSignerConfig(s)
+                )
+                .map((s) => s.address);
         this.#apiDelegatedServerSignerAddresses = apiDelegatedServerSignerAddresses ?? [];
         this.#initialSigners = signers ?? [];
         this.#serverSignerResolver = new ServerSignerResolver({
             chain,
             projectId: this.#apiClient.projectId,
             environment: this.#apiClient.environment,
-            apiRecoveryAddress,
+            apiRecoveryAddresses,
             apiDelegatedAddresses: this.#apiDelegatedServerSignerAddresses,
             knownOnChainAddresses: () => [
                 ...this.#initialSigners
@@ -154,7 +154,7 @@ export class Wallet<C extends Chain> {
             walletAddress: this.address,
             walletLocator: () => this.walletLocator,
             serverSignerResolver: this.#serverSignerResolver,
-            recovery: primaryRecovery,
+            recoverySigners,
             initialSigners: this.#initialSigners,
             signers: () => this.signers(),
             signer,
@@ -262,8 +262,8 @@ export class Wallet<C extends Chain> {
         return wallet.#initialSigners;
     }
 
-    protected static getApiRecoveryServerSignerAddress<C extends Chain>(wallet: Wallet<C>): string | undefined {
-        return wallet.#serverSignerResolver.apiRecoveryAddress ?? undefined;
+    protected static getApiRecoveryServerSignerAddresses<C extends Chain>(wallet: Wallet<C>): string[] {
+        return wallet.#serverSignerResolver.apiRecoveryAddresses;
     }
 
     protected static getApiDelegatedServerSignerAddresses<C extends Chain>(wallet: Wallet<C>): string[] {
@@ -306,9 +306,7 @@ export class Wallet<C extends Chain> {
      * @experimental This API is experimental and may change in the future
      */
     public get recoveryMethods(): Array<RecoverySignerConfigForChain<C>> {
-        // The first entry is read from the signer manager, which owns the wallet's primary recovery
-        // signer and may replace it (e.g. stripping a server secret).
-        return [this.recovery, ...this.#recoverySigners.slice(1)];
+        return this.#signerManager.recoverySigners;
     }
 
     /**
@@ -924,15 +922,19 @@ export class Wallet<C extends Chain> {
     private async resolveServerSigner(signer: ServerSignerConfig): Promise<boolean> {
         const existingSigners = await this.signers();
         const registeredLocators = existingSigners.map((s) => s.locator);
-        const resolution = this.#serverSignerResolver.resolveForUseSigner(signer, registeredLocators, () =>
-            this.isRecoverySigner(signer as SignerConfigForChain<C>)
-        );
+        const match: { recoveryIndex: number | null } = { recoveryIndex: null };
+        const resolution = this.#serverSignerResolver.resolveForUseSigner(signer, registeredLocators, () => {
+            match.recoveryIndex = this.matchRecoverySigner(signer as SignerConfigForChain<C>);
+            return match.recoveryIndex != null;
+        });
         switch (resolution.kind) {
             case "delegated":
                 this.#deviceRecovery.onSignerSelected();
                 return false;
             case "recovery":
-                this.#signerManager.stripSecretFromRecovery();
+                if (match.recoveryIndex != null) {
+                    this.#signerManager.stripSecretFromRecovery(match.recoveryIndex, resolution.address);
+                }
                 this.#deviceRecovery.onSignerSelected();
                 return true;
             case "unregistered":
@@ -1110,27 +1112,29 @@ export class Wallet<C extends Chain> {
      * Check if a signer config matches any of the wallet's recovery signers.
      */
     private isRecoverySigner(signerConfig: SignerConfigForChain<C>): boolean {
+        return this.matchRecoverySigner(signerConfig) != null;
+    }
+
+    /**
+     * Find the recovery signer that `signerConfig` refers to and, for signer types that need the
+     * caller's fuller config to operate (e.g. an onSign callback or a server secret), adopt it in
+     * place of the stored one. Returns the index of the matched recovery signer, or null.
+     */
+    private matchRecoverySigner(signerConfig: SignerConfigForChain<C>): number | null {
         const signerDescriptor = getSignerDescriptor<C>(signerConfig.type);
         const descriptorContext = this.#signerManager.descriptorContext();
-        for (const [index, recovery] of this.recoveryMethods.entries()) {
-            if (recovery == null || recovery.type !== signerConfig.type) {
-                continue;
-            }
-            if (!signerDescriptor.matchesRecovery(signerConfig, recovery, descriptorContext)) {
-                continue;
-            }
-            if (signerDescriptor.adoptsRecoveryConfigOnMatch) {
-                if (index === 0) {
-                    this.#signerManager.adoptRecoveryConfig(signerConfig);
-                } else if (signerConfig.type !== "server") {
-                    // Server configs carry the secret; the api-sourced entry already
-                    // identifies the signer, so the list never stores server secrets.
-                    this.#recoverySigners[index] = signerConfig as RecoverySignerConfigForChain<C>;
-                }
-            }
-            return true;
+        const index = this.recoveryMethods.findIndex(
+            (recovery) =>
+                recovery.type === signerConfig.type &&
+                signerDescriptor.matchesRecovery(signerConfig, recovery, descriptorContext)
+        );
+        if (index === -1) {
+            return null;
         }
-        return false;
+        if (signerDescriptor.adoptsRecoveryConfigOnMatch) {
+            this.#signerManager.adoptRecoveryConfig(index, signerConfig);
+        }
+        return index;
     }
 
     protected resolveChainForEnvironment(): C {

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -60,7 +60,7 @@ import { ServerSignerResolver } from "../signers/server/resolver";
 import { getSignerDescriptor } from "../signers/descriptors";
 import { walletsLogger } from "../logger";
 
-import { getSignerLocator } from "../utils/signer-locator";
+import { getSignerLocator, passkeyCredentialId } from "../utils/signer-locator";
 import { toRecipientLocator, toTokenLocator } from "../utils/locators";
 import { formatBalanceResponse } from "./services/balance-formatter";
 import { SignerManager } from "./services/signer-manager";
@@ -976,7 +976,7 @@ export class Wallet<C extends Chain> {
     }
 
     private isPasskeyMissingId(signer: PasskeySignerConfig): boolean {
-        return signer.id == null || signer.id === "";
+        return passkeyCredentialId(signer) == null;
     }
 
     /**


### PR DESCRIPTION
## Description

Stacked on #2045 (rebased on its latest head, which renamed the getter to `recoveryMethods` and added a partial server-secret fix that this PR supersedes). That PR let `wallet.useSigner` match any entry of the recovery list, but the downstream code still assumed a single recovery signer, which left a few sharp edges (found while reviewing the stack):

- A server recovery signer at index ≥ 1 kept the caller's `{ type: "server", secret }` in the list, so **the raw secret was exposed through `wallet.recoveryMethods`**, and `#selectRecovery` could pick the primary derivation for a secondary whose on-chain address is the legacy one (signs with the wrong key, only fails on-chain).
- `ServerSignerResolver` had one `apiRecoveryAddress` and one cached recovery derivation, so two server recovery signers shared a cache slot and `resolveDerivation`/`apiLocator` for an api-sourced config returned whichever was resolved last.
- `passkeyDescriptor.matchesRecovery` returned `true` unconditionally, so with `[api-key, passkey]` any unregistered passkey resolved as admin.
- `[]` as `recovery` in the `Wallet` constructor was a `TypeError` instead of a coded error.
- Recovery state was split between `SignerManager.#recovery` (index 0) and `Wallet.#recoverySigners` (the rest), which is what caused the first bug.

### What changed

**The list is now the single source of truth.** `SignerManager` owns `recoverySigners`; `recovery` is a derived `[0]` getter and `Wallet` no longer keeps a parallel copy. This also means a future switch of the public `recovery` getter to return the array is a one-getter/one-type change.

```ts
// SignerManager
- recovery: RecoverySignerConfigForChain<C>
+ recoverySigners: Array<RecoverySignerConfigForChain<C>>   // throws InvalidRecoveryConfigError when empty
  get recovery()          // => recoverySigners[0]
  get recoverySigners()   // => copy of the list
- adoptRecoveryConfig(config)
+ adoptRecoveryConfig(index, config)
- stripSecretFromRecovery()
+ stripSecretFromRecovery(index, resolvedAddress)

// ServerSignerResolver
- apiRecoveryAddress: string | null            → apiRecoveryAddresses: string[]
- #resolvedRecoveryServerSigner (one slot)     → #resolvedRecoveryServerSigners (one per derived address)
- hasRecoveryResolution / resolvedRecoveryAddress
+ hasRecoveryResolutionFor(address)
  resolveForUseSigner(...) => { kind: "recovery", address }  // reports which derivation was selected

// Wallet
- apiRecoveryServerSignerAddress?: string      → apiRecoveryServerSignerAddresses?: string[]
- isRecoverySigner(config): boolean            → matchRecoverySigner(config): index | null  (isRecoverySigner kept as a thin wrapper)
```

`WalletFactory` now forwards every api-sourced server recovery address (previously `[0]`), and `passkeyDescriptor.matchesRecovery` compares credential ids (`id` or `passkey:{id}` locator) when both sides have one, falling back to type-only for the api-sourced `{ type: "passkey" }` shape.

No public API changes beyond the new `InvalidRecoveryConfigError` on an empty list; `wallet.recovery` / `wallet.recoveryMethods` behave as in #2044/#2045.

## Test plan

Unit tests (`pnpm --filter @crossmint/wallets-sdk test:vitest`, 723 passing):

- `wallet.test.ts`: secondary server recovery signer resolves with its legacy derivation and `recoveryMethods` never contains the secret; passkey with an unrelated credential id is rejected while the matching id resolves as admin; empty `recovery` list throws `InvalidRecoveryConfigError`.
- `resolver.test.ts`: independent cache entries for two api-sourced recovery addresses; missing cache for one address despite another being cached; legacy selection for a secondary recovery signer; re-resolving the same address replaces (and wipes) the previous entry.
- `signer-manager.test.ts`: list/index semantics of `recovery`, `recoverySigners`, `adoptRecoveryConfig`, `stripSecretFromRecovery`, empty list rejection.
- `descriptors.test.ts`: passkey credential-id matching matrix.

`pnpm --filter @crossmint/wallets-sdk build` and `pnpm lint` pass.

## Package updates

- `@crossmint/wallets-sdk` (patch) — `.changeset/recovery-list-hardening.md`


Link to Devin session: https://crossmint.devinenterprise.com/sessions/ef5c93254ce84504bd952a008d5eadfd
Open in Devin Desktop: https://crossmint.devinenterprise.com/desktop/session/ef5c93254ce84504bd952a008d5eadfd?variant=devin
Requested by: @panosinthezone