### PR TITLE
Wallets SDK: never expose the recovery server secret through `wallet.recovery`/`recoveryMethods`

### DIFF
--- a/.changeset/hide-recovery-server-secret.md
+++ b/.changeset/hide-recovery-server-secret.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+`wallet.recovery` and `wallet.recoveryMethods` no longer return the caller's raw server secret after `createWallet` (or after constructing a `Wallet` with a `{ type: "server", secret }` recovery config). The secret is retained internally for signing; the public getters now expose the same address-only `{ type: "server", address }` form that `getWallet` already returned.

--- a/packages/wallets/src/signers/server/resolver.test.ts
+++ b/packages/wallets/src/signers/server/resolver.test.ts
@@ -70,6 +70,23 @@ describe("ServerSignerResolver", () => {
         const ctx = ["base-sepolia", "proj_test_123", "staging"];
         expect(mockedCandidates).toHaveBeenNthCalledWith(1, fullConfig("s"), ...ctx);
     });
+    describe("resolveRecovery", () => {
+        it("caches the legacy derivation when the API reports it as a recovery address and wipes the primary", () => {
+            const recorded = installDual();
+            const resolver = makeResolver({ apiRecoveryAddresses: ["0xLegacy"] });
+            expect(resolver.resolveRecovery(fullConfig("s"))).toBe("0xLegacy");
+            expectWipedAndKept(recorded[0], "primary", "legacy", 9);
+            expect(resolver.hasRecoveryResolutionFor("0xLegacy")).toBe(true);
+            expect(resolver.resolveDerivation(apiConfig("0xLegacy")).derivedAddress).toBe("0xLegacy");
+        });
+        it("caches the primary derivation otherwise, without consulting registered signers", () => {
+            const recorded = installDual();
+            const resolver = makeResolver();
+            expect(resolver.resolveRecovery(fullConfig("s"))).toBe("0xPrimary");
+            expectWipedAndKept(recorded[0], "legacy", "primary", 7);
+            expect(resolver.hasRecoveryResolutionFor("0xPrimary")).toBe(true);
+        });
+    });
     describe("resolveDerivation", () => {
         it("returns the cached recovery resolution for api-sourced config", () => {
             const recorded = installCandidates({ rec: { primary: { address: "0xRec", fill: 5 }, legacy: null } });

--- a/packages/wallets/src/signers/server/resolver.ts
+++ b/packages/wallets/src/signers/server/resolver.ts
@@ -114,6 +114,15 @@ export class ServerSignerResolver {
         return { kind: "unregistered", message: `Signer ${tried} is not registered in this wallet.` };
     }
 
+    /**
+     * Caches the derivation behind a recovery server secret without consulting registered signers, and
+     * reports the selected address so the caller can drop the secret-carrying config.
+     */
+    resolveRecovery(config: ServerSignerConfig): string {
+        const { primary, legacy } = this.deriveCandidates(config);
+        return this.#selectRecovery(primary, legacy).derivedAddress;
+    }
+
     #selectRegistered(
         primary: DerivedServerSigner,
         legacy: DerivedServerSigner | null,

--- a/packages/wallets/src/wallets/wallet-factory.test.ts
+++ b/packages/wallets/src/wallets/wallet-factory.test.ts
@@ -1209,7 +1209,7 @@ describe("WalletFactory - recovery signer lists", () => {
             expect(wallet.recoveryMethods.map((signer) => signer.type)).toEqual(["email", "external-wallet"]);
         });
 
-        it("keeps the caller's server signer config for the matching entry of the recovery list", async () => {
+        it("exposes the caller's server recovery signer address-only, never its secret", async () => {
             const firstAddress = derivedServerAddress(FIRST_SERVER_SECRET, "solana");
             mockApiClient.createWallet.mockResolvedValue(
                 walletResponseWithRecovery("solana", SOLANA_ADDRESS, [
@@ -1223,7 +1223,8 @@ describe("WalletFactory - recovery signer lists", () => {
                 recovery: [{ type: "api-key" }, { type: "server", secret: FIRST_SERVER_SECRET }],
             });
 
-            expect(wallet.recoveryMethods[1]).toEqual({ type: "server", secret: FIRST_SERVER_SECRET });
+            expect(wallet.recoveryMethods[1]).toEqual({ type: "server", address: firstAddress });
+            expect(JSON.stringify(wallet.recoveryMethods)).not.toContain(FIRST_SERVER_SECRET);
         });
 
         it("falls back to the deprecated adminSigner for responses without a recovery list", async () => {

--- a/packages/wallets/src/wallets/wallet.test.ts
+++ b/packages/wallets/src/wallets/wallet.test.ts
@@ -2406,6 +2406,53 @@ describe("Wallet - useSigner()", () => {
             expect("onSign" in wallet.recoveryMethods[1]).toBe(true);
         });
 
+        it("a caller-provided server recovery secret is exposed address-only yet still drives addSigner", async () => {
+            const { deriveServerSignerDetails, deriveServerSignerCandidates, assembleServerSigner } = await import(
+                "@/signers/server"
+            );
+            vi.mocked(deriveServerSignerDetails).mockReturnValue({
+                derivedKeyBytes: new Uint8Array(32),
+                derivedAddress: "0xDerivedServerAddress",
+            });
+            vi.mocked(deriveServerSignerCandidates).mockReturnValue({
+                primary: { derivedKeyBytes: new Uint8Array(32), derivedAddress: "0xDerivedServerAddress" },
+                legacy: null,
+            });
+            vi.mocked(assembleServerSigner).mockReturnValue({
+                type: "server",
+                locator: () => "server:0xDerivedServerAddress",
+                address: () => "0xDerivedServerAddress",
+                status: undefined,
+                signMessage: vi.fn().mockResolvedValue({ signature: "0xmocksig" }),
+                signTransaction: vi.fn().mockResolvedValue({ signature: "0xmocksig" }),
+            } as any);
+            mockApiClient = createMockApiClient();
+            const wallet = new Wallet(
+                {
+                    chain: "base-sepolia" as const,
+                    address: "0x1234567890123456789012345678901234567890",
+                    recovery: { type: "server", secret: "recovery-secret" },
+                },
+                mockApiClient as unknown as ApiClient
+            );
+            await wallet.waitForInit();
+            vi.spyOn(wallet, "signers").mockResolvedValue([]);
+
+            expect(wallet.recovery).toEqual({ type: "server", address: "0xDerivedServerAddress" });
+            expect(wallet.recoveryMethods).toEqual([{ type: "server", address: "0xDerivedServerAddress" }]);
+            expect(JSON.stringify(wallet.recoveryMethods)).not.toContain("recovery-secret");
+            expect(wallet.signer?.locator()).toBe("server:0xDerivedServerAddress");
+
+            mockApiClient.registerSigner.mockResolvedValue({
+                type: "email",
+                address: "0xNewEmail",
+                locator: "email:new@example.com",
+                chains: { "base-sepolia": { id: "sig-new", status: "success" } },
+            } as any);
+            const result = await wallet.addSigner({ type: "email", email: "new@example.com" } as any);
+            expect(result.locator).toBe("email:new@example.com");
+        });
+
         it("useSigner with a secondary server recovery signer never stores the secret in the list", async () => {
             const { deriveServerSignerDetails, deriveServerSignerCandidates, assembleServerSigner } = await import(
                 "@/signers/server"

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -159,6 +159,16 @@ export class Wallet<C extends Chain> {
             signers: () => this.signers(),
             signer,
         });
+        // Recovery server secrets only ever live inside the resolver: the public recovery getters expose
+        // the address-only form regardless of whether the wallet was created or fetched.
+        recoverySigners.forEach((recoverySigner, index) => {
+            if (recoverySigner.type === "server" && !isApiSourcedServerSignerConfig(recoverySigner)) {
+                this.#signerManager.stripSecretFromRecovery(
+                    index,
+                    this.#serverSignerResolver.resolveRecovery(recoverySigner as ServerSignerConfig)
+                );
+            }
+        });
         this.#deviceRecovery = new DeviceRecoveryService({
             chain,
             walletAddress: this.address,


### PR DESCRIPTION
## Description

Fixes [WAL-12154](https://linear.app/crossmint/issue/WAL-12154). After `createWallet({ recovery: { type: "server", secret } })`, `wallet.recovery` and `wallet.recoveryMethods` returned the caller's raw secret, while the same getters on a `getWallet` instance returned `{ type: "server", address }`. The property is a natural thing to log or return from a server route, and `JSON.stringify(wallet)` looks clean, so the leak is easy to miss.

The secret still has to be retained for signing, so this moves it into the place the `useSigner` path already uses: the `ServerSignerResolver`'s cached recovery derivations. The `Wallet` constructor now resolves every secret-bearing server recovery config up front and replaces it with its address-only form — the same state the wallet ends up in after `useSigner({ type: "server", secret })` today.

```ts
// ServerSignerResolver
+ resolveRecovery(config: ServerSignerConfig): string   // deriveCandidates + #selectRecovery, returns the chosen address

// Wallet constructor, after SignerManager is built
+ recoverySigners.forEach((s, i) => {
+     if (s.type === "server" && !isApiSourcedServerSignerConfig(s)) {
+         signerManager.stripSecretFromRecovery(i, serverSignerResolver.resolveRecovery(s));
+     }
+ });
```

Downstream behaviour is unchanged because everything that needs the key (`withRecoverySigner`, `canAutoAssemble`, `keyMaterialForAssembly`) already handles the api-sourced config via `hasRecoveryResolutionFor` / `#resolvedRecoveryFor`. Legacy-derivation selection is preserved: `#selectRecovery` picks the legacy candidate when the API reported it as the recovery address.

Not a type-level break: `recovery`/`recoveryMethods` already returned a union including the address-only shape (the `getWallet` path). Only code reading `.secret` off the `createWallet` result changes, and that code already broke on `getWallet` instances. Both getters are `@experimental`.

## Test plan

* `resolver.test.ts`: `resolveRecovery` caches the legacy derivation when the API reports it (wiping primary), otherwise primary; resolution is then visible to `hasRecoveryResolutionFor` / `resolveDerivation`.
* `wallet.test.ts`: a `Wallet` built with `{ type: "server", secret }` exposes address-only `recovery`/`recoveryMethods`, auto-assembles the server recovery signer, and `addSigner` still works through `withRecoverySigner`.
* `wallet-factory.test.ts`: the existing "keeps the caller's server signer config" test now asserts the address-only form and that the secret is absent from `JSON.stringify(recoveryMethods)`.
* Full `@crossmint/wallets-sdk` vitest suite passes (727 tests); `tsc --noEmit` clean.

## Package updates

* `@crossmint/wallets-sdk` — patch (`.changeset/hide-recovery-server-secret.md`)

Link to Devin session: https://crossmint.devinenterprise.com/sessions/b949f693e7524252917667e820afd677
Open in Devin Desktop: https://crossmint.devinenterprise.com/desktop/session/b949f693e7524252917667e820afd677?variant=devin
Requested by: @panosinthezone