### PR TITLE
fix(wallets): authorize addSigner/removeSigner with the selected recovery signer (WAL-12155)

### DIFF
--- a/.changeset/multi-recovery-approver.md
+++ b/.changeset/multi-recovery-approver.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+`wallet.addSigner` and `wallet.removeSigner` now work on wallets with several recovery signers: they are authorized by the recovery signer selected with `wallet.useSigner`, whose locator is sent to the API as `approver`. Selecting an operational (delegated) signer and then adding or removing a signer throws a `SignerRequiredError` before any request is made. `RegisterSignerParams` and `RemoveSignerParams` expose the new optional `approver` field.

--- a/.changeset/multi-recovery-approver.md
+++ b/.changeset/multi-recovery-approver.md
@@ -2,4 +2,4 @@
 "@crossmint/wallets-sdk": patch
 ---
 
-`wallet.addSigner` and `wallet.removeSigner` now work on wallets with several recovery signers: they are authorized by the recovery signer selected with `wallet.useSigner`, whose locator is sent to the API as `approver`. Selecting an operational (delegated) signer and then adding or removing a signer throws a `SignerRequiredError` before any request is made. `RegisterSignerParams` and `RemoveSignerParams` expose the new optional `approver` field.
+`wallet.addSigner` and `wallet.removeSigner` now work on wallets with several recovery methods: they are authorized by the recovery method selected with `wallet.useSigner`, whose locator is sent to the API as `approver`. Selecting an operational (delegated) signer and then adding or removing a signer throws a `SignerRequiredError` before any request is made. `RegisterSignerParams` and `RemoveSignerParams` expose the new optional `approver` field.

--- a/packages/wallets/src/api/client.test.ts
+++ b/packages/wallets/src/api/client.test.ts
@@ -1115,6 +1115,37 @@ describe("ApiClient - getSigner()", () => {
     });
 });
 
