### PR TITLE
ci: run mobile E2E on demand with an /e2e comment

### DIFF
--- a/.github/workflows/e2e-mobile-command.yml
+++ b/.github/workflows/e2e-mobile-command.yml
@@ -1,0 +1,155 @@
+name: Mobile E2E command
+
+# Lets an engineer ask for mobile E2E feedback on a pull request by commenting
+# `/e2e`. This replaces the automatic per-push dispatch, which spent more device
+# runner time than any other trigger while gating nothing, because no repo made
+# its commit status a required check. A human now decides when a run is worth it.
+#
+# Security notes, because `issue_comment` is the easy workflow to get wrong:
+#   - This runs from the default branch, with secrets, regardless of what the
+#     pull request contains. It never checks out the pull request's code.
+#   - The comment body is untrusted input. It is read only through `env`, never
+#     interpolated into a `run:` block, so it cannot inject shell.
+#   - Only users with write access can trigger it. Anyone else is ignored
+#     silently, so this is not a probe for who has access.
+
+on:
+    issue_comment:
+        types: [created]
+
+permissions:
+    contents: read
+    issues: write
+    pull-requests: write
+
+jobs:
+    dispatch:
+        name: Dispatch mobile E2E
+        # `github.event.issue.pull_request` is null on plain issue comments.
+        if: >-
+            github.event.issue.pull_request != null &&
+            startsWith(github.event.comment.body, '/e2e') &&
+            contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        steps:
+            - name: Acknowledge the comment
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  REPO: ${{ github.repository }}
+                  COMMENT_ID: ${{ github.event.comment.id }}
+              run: |
+                  gh api --method POST --silent \
+                    "repos/$REPO/issues/comments/$COMMENT_ID/reactions" \
+                    -f content=eyes
+
+            - name: Parse the command
+              id: cmd
+              env:
+                  COMMENT: ${{ github.event.comment.body }}
+              run: |
+                  set -euo pipefail
+                  # Comments from the web UI carry CRLF; a trailing \r would make
+                  # the bare `/e2e` fail to match.
+                  line=$(printf '%s' "$COMMENT" | tr -d '\r' | head -n 1)
+                  verb=${line%% *}
+                  args=${line#"$verb"}
+
+                  if [ "$verb" != "/e2e" ]; then
+                      echo "::notice::not an /e2e command, ignoring"
+                      echo "skip=true" >>"$GITHUB_OUTPUT"
+                      exit 0
+                  fi
+
+                  platform=all
+                  ref=""
+                  # `args` is deliberately unquoted, to split on whitespace. Every
+                  # token is matched against a fixed set and never executed.
+                  for arg in $args; do
+                      case "$arg" in
+                          ios | android | all) platform="$arg" ;;
+                          ref=*) ref="${arg#ref=}" ;;
+                          *) echo "::warning::ignoring unrecognised argument" ;;
+                      esac
+                  done
+
+                  {
+                      echo "skip=false"
+                      echo "platform=$platform"
+                      echo "ref=$ref"
+                  } >>"$GITHUB_OUTPUT"
+
+            - name: Resolve the pull request head
+              id: pr
+              if: steps.cmd.outputs.skip == 'false'
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  REPO: ${{ github.repository }}
+                  PR: ${{ github.event.issue.number }}
+              run: |
+                  set -euo pipefail
+                  gh api "repos/$REPO/pulls/$PR" \
+                    --jq '"sha=\(.head.sha)\nbranch=\(.head.ref)"' >>"$GITHUB_OUTPUT"
+
+            - name: Dispatch the run
+              id: dispatch
+              if: steps.cmd.outputs.skip == 'false'
+              env:
+                  # Reused from the deleted automatic trigger. The workflow being
+                  # started lives in another repo, which needs actions:write
+                  # there — something no GITHUB_TOKEN can give.
+                  GH_TOKEN: ${{ secrets.CROSSMINT_E2E_BOT_TOKEN }}
+                  SDK: react-native
+                  PLATFORM: ${{ steps.cmd.outputs.platform }}
+                  SDK_REF: ${{ steps.cmd.outputs.ref || steps.pr.outputs.sha }}
+                  ORIGIN: ${{ github.repository }}#${{ github.event.issue.number }}
+              run: |
+                  set -euo pipefail
+                  gh workflow run on-dispatch.yml \
+                    -R Crossmint/crossmint-mobile-e2e-tests \
+                    -f sdk="$SDK" \
+                    -f platform="$PLATFORM" \
+                    -f sdk_ref="$SDK_REF" \
+                    -f origin="$ORIGIN"
+
+                  # workflow_dispatch returns no run id, so the run is found by
+                  # the `origin` string it carries in its run name. The fallback
+                  # keeps the reply useful if the run is slow to appear.
+                  url="https://github.com/Crossmint/crossmint-mobile-e2e-tests/actions/workflows/on-dispatch.yml"
+                  for _ in $(seq 1 10); do
+                      sleep 3
+                      found=$(gh run list -R Crossmint/crossmint-mobile-e2e-tests \
+                          --workflow on-dispatch.yml --limit 20 --json displayTitle,url |
+                          jq -r --arg o "$ORIGIN" \
+                            'map(select(.displayTitle | contains($o))) | first | .url // empty')
+                      if [ -n "$found" ]; then
+                          url="$found"
+                          break
+                      fi
+                  done
+                  echo "url=$url" >>"$GITHUB_OUTPUT"
+
+            - name: Report back
+              if: always() && steps.cmd.outputs.skip == 'false'
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  REPO: ${{ github.repository }}
+                  PR: ${{ github.event.issue.number }}
+                  OUTCOME: ${{ steps.dispatch.outcome }}
+                  URL: ${{ steps.dispatch.outputs.url }}
+                  SDK: react-native
+                  PLATFORM: ${{ steps.cmd.outputs.platform }}
+                  SDK_REF: ${{ steps.cmd.outputs.ref || steps.pr.outputs.branch }}
+                  LOG: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+              run: |
+                  set -euo pipefail
+                  # Built with printf rather than an inline string, so the block
+                  # indentation above cannot leak in and turn the comment into a
+                  # markdown code block.
+                  if [ "$OUTCOME" = "success" ]; then
+                      printf 'Mobile E2E started — `%s` / `%s` on `%s`.\n\n%s\n\nResults are not mirrored back here; open the run to see them.\n' \
+                        "$SDK" "$PLATFORM" "$SDK_REF" "$URL" >"$RUNNER_TEMP/body.md"
+                  else
+                      printf 'Could not start mobile E2E — see %s\n' "$LOG" >"$RUNNER_TEMP/body.md"
+                  fi
+                  gh pr comment "$PR" -R "$REPO" --body-file "$RUNNER_TEMP/body.md"

