### PR TITLE
fix(devkit-tests): give the smoke suite a new wallet on every run

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -56,9 +56,12 @@ jobs:
                   MAILOSAUR_SERVER_ID: ${{ secrets.SERVER_ID_MAILOSAUR }}
                   MAILOSAUR_PHONE_NUMBER: ${{ secrets.PHONE_NUMBER_MAILOSAUR }}
                   PLAYWRIGHT_BASE_URL: "http://localhost:3000"
-                  # Dedicated persistent wallet identity so smoke runs never share
-                  # emails (and OTP requests) with concurrently running e2e jobs.
-                  TESTS_WALLET_EMAIL_SUFFIX: smoke
+                  # A new wallet identity per run, kept distinct from the e2e jobs so the
+                  # two never share an email (and its OTP requests). A reused wallet
+                  # collected one device signer per run, because each CI browser starts
+                  # with no device key, until the wallet reached the backend signer cap
+                  # and every transfer failed. run_id is stable across re-run attempts.
+                  TESTS_WALLET_EMAIL_SUFFIX: smoke-${{ github.run_id }}
               run: |
                   pnpm exec playwright test --project=smoke
 

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -56,11 +56,8 @@ jobs:
                   MAILOSAUR_SERVER_ID: ${{ secrets.SERVER_ID_MAILOSAUR }}
                   MAILOSAUR_PHONE_NUMBER: ${{ secrets.PHONE_NUMBER_MAILOSAUR }}
                   PLAYWRIGHT_BASE_URL: "http://localhost:3000"
-                  # A new wallet identity per run, kept distinct from the e2e jobs so the
-                  # two never share an email (and its OTP requests). A reused wallet
-                  # collected one device signer per run, because each CI browser starts
-                  # with no device key, until the wallet reached the backend signer cap
-                  # and every transfer failed. run_id is stable across re-run attempts.
+                  # A new wallet per run; a reused one collects a device signer every run
+                  # until it reaches the backend signer cap and transfers start failing.
                   TESTS_WALLET_EMAIL_SUFFIX: smoke-${{ github.run_id }}
               run: |
                   pnpm exec playwright test --project=smoke

--- a/apps/wallets/quickstart-devkit/e2e/README.md
+++ b/apps/wallets/quickstart-devkit/e2e/README.md
@@ -12,7 +12,8 @@ Tests are configured to:
 - **Mailosaur errors**: Verify your API key and server ID are correct
 - **Timeout issues**: Check if the local dev server is running on port 3000
 - **OTP failures**: Tests run sequentially to avoid multiple OTP codes
-- **Sudden auth failures**: If you encounter repeated authentication failures, it may be due to rate limiting on auth requests. To work around this, try modifying the signer type by adding a number (e.g., change `email` to `email1`), then create a new wallet, fund it, and rerun the tests.
+- **Sudden auth failures**: If you encounter repeated authentication failures, it may be due to rate limiting on auth requests. To work around this, set `TESTS_WALLET_EMAIL_SUFFIX` to an unused value. You get a new user and a new wallet, which you must then fund.
+- **`Transaction did not start` on a wallet that worked before**: each run in a new browser adds a device signer to the wallet, and the backend rejects transactions once the wallet is at its signer limit. Set `TESTS_WALLET_EMAIL_SUFFIX` to an unused value to move to a new wallet.
 
 ## 📋 Environment Variables
 