+describe("ApiClient - removeSigner()", () => {
+    let apiClient: ApiClient;
+    let mockDelete: MockedFunction<ApiClient["delete"]>;
+
+    beforeEach(() => {
+        apiClient = createTestApiClient();
+        mockDelete = vi.spyOn(apiClient, "delete") as MockedFunction<ApiClient["delete"]>;
+        mockDelete.mockResolvedValue(createMockSuccessResponse({ id: "txn-1" }));
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it.each([
+        ["no params", {}, ""],
+        ["a chain", { chain: "base-sepolia" as const }, "?chain=base-sepolia"],
+        ["an approver", { approver: "email:recovery@example.com" }, "?approver=email%3Arecovery%40example.com"],
+        [
+            "a chain and an approver",
+            { chain: "base-sepolia" as const, approver: "passkey:abc" },
+            "?chain=base-sepolia&approver=passkey%3Aabc",
+        ],
+    ])("encodes %s in the query string", async (_name, params, expectedQuery) => {
+        await apiClient.removeSigner(WALLET_LOCATORS.EVM_SMART_WALLET, "external-wallet:0x456", params);
+
+        const [url] = mockDelete.mock.calls[0];
+        expect(url.endsWith(`/signers/external-wallet%3A0x456${expectedQuery}`)).toBe(true);
+    });
+});
+
 describe("ApiClient - edge cases and integration scenarios", () => {
     let apiClient: ApiClient;
 

--- a/packages/wallets/src/api/client.ts
+++ b/packages/wallets/src/api/client.ts
@@ -250,6 +250,9 @@ class ApiClient extends CrossmintApiClient {
         if (params.chain) {
             queryParams.append("chain", params.chain);
         }
+        if (params.approver != null) {
+            queryParams.append("approver", params.approver);
+        }
         const url = `${this.apiPrefix}/${walletLocator}/signers/${encodedSigner}${queryParams.size > 0 ? `?${queryParams.toString()}` : ""}`;
         const response = await this.delete(url, {
             headers: this.headers,

--- a/packages/wallets/src/api/types.ts
+++ b/packages/wallets/src/api/types.ts
@@ -97,10 +97,14 @@ export type RegisterSignerParams = {
     chain?: RegisterSignerChain;
     scopes?: Scope[];
     deployImmediately?: boolean;
+    /** Recovery signer authorizing the registration. Required when the wallet has multiple recovery signers. */
+    approver?: CreateSignerV2025InputDtoClass["approver"];
 };
 export type RegisterSignerResponse = DelegatedSignerV2025DtoClass | WalletsV2025ControllerCreateDelegatedSigner2Error;
 export type RemoveSignerParams = {
     chain?: RegisterSignerChain;
+    /** Recovery signer authorizing the removal. Required when the wallet has multiple recovery signers. */
+    approver?: CreateSignerV2025InputDtoClass["approver"];
 };
 export type RemoveSignerResponse =
     | WalletsTransactionV2025ResponseDtoClass

--- a/packages/wallets/src/api/types.ts
+++ b/packages/wallets/src/api/types.ts
@@ -97,13 +97,11 @@ export type RegisterSignerParams = {
     chain?: RegisterSignerChain;
     scopes?: Scope[];
     deployImmediately?: boolean;
-    /** Recovery signer authorizing the registration. Required when the wallet has multiple recovery signers. */
     approver?: CreateSignerV2025InputDtoClass["approver"];
 };
 export type RegisterSignerResponse = DelegatedSignerV2025DtoClass | WalletsV2025ControllerCreateDelegatedSigner2Error;
 export type RemoveSignerParams = {
     chain?: RegisterSignerChain;
-    /** Recovery signer authorizing the removal. Required when the wallet has multiple recovery signers. */
     approver?: CreateSignerV2025InputDtoClass["approver"];
 };
 export type RemoveSignerResponse =

--- a/packages/wallets/src/openapi.json
+++ b/packages/wallets/src/openapi.json
@@ -1248,7 +1248,61 @@
                         "required": false,
                         "in": "query",
                         "description": "The chain to remove the signer from. Required for EVM wallets.",
-                        "schema": {}
+                        "schema": {
+                            "enum": [
+                                "abstract",
+                                "apechain",
+                                "arbitrum",
+                                "arbitrumnova",
+                                "avalanche",
+                                "base",
+                                "bsc",
+                                "flow",
+                                "mantle",
+                                "mode",
+                                "optimism",
+                                "plume",
+                                "polygon",
+                                "scroll",
+                                "sei-pacific-1",
+                                "shape",
+                                "story",
+                                "tempo",
+                                "world-chain",
+                                "zora",
+                                "ethereum",
+                                "abstract-testnet",
+                                "arbitrum-sepolia",
+                                "avalanche-fuji",
+                                "base-sepolia",
+                                "curtis",
+                                "ethereum-sepolia",
+                                "flow-testnet",
+                                "mantle-sepolia",
+                                "mode-sepolia",
+                                "optimism-sepolia",
+                                "plume-testnet",
+                                "polygon-amoy",
+                                "scroll-sepolia",
+                                "sei-atlantic-2-testnet",
+                                "story-testnet",
+                                "world-chain-sepolia",
+                                "zora-sepolia",
+                                "arc-testnet",
+                                "tempo-testnet"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "approver",
+                        "required": false,
+                        "in": "query",
+                        "description": "The recovery signer that authorizes this operation. Required when the wallet has multiple recovery signers.",
+                        "schema": {
+                            "title": "Signer Locator",
+                            "type": "string"
+                        },
+                        "example": "passkey:cWtP7gmZbd98HbKUuGXx5Q"
                     }
                 ],
                 "responses": {
@@ -2394,7 +2448,61 @@
                         "required": false,
                         "in": "query",
                         "description": "The chain to remove the signer from. Required for EVM wallets.",
-                        "schema": {}
+                        "schema": {
+                            "enum": [
+                                "abstract",
+                                "apechain",
+                                "arbitrum",
+                                "arbitrumnova",
+                                "avalanche",
+                                "base",
+                                "bsc",
+                                "flow",
+                                "mantle",
+                                "mode",
+                                "optimism",
+                                "plume",
+                                "polygon",
+                                "scroll",
+                                "sei-pacific-1",
+                                "shape",
+                                "story",
+                                "tempo",
+                                "world-chain",
+                                "zora",
+                                "ethereum",
+                                "abstract-testnet",
+                                "arbitrum-sepolia",
+                                "avalanche-fuji",
+                                "base-sepolia",
+                                "curtis",
+                                "ethereum-sepolia",
+                                "flow-testnet",
+                                "mantle-sepolia",
+                                "mode-sepolia",
+                                "optimism-sepolia",
+                                "plume-testnet",
+                                "polygon-amoy",
+                                "scroll-sepolia",
+                                "sei-atlantic-2-testnet",
+                                "story-testnet",
+                                "world-chain-sepolia",
+                                "zora-sepolia",
+                                "arc-testnet",
+                                "tempo-testnet"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "approver",
+                        "required": false,
+                        "in": "query",
+                        "description": "The recovery signer that authorizes this operation. Required when the wallet has multiple recovery signers.",
+                        "schema": {
+                            "title": "Signer Locator",
+                            "type": "string"
+                        },
+                        "example": "passkey:cWtP7gmZbd98HbKUuGXx5Q"
                     }
                 ],
                 "responses": {
@@ -28418,7 +28526,9 @@
                                                     },
                                                     "id": {
                                                         "type": "string",
-                                                        "description": "Credential ID from the WebAuthn registration response"
+                                                        "minLength": 1,
+                                                        "pattern": "^[A-Za-z0-9_-]+$",
+                                                        "description": "Credential ID from the WebAuthn registration response, as unpadded base64url"
                                                     },
                                                     "name": {
                                                         "type": "string",
@@ -28429,11 +28539,11 @@
                                                         "properties": {
                                                             "x": {
                                                                 "type": "string",
-                                                                "description": "S component of the signature as a stringified bigint"
+                                                                "description": "X coordinate of the public key as a decimal string"
                                                             },
                                                             "y": {
                                                                 "type": "string",
-                                                                "description": "S component of the signature as a stringified bigint"
+                                                                "description": "Y coordinate of the public key as a decimal string"
                                                             }
                                                         },
                                                         "required": ["x", "y"],
@@ -28562,7 +28672,7 @@
                                                         "properties": {
                                                             "x": {
                                                                 "type": "string",
-                                                                "description": "The y coordinate of the p256 public key"
+                                                                "description": "The x coordinate of the p256 public key"
                                                             },
                                                             "y": {
                                                                 "type": "string",
@@ -28594,13 +28704,61 @@
                                     {
                                         "type": "string",
                                         "title": "Signer Locator",
-                                        "description": "The locator for the signer",
-                                        "example": "external-wallet:0x1234567890123456789012345678901234567890"
+                                        "description": "A signer locator that can be either a of format '<signerAddress>' for external wallet type signers or '<signerType>:<signerIdentifier>'",
+                                        "example": "passkey:cWtP7gmZbd98HbKUuGXx5Q"
                                     }
                                 ]
                             },
                             "chain": {
+                                "enum": [
+                                    "abstract",
+                                    "apechain",
+                                    "arbitrum",
+                                    "arbitrumnova",
+                                    "avalanche",
+                                    "base",
+                                    "bsc",
+                                    "flow",
+                                    "mantle",
+                                    "mode",
+                                    "optimism",
+                                    "plume",
+                                    "polygon",
+                                    "scroll",
+                                    "sei-pacific-1",
+                                    "shape",
+                                    "story",
+                                    "tempo",
+                                    "world-chain",
+                                    "zora",
+                                    "ethereum",
+                                    "abstract-testnet",
+                                    "arbitrum-sepolia",
+                                    "avalanche-fuji",
+                                    "base-sepolia",
+                                    "curtis",
+                                    "ethereum-sepolia",
+                                    "flow-testnet",
+                                    "mantle-sepolia",
+                                    "mode-sepolia",
+                                    "optimism-sepolia",
+                                    "plume-testnet",
+                                    "polygon-amoy",
+                                    "scroll-sepolia",
+                                    "sei-atlantic-2-testnet",
+                                    "story-testnet",
+                                    "world-chain-sepolia",
+                                    "zora-sepolia",
+                                    "arc-testnet",
+                                    "tempo-testnet"
+                                ],
                                 "description": "The chain where the signer will be registered"
+                            },
+                            "approver": {
+                                "description": "The recovery signer that authorizes this operation. Required when the wallet has multiple recovery signers.",
+                                "type": "string",
+                                "title": "Signer Locator",
+                                "example": "passkey:cWtP7gmZbd98HbKUuGXx5Q"
                             },
                             "scopes": {
                                 "description": "Optional array of scopes to restrict the signer's capabilities",
@@ -28690,7 +28848,9 @@
                                                     },
                                                     "id": {
                                                         "type": "string",
-                                                        "description": "Credential ID from the WebAuthn registration response"
+                                                        "minLength": 1,
+                                                        "pattern": "^[A-Za-z0-9_-]+$",
+                                                        "description": "Credential ID from the WebAuthn registration response, as unpadded base64url"
                                                     },
                                                     "name": {
                                                         "type": "string",
@@ -28701,11 +28861,11 @@
                                                         "properties": {
                                                             "x": {
                                                                 "type": "string",
-                                                                "description": "S component of the signature as a stringified bigint"
+                                                                "description": "X coordinate of the public key as a decimal string"
                                                             },
                                                             "y": {
                                                                 "type": "string",
-                                                                "description": "S component of the signature as a stringified bigint"
+                                                                "description": "Y coordinate of the public key as a decimal string"
                                                             }
                                                         },
                                                         "required": ["x", "y"],
@@ -28834,7 +28994,7 @@
                                                         "properties": {
                                                             "x": {
                                                                 "type": "string",
-                                                                "description": "The y coordinate of the p256 public key"
+                                                                "description": "The x coordinate of the p256 public key"
                                                             },
                                                             "y": {
                                                                 "type": "string",
@@ -28866,10 +29026,16 @@
                                     {
                                         "type": "string",
                                         "title": "Signer Locator",
-                                        "description": "The locator for the signer",
-                                        "example": "external-wallet:0x1234567890123456789012345678901234567890"
+                                        "description": "A signer locator that can be either a of format '<signerAddress>' for external wallet type signers or '<signerType>:<signerIdentifier>'",
+                                        "example": "passkey:cWtP7gmZbd98HbKUuGXx5Q"
                                     }
                                 ]
+                            },
+                            "approver": {
+                                "description": "The recovery signer that authorizes this operation. Required when the wallet has multiple recovery signers.",
+                                "type": "string",
+                                "title": "Signer Locator",
+                                "example": "passkey:cWtP7gmZbd98HbKUuGXx5Q"
                             },
                             "scopes": {
                                 "description": "Optional array of scopes to restrict the signer's capabilities",
@@ -28954,7 +29120,9 @@
                                                     },
                                                     "id": {
                                                         "type": "string",
-                                                        "description": "Credential ID from the WebAuthn registration response"
+                                                        "minLength": 1,
+                                                        "pattern": "^[A-Za-z0-9_-]+$",
+                                                        "description": "Credential ID from the WebAuthn registration response, as unpadded base64url"
                                                     },
                                                     "name": {
                                                         "type": "string",
@@ -28965,11 +29133,11 @@
                                                         "properties": {
                                                             "x": {
                                                                 "type": "string",
-                                                                "description": "S component of the signature as a stringified bigint"
+                                                                "description": "X coordinate of the public key as a decimal string"
                                                             },
                                                             "y": {
                                                                 "type": "string",
-                                                                "description": "S component of the signature as a stringified bigint"
+                                                                "description": "Y coordinate of the public key as a decimal string"
                                                             }
                                                         },
                                                         "required": ["x", "y"],
@@ -29098,7 +29266,7 @@
                                                         "properties": {
                                                             "x": {
                                                                 "type": "string",
-                                                                "description": "The y coordinate of the p256 public key"
+                                                                "description": "The x coordinate of the p256 public key"
                                                             },
                                                             "y": {
                                                                 "type": "string",
@@ -29130,10 +29298,16 @@
                                     {
                                         "type": "string",
                                         "title": "Signer Locator",
-                                        "description": "The locator for the signer",
-                                        "example": "external-wallet:0x1234567890123456789012345678901234567890"
+                                        "description": "A signer locator that can be either a of format '<signerAddress>' for external wallet type signers or '<signerType>:<signerIdentifier>'",
+                                        "example": "passkey:cWtP7gmZbd98HbKUuGXx5Q"
                                     }
                                 ]
+                            },
+                            "approver": {
+                                "description": "The recovery signer that authorizes this operation. Required when the wallet has multiple recovery signers.",
+                                "type": "string",
+                                "title": "Signer Locator",
+                                "example": "passkey:cWtP7gmZbd98HbKUuGXx5Q"
                             },
                             "scopes": {
                                 "description": "Optional array of scopes to restrict the signer's capabilities",

--- a/packages/wallets/src/wallets/services/signer-manager.test.ts
+++ b/packages/wallets/src/wallets/services/signer-manager.test.ts
@@ -213,12 +213,12 @@ describe("SignerManager", () => {
         [
             "an operational active signer",
             makeSignerWithLocator("email:operational@example.com"),
-            /not one of this wallet's recovery signers/,
+            /not one of this wallet's recovery methods/,
         ],
         [
             "an active server signer whose recovery entry still carries a secret",
             makeSignerWithLocator("server:0xUnresolved"),
-            /not one of this wallet's recovery signers/,
+            /not one of this wallet's recovery methods/,
         ],
     ] as const)(
         "resolveAuthorizingRecovery() with several recovery signers and %s throws a SignerRequiredError listing them",

--- a/packages/wallets/src/wallets/services/signer-manager.test.ts
+++ b/packages/wallets/src/wallets/services/signer-manager.test.ts
@@ -9,7 +9,7 @@ import type {
     SignerLocator,
 } from "../../signers/types";
 import type { ServerSignerResolver } from "../../signers/server/resolver";
-import { InvalidRecoveryConfigError } from "../../utils/errors";
+import { InvalidRecoveryConfigError, SignerRequiredError } from "../../utils/errors";
 import type { WalletOptions } from "../types";
 import { SignerManager, type SignerManagerParams } from "./signer-manager";
 import { assembleSigner } from "../../signers";
@@ -28,7 +28,11 @@ const asRecoveryConfig = (config: unknown) => config as RecoverySignerConfigForC
 type Overrides = Partial<SignerManagerParams<Chain>>;
 
 function makeSigner(tag: string): SignerAdapter {
-    return { locator: () => `api-key:${tag}` as SignerLocator, status: undefined } as unknown as SignerAdapter;
+    return makeSignerWithLocator(`api-key:${tag}` as SignerLocator);
+}
+
+function makeSignerWithLocator(locator: SignerLocator): SignerAdapter {
+    return { locator: () => locator, status: undefined } as unknown as SignerAdapter;
 }
 
 function makeApiClient(overrides: Partial<ApiClient> = {}): ApiClient {
@@ -156,6 +160,108 @@ describe("SignerManager", () => {
             () => makeManager(overrides as unknown as Overrides).withRecoverySigner(async () => "unused"),
             branchKeyword
         );
+    });
+
+    const primaryRecovery = asRecoveryConfig({ type: "external-wallet", address: "0xPrimary" });
+    const secondaryRecovery = asRecoveryConfig({ type: "email", email: "Second@Example.com" });
+    const serverRecovery = asRecoveryConfig({ type: "server", address: "0xServerRecovery" });
+    const multiRecovery = [primaryRecovery, secondaryRecovery, serverRecovery];
+
+    it.each([
+        ["a single recovery signer and no active signer", [apiKeyConfig], undefined, apiKeyConfig, undefined],
+        [
+            "a single recovery signer and an operational active signer",
+            [apiKeyConfig],
+            makeSignerWithLocator("email:operational@example.com"),
+            apiKeyConfig,
+            undefined,
+        ],
+        [
+            "several recovery signers and the primary one active",
+            multiRecovery,
+            makeSignerWithLocator("external-wallet:0xPrimary"),
+            primaryRecovery,
+            "external-wallet:0xPrimary",
+        ],
+        [
+            "several recovery signers and a secondary one active (matched on the normalized locator)",
+            multiRecovery,
+            makeSignerWithLocator("email:second@example.com"),
+            secondaryRecovery,
+            "email:second@example.com",
+        ],
+        [
+            "several recovery signers and the api-sourced server one active",
+            multiRecovery,
+            makeSignerWithLocator("server:0xServerRecovery"),
+            serverRecovery,
+            "server:0xServerRecovery",
+        ],
+    ] as const)(
+        "resolveAuthorizingRecovery() with %s picks the authorizing recovery signer",
+        (_name, recoverySigners, signer, expectedRecovery, expectedApprover) => {
+            const manager = makeManager({ recoverySigners: [...recoverySigners], signer });
+            expect(manager.resolveAuthorizingRecovery()).toEqual({
+                recovery: expectedRecovery,
+                approver: expectedApprover,
+            });
+        }
+    );
+
+    it.each([
+        ["no active signer", undefined, /must be selected/],
+        [
+            "an operational active signer",
+            makeSignerWithLocator("email:operational@example.com"),
+            /not one of this wallet's recovery signers/,
+        ],
+        [
+            "an active server signer whose recovery entry still carries a secret",
+            makeSignerWithLocator("server:0xUnresolved"),
+            /not one of this wallet's recovery signers/,
+        ],
+    ] as const)(
+        "resolveAuthorizingRecovery() with several recovery signers and %s throws a SignerRequiredError listing them",
+        (_name, signer, branchKeyword) => {
+            const manager = makeManager({
+                recoverySigners: [...multiRecovery, asRecoveryConfig({ type: "server", secret: "topsecret" })],
+                signer,
+            });
+            expect(() => manager.resolveAuthorizingRecovery()).toThrow(SignerRequiredError);
+            expect(() => manager.resolveAuthorizingRecovery()).toThrow(branchKeyword);
+            expect(() => manager.resolveAuthorizingRecovery()).toThrow(
+                "external-wallet:0xPrimary, email:second@example.com, server:0xServerRecovery"
+            );
+            expect(() => manager.resolveAuthorizingRecovery()).not.toThrow(/topsecret/);
+        }
+    );
+
+    it("withRecoverySigner() assembles the active recovery signer and hands its locator to the operation", async () => {
+        const active = makeSignerWithLocator("external-wallet:0xPrimary");
+        const onSign = vi.fn();
+        const recoverySigners = [
+            asRecoveryConfig({ type: "api-key" }),
+            asRecoveryConfig({ type: "external-wallet", address: "0xPrimary", onSign }),
+        ];
+        const assembled = makeSignerWithLocator("external-wallet:0xPrimary");
+        mockedAssembleSigner.mockReturnValue(assembled);
+        const manager = makeManager({ signer: active, recoverySigners });
+
+        const approver = await manager.withRecoverySigner(async (approver) => approver);
+
+        expect(approver).toBe("external-wallet:0xPrimary");
+        expect(mockedAssembleSigner).toHaveBeenCalledWith(
+            "base-sepolia",
+            expect.objectContaining({ type: "external-wallet", address: "0xPrimary" }),
+            undefined
+        );
+        expect(manager.activeSigner).toBe(active);
+    });
+
+    it("withRecoverySigner() passes no approver for a wallet with a single recovery signer", async () => {
+        mockedAssembleSigner.mockReturnValue(makeSigner("recovery"));
+        const manager = makeManager({ signer: makeSigner("operational"), recoverySigners: [apiKeyConfig] });
+        await expect(manager.withRecoverySigner(async (approver) => approver)).resolves.toBeUndefined();
     });
 
     it("constructor rejects an empty recovery signer list", () => {

--- a/packages/wallets/src/wallets/services/signer-manager.test.ts
+++ b/packages/wallets/src/wallets/services/signer-manager.test.ts
@@ -27,12 +27,12 @@ const NULL_SIGNER_STATE = { response: null, signer: null, pendingOperation: null
 const asRecoveryConfig = (config: unknown) => config as RecoverySignerConfigForChain<Chain>;
 type Overrides = Partial<SignerManagerParams<Chain>>;
 
-function makeSigner(tag: string): SignerAdapter {
-    return makeSignerWithLocator(`api-key:${tag}` as SignerLocator);
+function makeSigner(type: SignerAdapter["type"], locator: SignerLocator): SignerAdapter {
+    return { type, locator: () => locator, signMessage: vi.fn(), signTransaction: vi.fn() };
 }
 
-function makeSignerWithLocator(locator: SignerLocator): SignerAdapter {
-    return { locator: () => locator, status: undefined } as unknown as SignerAdapter;
+function makeApiKeySigner(tag: string): SignerAdapter {
+    return makeSigner("api-key", `api-key:${tag}`);
 }
 
 function makeApiClient(overrides: Partial<ApiClient> = {}): ApiClient {
@@ -81,7 +81,7 @@ beforeEach(() => {
 
 describe("SignerManager", () => {
     it("require() returns the active signer when one is set", () => {
-        const signer = makeSigner("active");
+        const signer = makeApiKeySigner("active");
         expect(makeManager({ signer }).require()).toBe(signer);
     });
 
@@ -119,8 +119,8 @@ describe("SignerManager", () => {
     it.each([true, false])(
         "withRecoverySigner() swaps to the recovery signer then restores the original (operation succeeds=%s)",
         async (succeeds) => {
-            const original = makeSigner("original");
-            const recoverySigner = makeSigner("recovery");
+            const original = makeApiKeySigner("original");
+            const recoverySigner = makeApiKeySigner("recovery");
             mockedAssembleSigner.mockReturnValue(recoverySigner);
             const manager = makeManager({ signer: original, recoverySigners: [{ type: "api-key" }] });
             const failure = new Error("operation failed");
@@ -172,28 +172,28 @@ describe("SignerManager", () => {
         [
             "a single recovery signer and an operational active signer",
             [apiKeyConfig],
-            makeSignerWithLocator("email:operational@example.com"),
+            makeSigner("email", "email:operational@example.com"),
             apiKeyConfig,
             undefined,
         ],
         [
             "several recovery signers and the primary one active",
             multiRecovery,
-            makeSignerWithLocator("external-wallet:0xPrimary"),
+            makeSigner("external-wallet", "external-wallet:0xPrimary"),
             primaryRecovery,
             "external-wallet:0xPrimary",
         ],
         [
             "several recovery signers and a secondary one active (matched on the normalized locator)",
             multiRecovery,
-            makeSignerWithLocator("email:second@example.com"),
+            makeSigner("email", "email:second@example.com"),
             secondaryRecovery,
             "email:second@example.com",
         ],
         [
             "several recovery signers and the api-sourced server one active",
             multiRecovery,
-            makeSignerWithLocator("server:0xServerRecovery"),
+            makeSigner("server", "server:0xServerRecovery"),
             serverRecovery,
             "server:0xServerRecovery",
         ],
@@ -212,12 +212,12 @@ describe("SignerManager", () => {
         ["no active signer", undefined, /must be selected/],
         [
             "an operational active signer",
-            makeSignerWithLocator("email:operational@example.com"),
+            makeSigner("email", "email:operational@example.com"),
             /not one of this wallet's recovery methods/,
         ],
         [
             "an active server signer whose recovery entry still carries a secret",
-            makeSignerWithLocator("server:0xUnresolved"),
+            makeSigner("server", "server:0xUnresolved"),
             /not one of this wallet's recovery methods/,
         ],
     ] as const)(
@@ -237,13 +237,13 @@ describe("SignerManager", () => {
     );
 
     it("withRecoverySigner() assembles the active recovery signer and hands its locator to the operation", async () => {
-        const active = makeSignerWithLocator("external-wallet:0xPrimary");
+        const active = makeSigner("external-wallet", "external-wallet:0xPrimary");
         const onSign = vi.fn();
         const recoverySigners = [
             asRecoveryConfig({ type: "api-key" }),
             asRecoveryConfig({ type: "external-wallet", address: "0xPrimary", onSign }),
         ];
-        const assembled = makeSignerWithLocator("external-wallet:0xPrimary");
+        const assembled = makeSigner("external-wallet", "external-wallet:0xPrimary");
         mockedAssembleSigner.mockReturnValue(assembled);
         const manager = makeManager({ signer: active, recoverySigners });
 
@@ -259,8 +259,8 @@ describe("SignerManager", () => {
     });
 
     it("withRecoverySigner() passes no approver for a wallet with a single recovery signer", async () => {
-        mockedAssembleSigner.mockReturnValue(makeSigner("recovery"));
-        const manager = makeManager({ signer: makeSigner("operational"), recoverySigners: [apiKeyConfig] });
+        mockedAssembleSigner.mockReturnValue(makeApiKeySigner("recovery"));
+        const manager = makeManager({ signer: makeApiKeySigner("operational"), recoverySigners: [apiKeyConfig] });
         await expect(manager.withRecoverySigner(async (approver) => approver)).resolves.toBeUndefined();
     });
 
@@ -396,7 +396,7 @@ describe("SignerManager", () => {
     const internalConfig = { type: "api-key", locator: "api-key", address: WALLET_ADDRESS } as never;
 
     it("assemble() marks admin signers active without calling getSigner", async () => {
-        mockedAssembleSigner.mockReturnValue(makeSigner("admin"));
+        mockedAssembleSigner.mockReturnValue(makeApiKeySigner("admin"));
         const getSigner = vi.fn();
         const manager = makeManager({ apiClient: makeApiClient({ getSigner }) });
         const result = await manager.assemble(internalConfig, { isAdminSigner: true });
@@ -405,7 +405,7 @@ describe("SignerManager", () => {
     });
 
     it("assemble() reads status from getSigner for delegated signers", async () => {
-        mockedAssembleSigner.mockReturnValue(makeSigner("delegated"));
+        mockedAssembleSigner.mockReturnValue(makeApiKeySigner("delegated"));
         const getSigner = vi.fn().mockResolvedValue({
             type: "api-key",
             locator: "api-key:delegated",

--- a/packages/wallets/src/wallets/services/signer-manager.ts
+++ b/packages/wallets/src/wallets/services/signer-manager.ts
@@ -13,7 +13,8 @@ import {
     type SignerConfigForChain,
     type SignerLocator,
 } from "../../signers/types";
-import { InvalidRecoveryConfigError } from "../../utils/errors";
+import { InvalidRecoveryConfigError, SignerRequiredError } from "../../utils/errors";
+import { getSignerLocator } from "../../utils/signer-locator";
 import { getPendingSignerOperation, mapApiSignerToSigner } from "../../utils/signer-mapping";
 import { walletsLogger } from "../../logger";
 import type { PendingSignerOperation, Signer as WalletSigner, SignerStatus, WalletOptions } from "../types";
@@ -159,9 +160,49 @@ export class SignerManager<C extends Chain> {
         return this.#activeSigner;
     }
 
-    async withRecoverySigner<T>(operation: () => Promise<T>): Promise<T> {
+    /**
+     * The recovery signer that authorizes a signer-management operation (add/remove signer), and the
+     * `approver` locator to send to the API when the wallet has several recovery signers.
+     *
+     * A wallet with a single recovery signer always authorizes with it, whatever the active signer is.
+     * A wallet with several recovery signers needs `useSigner()` to have selected one of them: the API
+     * has to know which key will approve, and an operational signer cannot authorize these changes.
+     */
+    resolveAuthorizingRecovery(): { recovery: RecoverySignerConfigForChain<C>; approver: SignerLocator | undefined } {
+        if (this.#recoverySigners.length === 1) {
+            return { recovery: this.#recoverySigners[0], approver: undefined };
+        }
+        const recoveryLocators = this.#recoverySigners.map((recovery) => this.#recoveryLocator(recovery));
+        const activeLocator = this.#activeSigner?.locator();
+        const activeIndex = activeLocator == null ? -1 : recoveryLocators.indexOf(activeLocator);
+        if (activeIndex === -1) {
+            const known = recoveryLocators.filter((locator): locator is SignerLocator => locator != null);
+            const selection = `Call wallet.useSigner() with one of them (${known.join(", ")}) first.`;
+            throw new SignerRequiredError(
+                activeLocator == null
+                    ? `This wallet has multiple recovery signers, so the one authorizing this operation must be selected. ${selection}`
+                    : `Signer "${activeLocator}" is not one of this wallet's recovery signers, and only a recovery signer can add or remove signers. ${selection}`
+            );
+        }
+        return { recovery: this.#recoverySigners[activeIndex], approver: activeLocator };
+    }
+
+    /** Locator of a recovery signer, or null when it cannot be known without deriving a server secret. */
+    #recoveryLocator(recovery: RecoverySignerConfigForChain<C>): SignerLocator | null {
+        if (recovery.type === "server") {
+            return isApiSourcedServerSignerConfig(recovery) ? `server:${recovery.address}` : null;
+        }
+        return getSignerLocator(recovery);
+    }
+
+    /**
+     * Run `operation` with the authorizing recovery signer temporarily set as the active signer.
+     * The operation receives the `approver` locator to forward to the API (see {@link resolveAuthorizingRecovery}).
+     */
+    async withRecoverySigner<T>(operation: (approver: SignerLocator | undefined) => Promise<T>): Promise<T> {
         const originalSigner = this.#activeSigner;
-        const recovery = this.recovery;
+        const { recovery: authorizingRecovery, approver } = this.resolveAuthorizingRecovery();
+        const recovery = authorizingRecovery as SignerConfigForChain<C>;
         if (
             isApiSourcedServerSignerConfig(recovery) &&
             !this.#serverSignerResolver.hasRecoveryResolutionFor(recovery.address)
@@ -186,7 +227,7 @@ export class SignerManager<C extends Chain> {
         this.#activeSigner = assembleSigner(this.#chain, recoveryInternalConfig, this.#options?.deviceSignerKeyStorage);
 
         try {
-            return await operation();
+            return await operation(approver);
         } finally {
             this.#activeSigner = originalSigner;
         }

--- a/packages/wallets/src/wallets/services/signer-manager.ts
+++ b/packages/wallets/src/wallets/services/signer-manager.ts
@@ -161,11 +161,11 @@ export class SignerManager<C extends Chain> {
     }
 
     /**
-     * The recovery signer that authorizes a signer-management operation (add/remove signer), and the
-     * `approver` locator to send to the API when the wallet has several recovery signers.
+     * The recovery method that authorizes a signer-management operation (add/remove signer), and the
+     * `approver` locator to send to the API when the wallet has several recovery methods.
      *
-     * A wallet with a single recovery signer always authorizes with it, whatever the active signer is.
-     * A wallet with several recovery signers needs `useSigner()` to have selected one of them: the API
+     * A wallet with a single recovery method always authorizes with it, whatever the active signer is.
+     * A wallet with several recovery methods needs `useSigner()` to have selected one of them: the API
      * has to know which key will approve, and an operational signer cannot authorize these changes.
      */
     resolveAuthorizingRecovery(): { recovery: RecoverySignerConfigForChain<C>; approver: SignerLocator | undefined } {
@@ -180,14 +180,14 @@ export class SignerManager<C extends Chain> {
             const selection = `Call wallet.useSigner() with one of them (${known.join(", ")}) first.`;
             throw new SignerRequiredError(
                 activeLocator == null
-                    ? `This wallet has multiple recovery signers, so the one authorizing this operation must be selected. ${selection}`
-                    : `Signer "${activeLocator}" is not one of this wallet's recovery signers, and only a recovery signer can add or remove signers. ${selection}`
+                    ? `This wallet has multiple recovery methods, so the one authorizing this operation must be selected. ${selection}`
+                    : `Signer "${activeLocator}" is not one of this wallet's recovery methods, and only a recovery method can add or remove signers. ${selection}`
             );
         }
         return { recovery: this.#recoverySigners[activeIndex], approver: activeLocator };
     }
 
-    /** Locator of a recovery signer, or null when it cannot be known without deriving a server secret. */
+    /** Locator of a recovery method, or null when it cannot be known without deriving a server secret. */
     #recoveryLocator(recovery: RecoverySignerConfigForChain<C>): SignerLocator | null {
         if (recovery.type === "server") {
             return isApiSourcedServerSignerConfig(recovery) ? `server:${recovery.address}` : null;
@@ -196,7 +196,7 @@ export class SignerManager<C extends Chain> {
     }
 
     /**
-     * Run `operation` with the authorizing recovery signer temporarily set as the active signer.
+     * Run `operation` with the authorizing recovery method temporarily set as the active signer.
      * The operation receives the `approver` locator to forward to the API (see {@link resolveAuthorizingRecovery}).
      */
     async withRecoverySigner<T>(operation: (approver: SignerLocator | undefined) => Promise<T>): Promise<T> {

--- a/packages/wallets/src/wallets/wallet.test.ts
+++ b/packages/wallets/src/wallets/wallet.test.ts
@@ -2524,7 +2524,7 @@ describe("Wallet - useSigner()", () => {
                 const wallet = await makeWallet();
                 await wallet.useSigner(operationalSigner);
 
-                const rejection = /"external-wallet:Delegated333" is not one of this wallet's recovery signers/;
+                const rejection = /"external-wallet:Delegated333" is not one of this wallet's recovery methods/;
                 await expect(
                     wallet.addSigner({ type: "external-wallet", address: "NewSigner444" }, { prepareOnly: true })
                 ).rejects.toThrow(rejection);

--- a/packages/wallets/src/wallets/wallet.test.ts
+++ b/packages/wallets/src/wallets/wallet.test.ts
@@ -2452,6 +2452,103 @@ describe("Wallet - useSigner()", () => {
             expect(wallet.recoveryMethods[1]).toEqual({ type: "server", address: "0xDerivedServerAddress" });
         });
 
+        describe("addSigner / removeSigner on a wallet with several recovery signers", () => {
+            const secondRecovery = {
+                type: "external-wallet",
+                address: "SecondRecovery222",
+                onSign: vi.fn().mockResolvedValue("signed"),
+            } as unknown as SignerConfigForChain<"solana">;
+            const operationalSigner = {
+                type: "external-wallet",
+                address: "Delegated333",
+                onSign: vi.fn().mockResolvedValue("signed"),
+            } as unknown as SignerConfigForChain<"solana">;
+
+            async function makeWallet() {
+                mockApiClient = createMockApiClient();
+                mockApiClient.getWallet.mockResolvedValue({
+                    chainType: "solana",
+                    type: "smart",
+                    address: "5FHwkrdxntdK24hgQU8qgBjn35Y1zwhz1GZwCkP2UJnM",
+                    config: {
+                        recovery: [{ type: "api-key" }, { type: "external-wallet", address: "SecondRecovery222" }],
+                        delegatedSigners: [],
+                    },
+                    createdAt: Date.now(),
+                } as unknown as GetWalletSuccessResponse);
+                const wallet = await new WalletFactory(mockApiClient as unknown as ApiClient).getWallet({
+                    chain: "solana",
+                });
+                vi.spyOn(wallet, "signers").mockResolvedValue([
+                    {
+                        type: "external-wallet",
+                        address: "Delegated333",
+                        locator: "external-wallet:Delegated333",
+                        status: "success" as const,
+                    },
+                ]);
+                mockApiClient.registerSigner.mockResolvedValue({
+                    type: "external-wallet",
+                    address: "NewSigner444",
+                    locator: "external-wallet:NewSigner444",
+                    transaction: { id: "txn-add", status: "awaiting-approval" },
+                } as any);
+                mockApiClient.removeSigner.mockResolvedValue({
+                    id: "txn-remove",
+                    status: "awaiting-approval",
+                    approvals: { pending: [], submitted: [] },
+                } as any);
+                return wallet;
+            }
+
+            it("sends the recovery signer selected with useSigner as the approver of both operations", async () => {
+                const wallet = await makeWallet();
+                await wallet.useSigner(secondRecovery);
+
+                await wallet.addSigner({ type: "external-wallet", address: "NewSigner444" }, { prepareOnly: true });
+                await wallet.removeSigner({ type: "external-wallet", address: "Delegated333" }, { prepareOnly: true });
+
+                expect(mockApiClient.registerSigner).toHaveBeenCalledWith(
+                    expect.any(String),
+                    expect.objectContaining({ approver: "external-wallet:SecondRecovery222" })
+                );
+                expect(mockApiClient.removeSigner).toHaveBeenCalledWith(
+                    expect.any(String),
+                    "external-wallet:Delegated333",
+                    expect.objectContaining({ approver: "external-wallet:SecondRecovery222" })
+                );
+                expect(wallet.signer?.locator()).toBe("external-wallet:SecondRecovery222");
+            });
+
+            it("rejects both operations before calling the API when an operational signer is selected", async () => {
+                const wallet = await makeWallet();
+                await wallet.useSigner(operationalSigner);
+
+                const rejection = /"external-wallet:Delegated333" is not one of this wallet's recovery signers/;
+                await expect(
+                    wallet.addSigner({ type: "external-wallet", address: "NewSigner444" }, { prepareOnly: true })
+                ).rejects.toThrow(rejection);
+                await expect(
+                    wallet.removeSigner({ type: "external-wallet", address: "NewSigner444" }, { prepareOnly: true })
+                ).rejects.toThrow(rejection);
+
+                expect(mockApiClient.registerSigner).not.toHaveBeenCalled();
+                expect(mockApiClient.removeSigner).not.toHaveBeenCalled();
+                expect(wallet.signer?.locator()).toBe("external-wallet:Delegated333");
+            });
+
+            it("uses the auto-assembled primary recovery signer as approver when none was selected", async () => {
+                const wallet = await makeWallet();
+
+                await wallet.addSigner({ type: "external-wallet", address: "NewSigner444" }, { prepareOnly: true });
+
+                expect(mockApiClient.registerSigner).toHaveBeenCalledWith(
+                    expect.any(String),
+                    expect.objectContaining({ approver: "api-key" })
+                );
+            });
+        });
+
         it("useSigner rejects a signer that matches no recovery signer in the list", async () => {
             mockApiClient = createMockApiClient();
 

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -606,7 +606,9 @@ export class Wallet<C extends Chain> {
 
     /**
      * Add a signer to the wallet.
-     * Always uses the recovery signer internally to approve the registration.
+     * Always uses a recovery signer internally to approve the registration: the active signer when it is one of
+     * the recovery signers, or the wallet's single recovery signer. Wallets with several recovery signers must
+     * select one via {@link useSigner} first; an operational signer cannot authorize this.
      * If the signer being added is the current operational signer, it will be reassembled with the new locator.
      * Otherwise, the original signer is restored after the operation.
      * @param signer - The signer configuration object
@@ -632,7 +634,7 @@ export class Wallet<C extends Chain> {
                 ? (this.resolveServerSignerApiLocator(signer) as `server:${string}`)
                 : signer;
 
-        return this.#signerManager.withRecoverySigner(async () => {
+        return this.#signerManager.withRecoverySigner(async (approver) => {
             // Check for an existing signer registration (e.g. from a previous interrupted attempt)
             const signerLocator =
                 typeof resolvedSigner === "string" ? resolvedSigner : getSignerLocator(resolvedSigner);
@@ -686,6 +688,7 @@ export class Wallet<C extends Chain> {
                 chain: this.chainAdapter.addSignerChain(this.chain),
                 ...(options?.scopes != null && { scopes: options.scopes }),
                 ...(deployImmediately != null && { deployImmediately }),
+                ...(approver != null && { approver }),
             });
 
             if ("error" in response) {
@@ -768,7 +771,7 @@ export class Wallet<C extends Chain> {
 
     /**
      * Remove a signer from the wallet.
-     * Always uses the recovery signer internally to approve the removal.
+     * Always uses a recovery signer internally to approve the removal, selected as in {@link addSigner}.
      * @param signer - The signer to remove, provided as a signer config object
      * @param options - The options for the operation
      * @param options.prepareOnly - If true, returns the operation ID without auto-approving
@@ -787,9 +790,10 @@ export class Wallet<C extends Chain> {
         const signerLocator = this.resolveSignerLocator(signer);
         walletsLogger.info("wallet.removeSigner.start", { signerLocator });
 
-        return this.#signerManager.withRecoverySigner(async () => {
+        return this.#signerManager.withRecoverySigner(async (approver) => {
             const response = await this.#apiClient.removeSigner(this.walletLocator, signerLocator, {
                 chain: this.chainAdapter.addSignerChain(this.chain),
+                ...(approver != null && { approver }),
             });
 
             if ("error" in response) {

--- a/packages/wallets/src/wallets/wallet.ts
+++ b/packages/wallets/src/wallets/wallet.ts
@@ -606,8 +606,8 @@ export class Wallet<C extends Chain> {
 
     /**
      * Add a signer to the wallet.
-     * Always uses a recovery signer internally to approve the registration: the active signer when it is one of
-     * the recovery signers, or the wallet's single recovery signer. Wallets with several recovery signers must
+     * Always uses a recovery method internally to approve the registration: the active signer when it is one of
+     * the recovery methods, or the wallet's single recovery method. Wallets with several recovery methods must
      * select one via {@link useSigner} first; an operational signer cannot authorize this.
      * If the signer being added is the current operational signer, it will be reassembled with the new locator.
      * Otherwise, the original signer is restored after the operation.
@@ -771,7 +771,7 @@ export class Wallet<C extends Chain> {
 
     /**
      * Remove a signer from the wallet.
-     * Always uses a recovery signer internally to approve the removal, selected as in {@link addSigner}.
+     * Always uses a recovery method internally to approve the removal, selected as in {@link addSigner}.
      * @param signer - The signer to remove, provided as a signer config object
      * @param options - The options for the operation
      * @param options.prepareOnly - If true, returns the operation ID without auto-approving


### PR DESCRIPTION
## Description

Fixes [WAL-12155](https://linear.app/crossmint/issue/WAL-12155/p1-a-wallet-with-two-or-more-recovery-signers-can-never-call-addsigner): a wallet created with 2+ recovery signers could never `addSigner`/`removeSigner`. Creation is counterfactual and succeeds, but changing the signer set is authorized by a recovery signer, and the API needs to know *which* one when there are several (`approver`, already supported server-side). The SDK never sent it and always assembled `recoverySigners[0]`, so the API rejected the request as ambiguous.

`useSigner` now decides who authorizes signer-management operations:

```ts
// SignerManager
resolveAuthorizingRecovery(): { recovery, approver }
//   1 recovery signer  -> that one, approver: undefined        (unchanged behaviour)
//   N recovery signers -> the active signer if its locator matches one of them, approver: its locator
//                         otherwise throw SignerRequiredError   (no signer / operational signer selected)
withRecoverySigner(operation: (approver) => Promise<T>)   // assembles the resolved recovery, passes approver
```

`Wallet.addSigner`/`removeSigner` forward `approver` on the request (new optional field on `RegisterSignerParams`/`RemoveSignerParams`, query param for DELETE). The rejection happens before any API call, so selecting an operational (delegated) signer and then adding/removing a signer throws locally with the list of recovery locators to pick from.

Notes:
- `src/openapi.json` is synced with the current API schemas for the signer create/remove endpoints only (adds `approver`; also picks up the `chain` enum and fixed descriptions on those same schemas). `src/api/gen` is gitignored and regenerated by `pnpm generate`/`build`.
- Recovery locators are compared without deriving anything: an API-sourced server recovery is `server:<address>`; a still-secret-bearing one cannot be named and is simply not matched (in practice `useSigner` strips the secret on resolution).
- Wallets loaded from the API with `api-key` as primary recovery keep working with no `useSigner` call: the auto-assembled `api-key` signer matches and is sent as approver.

## Test plan

- `signer-manager.test.ts`: table of `resolveAuthorizingRecovery` cases (single recovery with/without operational signer, primary/secondary/server recovery active, normalized email locator), rejections (no signer, operational signer, unresolvable server secret — message lists recovery locators and never the secret), `withRecoverySigner` assembling the matched recovery and passing `approver`.
- `wallet.test.ts`: Solana wallet with `[api-key, external-wallet]` recovery — `useSigner(secondary)` sends it as `approver` for both add and remove; `useSigner(delegated)` rejects both before calling the API and leaves the active signer untouched; no selection → `api-key` approver.
- `client.test.ts`: `removeSigner` query-string encoding of `chain`/`approver`.
- `pnpm lint`, `pnpm --filter @crossmint/wallets-sdk... build`, full `vitest` run for `@crossmint/wallets-sdk` (741 passed).

## Package updates

- `@crossmint/wallets-sdk` patch — `.changeset/multi-recovery-approver.md`


Link to Devin session: https://crossmint.devinenterprise.com/sessions/fd7966e358654357b5a2a6c4a196495c
Open in Devin Desktop: https://crossmint.devinenterprise.com/desktop/session/fd7966e358654357b5a2a6c4a196495c?variant=devin
Requested by: @panosinthezone