### PR TITLE
Embedded checkout: read the Solana transaction as versioned

### DIFF
--- a/.changeset/embed-solana-versioned-transaction.md
+++ b/.changeset/embed-solana-versioned-transaction.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/client-sdk-react-ui": patch
+---
+
+Parse the embedded checkout's Solana transaction with `VersionedTransaction.deserialize` instead of the legacy `Transaction.from`. The legacy parser rejects every versioned transaction — a version-0 payload failed with `Versioned messages must be deserialized with VersionedMessage.deserialize()`, surfacing to the buyer as "Failed to deserialize transaction". `VersionedTransaction.deserialize` accepts legacy and version-0 alike, and Dynamic's `signAndSendTransaction` accepts either object. Legacy payloads keep working, and now reach the wallet as a `VersionedTransaction` whose `message.version` is `"legacy"`.

--- a/packages/client/ui/react-ui/src/components/embed/v3/crypto/utils/handleSolanaTransaction.test.ts
+++ b/packages/client/ui/react-ui/src/components/embed/v3/crypto/utils/handleSolanaTransaction.test.ts
@@ -1,0 +1,63 @@
+import base58 from "bs58";
+import { describe, expect, it, vi } from "vitest";
+import { handleSolanaTransaction } from "./handleSolanaTransaction";
+
+const LEGACY_TRANSACTION =
+    "3md7BBV9wFjYGnMWcMNyAZcjca2HGfXWZkrU8vvho66z2sJMZFcx6HZdBiAddjo2kzgBv3uZoac3domBRjJJSXkbBvokxThZ5oh8T5ym9k6AXbRYtAAR6a3pECdz2pFCX2shi8b67DGHMtQVjLbdftyzbVvWeGJDUdj69qTnm6u6Lx2Z9iCXdGk4QSsRem8cHoAcpSq997N7BwMeauKofu9CA3Wa7YZYhdyoGk3LUF4B5U39sYKt6rpbWmxBAqT5sDh3ysRCy12ouPfuFcPFvubnf5GQRhmpB1yKD";
+
+const VERSION_0_TRANSACTION =
+    "vxBNpvao9QJmLKXUThbbjRnxm3ufu4Wku97kHd5a67FDjSqeHwcPrBKTjAHp4ECr61eWwoxvUEVTuuWX65P9bCNDJrTJpXGiS879qw3EiUHbtsVvir34pRPesJQ7S9S2MqxLzFKkYB5C4ada8bhKYW2eBkcM6D2D3aD2YpKPrF1TWnNEnpMctS13bhfaErAi1giU1UMwxzLwRPfrgLddjVwANYdUeye3GUYVJNre4Xzz4aKUAyhgek6TzRRwe6BMfshUYTeh65H2SyoE8MA9n14zAAL1CiiE47wQv3Z";
+
+vi.mock("@dynamic-labs/solana", () => ({ isSolanaWallet: () => true }));
+
+function harness() {
+    const signAndSendTransaction = vi.fn().mockResolvedValue({ signature: "tx-id" });
+    const primaryWallet = {
+        getSigner: vi.fn().mockResolvedValue({ signAndSendTransaction }),
+    } as never;
+    const send = vi.fn();
+    return { primaryWallet, iframeClient: { send } as never, signAndSendTransaction, send };
+}
+
+describe("handleSolanaTransaction", () => {
+    it("sends a legacy transaction", async () => {
+        const { primaryWallet, iframeClient, signAndSendTransaction, send } = harness();
+
+        await handleSolanaTransaction({
+            primaryWallet,
+            serializedTransaction: LEGACY_TRANSACTION,
+            iframeClient,
+        });
+
+        expect(signAndSendTransaction.mock.calls[0][0].message.version).toBe("legacy");
+        expect(send).toHaveBeenCalledWith("crypto:send-transaction:success", { txId: "tx-id" });
+    });
+
+    it("sends a version-0 transaction, which the legacy parser refused", async () => {
+        const { primaryWallet, iframeClient, signAndSendTransaction, send } = harness();
+
+        await handleSolanaTransaction({
+            primaryWallet,
+            serializedTransaction: VERSION_0_TRANSACTION,
+            iframeClient,
+        });
+
+        expect(signAndSendTransaction.mock.calls[0][0].message.version).toBe(0);
+        expect(send).toHaveBeenCalledWith("crypto:send-transaction:success", { txId: "tx-id" });
+    });
+
+    it("reports a failure when the payload is not a transaction", async () => {
+        const { primaryWallet, iframeClient, signAndSendTransaction, send } = harness();
+
+        await handleSolanaTransaction({
+            primaryWallet,
+            serializedTransaction: base58.encode(new Uint8Array([1, 2, 3])),
+            iframeClient,
+        });
+
+        expect(signAndSendTransaction).not.toHaveBeenCalled();
+        expect(send).toHaveBeenCalledWith("crypto:send-transaction:failed", {
+            error: "Failed to deserialize transaction",
+        });
+    });
+});