--- a/.github/workflows/e2e-mobile-command.yml
+++ b/.github/workflows/e2e-mobile-command.yml
@@ -1,17 +1,7 @@
 name: Mobile E2E command
 
-# Lets an engineer ask for mobile E2E feedback on a pull request by commenting
-# `/e2e`. This replaces the automatic per-push dispatch, which spent more device
-# runner time than any other trigger while gating nothing, because no repo made
-# its commit status a required check. A human now decides when a run is worth it.
-#
-# Security notes, because `issue_comment` is the easy workflow to get wrong:
-#   - This runs from the default branch, with secrets, regardless of what the
-#     pull request contains. It never checks out the pull request's code.
-#   - The comment body is untrusted input. It is read only through `env`, never
-#     interpolated into a `run:` block, so it cannot inject shell.
-#   - Only users with write access can trigger it. Anyone else is ignored
-#     silently, so this is not a probe for who has access.
+# Starts the mobile E2E suite when someone comments `/e2e` on a pull request.
+# Runs from the default branch with secrets, so it never checks out PR code.
 
 on:
     issue_comment:
@@ -28,12 +18,33 @@ jobs:
         # `github.event.issue.pull_request` is null on plain issue comments.
         if: >-
             github.event.issue.pull_request != null &&
-            startsWith(github.event.comment.body, '/e2e') &&
-            contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+            startsWith(github.event.comment.body, '/e2e')
         runs-on: ubuntu-latest
         timeout-minutes: 5
         steps:
+            - name: Check the commenter can write
+              id: auth
+              env:
+                  # The bot token, not GITHUB_TOKEN: this endpoint needs push
+                  # access to answer.
+                  GH_TOKEN: ${{ secrets.CROSSMINT_E2E_BOT_TOKEN }}
+                  REPO: ${{ github.repository }}
+                  ACTOR: ${{ github.event.comment.user.login }}
+              run: |
+                  set -euo pipefail
+                  # Not author_association: its COLLABORATOR value also covers
+                  # read-only outside collaborators. Unreadable means denied.
+                  perm=$(gh api "repos/$REPO/collaborators/$ACTOR/permission" \
+                      --jq '.permission' 2>/dev/null || echo unknown)
+                  case "$perm" in
+                      write | maintain | admin) allowed=true ;;
+                      *) allowed=false ;;
+                  esac
+                  echo "::notice::$ACTOR has '$perm' access, allowed=$allowed"
+                  echo "allowed=$allowed" >>"$GITHUB_OUTPUT"
+
             - name: Acknowledge the comment
+              if: steps.auth.outputs.allowed == 'true'
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   REPO: ${{ github.repository }}
@@ -45,26 +56,25 @@ jobs:
 
             - name: Parse the command
               id: cmd
+              if: steps.auth.outputs.allowed == 'true'
               env:
                   COMMENT: ${{ github.event.comment.body }}
               run: |
                   set -euo pipefail
-                  # Comments from the web UI carry CRLF; a trailing \r would make
-                  # the bare `/e2e` fail to match.
+                  # Web UI comments carry CRLF; a trailing \r stops `/e2e` matching.
                   line=$(printf '%s' "$COMMENT" | tr -d '\r' | head -n 1)
                   verb=${line%% *}
                   args=${line#"$verb"}
 
                   if [ "$verb" != "/e2e" ]; then
-                      echo "::notice::not an /e2e command, ignoring"
                       echo "skip=true" >>"$GITHUB_OUTPUT"
                       exit 0
                   fi
 
                   platform=all
                   ref=""
-                  # `args` is deliberately unquoted, to split on whitespace. Every
-                  # token is matched against a fixed set and never executed.
+                  # `args` is unquoted to split on whitespace. Every token is
+                  # matched against a fixed set and never executed.
                   for arg in $args; do
                       case "$arg" in
                           ios | android | all) platform="$arg" ;;
@@ -95,14 +105,13 @@ jobs:
               id: dispatch
               if: steps.cmd.outputs.skip == 'false'
               env:
-                  # Reused from the deleted automatic trigger. The workflow being
-                  # started lives in another repo, which needs actions:write
-                  # there — something no GITHUB_TOKEN can give.
                   GH_TOKEN: ${{ secrets.CROSSMINT_E2E_BOT_TOKEN }}
                   SDK: react-native
                   PLATFORM: ${{ steps.cmd.outputs.platform }}
                   SDK_REF: ${{ steps.cmd.outputs.ref || steps.pr.outputs.sha }}
-                  ORIGIN: ${{ github.repository }}#${{ github.event.issue.number }}
+                  # The comment id makes this unique per invocation, so two
+                  # `/e2e` comments on one PR cannot resolve to each other's run.
+                  ORIGIN: ${{ github.repository }}#${{ github.event.issue.number }} c${{ github.event.comment.id }}
               run: |
                   set -euo pipefail
                   gh workflow run on-dispatch.yml \
@@ -112,9 +121,9 @@ jobs:
                     -f sdk_ref="$SDK_REF" \
                     -f origin="$ORIGIN"
 
-                  # workflow_dispatch returns no run id, so the run is found by
-                  # the `origin` string it carries in its run name. The fallback
-                  # keeps the reply useful if the run is slow to appear.
+                  # workflow_dispatch returns no run id, so find the run by the
+                  # `origin` it carries in its name. The fallback keeps the reply
+                  # useful if the run is slow to appear.
                   url="https://github.com/Crossmint/crossmint-mobile-e2e-tests/actions/workflows/on-dispatch.yml"
                   for _ in $(seq 1 10); do
                       sleep 3