@@ -23,6 +24,7 @@ Tests are configured to:
 | `MAILOSAUR_PHONE_NUMBER` | ✅ | Your Mailosaur phone number |
 | `TESTS_CROSSMINT_API_KEY` | ✅ | Your Crossmint API key for e2e testing |
 | `PLAYWRIGHT_BASE_URL` | ❌ | App URL (defaults to http://localhost:3000) |
+| `TESTS_WALLET_EMAIL_SUFFIX` | ❌ | Selects the wallet identity (defaults to `e2e`). A fixed value reuses one funded wallet; a unique value per run gives a new wallet. |
 
 ---
 

--- a/apps/wallets/quickstart-devkit/e2e/README.md
+++ b/apps/wallets/quickstart-devkit/e2e/README.md
@@ -12,8 +12,7 @@ Tests are configured to:
 - **Mailosaur errors**: Verify your API key and server ID are correct
 - **Timeout issues**: Check if the local dev server is running on port 3000
 - **OTP failures**: Tests run sequentially to avoid multiple OTP codes
-- **Sudden auth failures**: If you encounter repeated authentication failures, it may be due to rate limiting on auth requests. To work around this, set `TESTS_WALLET_EMAIL_SUFFIX` to an unused value. You get a new user and a new wallet, which you must then fund.
-- **`Transaction did not start` on a wallet that worked before**: each run in a new browser adds a device signer to the wallet, and the backend rejects transactions once the wallet is at its signer limit. Set `TESTS_WALLET_EMAIL_SUFFIX` to an unused value to move to a new wallet.
+- **Sudden auth failures, or `Transaction did not start` on a wallet that worked before**: auth requests may be rate limited, or the wallet may be at its signer limit, because each run in a new browser adds a device signer to it. Set `TESTS_WALLET_EMAIL_SUFFIX` to an unused value to move to a new wallet, then fund it.
 
 ## 📋 Environment Variables
 

--- a/apps/wallets/quickstart-devkit/tests/shared/constants/globalConstants.ts
+++ b/apps/wallets/quickstart-devkit/tests/shared/constants/globalConstants.ts
@@ -81,13 +81,11 @@ const SIGNER_EMAIL_BASE: Record<SignerType, string> = {
     // "external-wallet": "external",
 };
 
-// The suffix selects the wallet identity. A fixed value reuses one wallet between
-// runs, which keeps its funding (USDXM and devnet SOL) and avoids the faucets, but
-// each run also adds a device signer to that wallet. A suite that runs often must
-// therefore pass a unique TESTS_WALLET_EMAIL_SUFFIX to stay under the signer cap.
+// A fixed suffix reuses one funded wallet between runs, which the chains without a
+// working faucet need. Each run also adds a device signer to that wallet, so a suite
+// that runs often must pass a unique value to stay under the backend signer cap.
 const WALLET_EMAIL_SUFFIX = process.env.TESTS_WALLET_EMAIL_SUFFIX || "e2e";
 
-// Email address for a specific signer type. Same suffix = same Crossmint user.
 export function getEmailForSigner(signerType: SignerType): string {
     const baseAlias = SIGNER_EMAIL_BASE[signerType];
     return `test-${baseAlias}-${WALLET_EMAIL_SUFFIX}@${AUTH_CONFIG.mailosaurServerId}.mailosaur.net`;

--- a/apps/wallets/quickstart-devkit/tests/shared/constants/globalConstants.ts
+++ b/apps/wallets/quickstart-devkit/tests/shared/constants/globalConstants.ts
@@ -81,14 +81,13 @@ const SIGNER_EMAIL_BASE: Record<SignerType, string> = {
     // "external-wallet": "external",
 };
 
-// Deterministic suffix so the same email (and therefore the same wallet) is reused
-// across test runs, retries, and browsers. Reusing wallets lets funding (USDXM and
-// devnet SOL) persist between runs instead of hammering faucets on every run.
-// Override via TESTS_WALLET_EMAIL_SUFFIX to rotate to a fresh identity if needed.
+// The suffix selects the wallet identity. A fixed value reuses one wallet between
+// runs, which keeps its funding (USDXM and devnet SOL) and avoids the faucets, but
+// each run also adds a device signer to that wallet. A suite that runs often must
+// therefore pass a unique TESTS_WALLET_EMAIL_SUFFIX to stay under the signer cap.
 const WALLET_EMAIL_SUFFIX = process.env.TESTS_WALLET_EMAIL_SUFFIX || "e2e";
 
-// Deterministic email address for a specific signer type.
-// Same email every run = same Crossmint user = same (already funded) wallets.
+// Email address for a specific signer type. Same suffix = same Crossmint user.
 export function getEmailForSigner(signerType: SignerType): string {
     const baseAlias = SIGNER_EMAIL_BASE[signerType];
     return `test-${baseAlias}-${WALLET_EMAIL_SUFFIX}@${AUTH_CONFIG.mailosaurServerId}.mailosaur.net`;


### PR DESCRIPTION
Fixes the smoke suite failure diagnosed in https://github.com/Crossmint/crossmint-sdk/pull/2049#issuecomment-5532680741.

## The failure

`Wallet Smoke › transfers funds` fails on `main`, and has since 2026-08-31. Latest run on `main` ([34218402880](https://github.com/Crossmint/crossmint-sdk/actions/runs/34218402880)): tests 1-3 pass, test 4 fails after 2.4m with

```
Error: Transaction did not start - transfer button is still enabled
```

That message comes from `tests/shared/utils/wallet.ts:299` and hides the real cause. The transfer is rejected by the backend.

## Why

`TESTS_WALLET_EMAIL_SUFFIX` was the fixed string `smoke`, so `getEmailForSigner` returned the same address on every run, and wallet creation is idempotent on that identity. One wallet therefore served every smoke run ever.

Each CI run starts in a clean browser with no device key, so `preAuthIfNeeded()` calls `recover()` and enrols another device signer on that wallet. `DeviceRecoveryService#resolveStaleDeviceSignerLocator` only prunes when the wallet has exactly one device signer, or exactly one with a matching device name, so none of the old ones were removed. The wallet reached 136 device signers. Paella-Labs/crossbit-main#29415 then added a combined signer cap (16 on staging, per Paella-Labs/crossbit-main#29636) and the backend started returning `400 SIGNER_LIMIT_EXCEEDED`.

The same wallet also made `wallet.signers()` issue one `getSignerState` call per delegated signer, which tripped the project rate limit.

## The change

Pass a run-scoped value through the existing suffix, which `globalConstants.ts` already documents as the way to move to a new identity. No new helper, no change to how the tests obtain a wallet.

A new EVM wallet needs no seeding. Both transfer tests already check the balance and call `fundWalletWithCrossmintFaucet` when it is short, and gas is sponsored on base-sepolia.

`github.run_id` is stable across re-run attempts, so a re-run keeps the wallet it created.

## Scope

The e2e suites keep their fixed suffix. Their Solana wallets need native SOL, and the devnet faucet is dry (`the airdrop faucet has run dry` appears in every recent e2e log); their Stellar wallets need XLM and this repo has no helper for it. Those wallets have to stay funded between runs, so they cannot rotate until funding is solved. Their EVM arms will eventually hit the same cap.

The e2e workflow also masks its own exit code with `|| true`, which is why it reports success while failing. #2029 covers that separately.

## Test plan

- [ ] Smoke workflow passes on this branch. The push triggers it, because the diff touches `apps/wallets/quickstart-devkit/**`, and the run uses this branch's workflow file.
- [ ] Job log shows `TESTS_WALLET_EMAIL_SUFFIX` resolved to `smoke-<run id>` and all 5 tests pass, including `transfers funds`.