--- a/packages/client/ui/react-ui/src/components/embed/v3/crypto/utils/handleSolanaTransaction.ts
+++ b/packages/client/ui/react-ui/src/components/embed/v3/crypto/utils/handleSolanaTransaction.ts
@@ -1,7 +1,7 @@
 import type { EmbeddedCheckoutV3IFrameEmitter } from "@crossmint/client-sdk-base";
 import type { Wallet } from "@dynamic-labs/sdk-react-core";
 import { isSolanaWallet } from "@dynamic-labs/solana";
-import { Transaction } from "@solana/web3.js";
+import { VersionedTransaction } from "@solana/web3.js";
 import base58 from "bs58";
 
 export async function handleSolanaTransaction({
@@ -29,9 +29,9 @@ export async function handleSolanaTransaction({
         return;
     }
 
-    let deserializedTransaction: Transaction;
+    let deserializedTransaction: VersionedTransaction;
     try {
-        deserializedTransaction = Transaction.from(base58.decode(serializedTransaction));
+        deserializedTransaction = VersionedTransaction.deserialize(base58.decode(serializedTransaction));
     } catch (error) {
         console.error("[CryptoWalletConnectionHandler] failed to deserialize transaction", error);
         iframeClient.send("crypto:send-transaction:failed", {


### PR DESCRIPTION
The embedded checkout's Solana handler parsed with the legacy `Transaction` class:

```ts
deserializedTransaction = Transaction.from(base58.decode(serializedTransaction));
```

That class reads pre-versioned transactions only. Measured against `@solana/web3.js` 1.98.1, the version this package pins:

```
version 0: THROWS Versioned messages must be deserialized with VersionedMessage.deserialize()
version 1: THROWS Reached end of buffer unexpectedly
```

The failure is caught and reported as `"Failed to deserialize transaction"`, so a buyer sees a generic error and the real reason stays in the console.

`VersionedTransaction.deserialize` reads legacy and version 0 alike — verified under the same pinned 1.98.1 — and Dynamic's signer accepts either object: `signAndSendTransaction<T extends Transaction | VersionedTransaction>`.

## The one behavioural change

For a **legacy** payload the wire bytes are unchanged, but the object handed to Dynamic is now a `VersionedTransaction` whose `message.version` is `"legacy"`, where before it was a legacy `Transaction`. Dynamic's type covers both. This is worth a reviewer's eye if any connector in the wild treats the two differently.

## What this does NOT do

Version 1 stays unsupported here, and deliberately so. This package pins `@solana/web3.js` 1.98.1, which cannot read a version-1 transaction; reading one needs 1.99.0-beta.0. Even then a third-party wallet signing it calls `MessageV1.serialize`, which throws by design. That is the same ecosystem constraint that blocks `SolanaExternalWalletSigner`, and it is not solvable in this PR.

I also did not determine which version the payments backend sends to this handler today. If it sends legacy, this is a forward fix; if it already sends version 0, this repairs a live break. Either way the handler should accept what it is given.

## Test plan

`npx vitest run` in `packages/client/ui/react-ui`: **40 passed, 0 failed** across 9 files, including 3 new cases.

- The new tests use checked-in base58 fixtures rather than building transactions in-test, because this package runs vitest under `jsdom` where web3.js's `SystemProgram.transfer` fails with `TypeError: b must be a Uint8Array`.
- Reverting the parser to `Transaction.from` fails both new transaction cases, so they do catch the defect rather than passing regardless.
- `biome check --diagnostic-level=error` clean across the repo; `tsc --noEmit` reports nothing for the changed files.