@@ -143,9 +152,8 @@ jobs:
                   LOG: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
               run: |
                   set -euo pipefail
-                  # Built with printf rather than an inline string, so the block
-                  # indentation above cannot leak in and turn the comment into a
-                  # markdown code block.
+                  # printf, not an inline string, so the block indentation above
+                  # cannot leak in and make the comment a markdown code block.
                   if [ "$OUTCOME" = "success" ]; then
                       printf 'Mobile E2E started — `%s` / `%s` on `%s`.\n\n%s\n\nResults are not mirrored back here; open the run to see them.\n' \
                         "$SDK" "$PLATFORM" "$SDK_REF" "$URL" >"$RUNNER_TEMP/body.md"


### PR DESCRIPTION
## Why

Companion to the deletion in **Crossmint/crossmint-sdk#2057**, which removes the automatic
`repository_dispatch` on every pull request. That trigger was the largest
consumer of mobile device-runner time and gated nothing — no SDK repo made the
`mobile-e2e / <sdk>` status a required check, so it could never block a merge.

Deleting it on its own would leave no branch-level E2E path for anyone without
write access on `crossmint-mobile-e2e-tests`. This restores one, opt-in.

## What you get

```
/e2e                    both platforms, against the PR head commit
/e2e ios                one leg only
/e2e ref=my-branch      a different ref
```

The workflow reacts 👀, starts the run, and replies with a link to it. Results
are **not** mirrored back as a check — that is the part that was providing no
signal, and re-adding it would recreate the gate nobody required.

`ios`/`android` only changes anything for React Native and Flutter. Swift is
iOS-only and Kotlin is Android-only, so on those repos a stray platform argument
still runs the one leg that exists rather than silently doing nothing.

## Cost

The trigger is now a person instead of a push. The old one fired on every
`synchronize` across every open pull request, which is what made it expensive;
a command cannot run unprompted, so the ceiling is however often someone
actually wants a run.

No new secret. `CROSSMINT_E2E_BOT_TOKEN` already exists in this repo — the
deletion removed its only consumer, not the secret — and it already had the
cross-repo scope this needs, because `GITHUB_TOKEN` cannot start a workflow in
another repository.

## Security

`issue_comment` workflows run from the **default branch with access to secrets**,
regardless of what the pull request contains, so they are easy to get wrong.
This one:

- never checks out the pull request's code, so no untrusted code executes
- reads the comment body only through `env`, never interpolating it into a
  `run:` block
- asks `repos/{owner}/{repo}/collaborators/{user}/permission` whether the
  commenter really can write, and accepts only `write`/`maintain`/`admin`

`author_association` looked like the cheap way to do that last check, and the
first revision used it. It is not an authorisation field: its `COLLABORATOR`
value also covers read-only outside collaborators, so it would have let them
start runs. The permission endpoint needs push access to answer, so the call
uses the bot token, and anything it cannot read resolves to `unknown` and is
denied.

`sdk_ref` was checked on the receiving side too, since this widens who can supply
it: across all six leg workflows it only ever reaches `actions/checkout`'s `ref:`
input, never a `run:` block, so a hostile value fails the checkout instead of
injecting.

## Test plan

- [x] Workflow parses as YAML
- [x] Denial path fails closed — every later step gates on the check, so a
      denied commenter gets no reaction and no dispatch
- [x] Parse block exercised against 16 inputs — bare command, each platform,
      `ref=`, extra whitespace, CRLF from the web UI, multi-line comments,
      non-matching commands, and `$(...)`, backtick and `;` injection attempts
- [ ] A real `/e2e` on a pull request here — unblocked, Crossmint/crossmint-mobile-e2e-tests#39 is merged

> **Ordering.** The `platform` and `origin` inputs this depends on shipped in
> Crossmint/crossmint-mobile-e2e-tests#39, now merged, so this is no longer
> blocked. (`workflow_dispatch` rejects unknown inputs, which is why the order
> mattered.)
