### PR TITLE
fix(wallets): use recoveryMethods in API payloads

### DIFF
--- a/.changeset/recovery-methods-wire.md
+++ b/.changeset/recovery-methods-wire.md
@@ -1,0 +1,5 @@
+---
+"@crossmint/wallets-sdk": patch
+---
+
+Use `recoveryMethods` for wallet recovery-method request and response payloads.

--- a/packages/wallets/src/openapi.json
+++ b/packages/wallets/src/openapi.json
@@ -29933,7 +29933,7 @@
                                 "type": "object",
                                 "properties": {
                                     "adminSigner": {
-                                        "description": "@deprecated Use `recovery` instead. The admin signer for the wallet. Mutually exclusive with `recovery`.",
+                                        "description": "@deprecated Use `recoveryMethods` instead. The admin signer for the wallet. Mutually exclusive with `recoveryMethods`.",
                                         "oneOf": [
                                             {
                                                 "type": "object",
@@ -30231,7 +30231,7 @@
                                             }
                                         ]
                                     },
-                                    "recovery": {
+                                    "recoveryMethods": {
                                         "description": "The recovery configuration (admin signer) for the wallet. Mutually exclusive with `adminSigner`.",
                                         "oneOf": [
                                             {
@@ -30861,7 +30861,7 @@
                                 "type": "object",
                                 "properties": {
                                     "adminSigner": {
-                                        "description": "@deprecated Use `recovery` instead. The admin signer for the wallet. Mutually exclusive with `recovery`.",
+                                        "description": "@deprecated Use `recoveryMethods` instead. The admin signer for the wallet. Mutually exclusive with `recoveryMethods`.",
                                         "oneOf": [
                                             {
                                                 "type": "object",
@@ -31114,7 +31114,7 @@
                                             }
                                         ]
                                     },
-                                    "recovery": {
+                                    "recoveryMethods": {
                                         "type": "array",
                                         "items": {
                                             "oneOf": [
@@ -31740,7 +31740,7 @@
                                 "type": "object",
                                 "properties": {
                                     "adminSigner": {
-                                        "description": "@deprecated Use `recovery` instead. The admin signer for the wallet. Mutually exclusive with `recovery`.",
+                                        "description": "@deprecated Use `recoveryMethods` instead. The admin signer for the wallet. Mutually exclusive with `recoveryMethods`.",
                                         "oneOf": [
                                             {
                                                 "type": "object",
@@ -31993,7 +31993,7 @@
                                             }
                                         ]
                                     },
-                                    "recovery": {
+                                    "recoveryMethods": {
                                         "type": "array",
                                         "items": {
                                             "oneOf": [
@@ -79604,9 +79604,9 @@
                                                 "description": "Quorum (m-of-n multisig) admin signer"
                                             }
                                         ],
-                                        "description": "@deprecated Use `recovery` instead. The wallet's first admin signer."
+                                        "description": "@deprecated Use `recoveryMethods` instead. The wallet's first admin signer."
                                     },
-                                    "recovery": {
+                                    "recoveryMethods": {
                                         "type": "array",
                                         "items": {
                                             "oneOf": [
@@ -81962,7 +81962,7 @@
                                         }
                                     }
                                 },
-                                "required": ["adminSigner", "recovery"]
+                                "required": ["adminSigner", "recoveryMethods"]
                             },
                             "address": {
                                 "type": "string",
@@ -82389,9 +82389,9 @@
                                                 "description": "Quorum (m-of-n multisig) admin signer"
                                             }
                                         ],
-                                        "description": "@deprecated Use `recovery` instead. The wallet's first admin signer."
+                                        "description": "@deprecated Use `recoveryMethods` instead. The wallet's first admin signer."
                                     },
-                                    "recovery": {
+                                    "recoveryMethods": {
                                         "type": "array",
                                         "items": {
                                             "oneOf": [
@@ -84773,7 +84773,7 @@
                                         "example": "CA3SGE76PWYAM4OVKETY47GASUGYDF3Y3QFFSPIWFCNKQLUOO4SOIT2W"
                                     }
                                 },
-                                "required": ["adminSigner", "recovery"]
+                                "required": ["adminSigner", "recoveryMethods"]
                             },
                             "address": {
                                 "type": "string",

--- a/packages/wallets/src/wallets/wallet-factory.test.ts
+++ b/packages/wallets/src/wallets/wallet-factory.test.ts
@@ -1018,7 +1018,7 @@ describe("WalletFactory - recovery signer lists", () => {
             type: "smart" as const,
             address,
             owner: "test-owner",
-            config: { adminSigner: recovery[0], recovery },
+            config: { adminSigner: recovery[0], recoveryMethods: recovery },
             createdAt: Date.now(),
         }) as unknown as GetWalletSuccessResponse;
 
@@ -1042,7 +1042,7 @@ describe("WalletFactory - recovery signer lists", () => {
     });
 
     describe("createWallet request", () => {
-        it("sends a Solana recovery list under config.recovery and never alongside adminSigner", async () => {
+        it("sends a Solana recovery list under config.recoveryMethods and never alongside adminSigner", async () => {
             const recovery = [
                 { type: "email" as const, email: "recovery@example.com" },
                 { type: "external-wallet" as const, address: EXTERNAL_WALLET_ADDRESS },
@@ -1054,11 +1054,11 @@ describe("WalletFactory - recovery signer lists", () => {
             await walletFactory.createWallet({ chain: "solana", recovery });
 
             const createWalletParams = mockApiClient.createWallet.mock.calls[0][0];
-            expect(createWalletParams.config).toEqual(expect.objectContaining({ recovery }));
+            expect(createWalletParams.config).toEqual(expect.objectContaining({ recoveryMethods: recovery }));
             expect(createWalletParams.config).not.toHaveProperty("adminSigner");
         });
 
-        it("sends a Stellar recovery list under config.recovery", async () => {
+        it("sends a Stellar recovery list under config.recoveryMethods", async () => {
             const recovery = [
                 { type: "api-key" as const },
                 { type: "phone" as const, phone: "+15550000001", channel: "sms" as const },
@@ -1070,7 +1070,7 @@ describe("WalletFactory - recovery signer lists", () => {
             await walletFactory.createWallet({ chain: "stellar", recovery });
 
             expect(mockApiClient.createWallet).toHaveBeenCalledWith(
-                expect.objectContaining({ config: expect.objectContaining({ recovery }) })
+                expect.objectContaining({ config: expect.objectContaining({ recoveryMethods: recovery }) })
             );
         });
 
@@ -1084,7 +1084,7 @@ describe("WalletFactory - recovery signer lists", () => {
 
             const createWalletParams = mockApiClient.createWallet.mock.calls[0][0];
             expect(createWalletParams.config).toEqual(expect.objectContaining({ adminSigner: recovery }));
-            expect(createWalletParams.config).not.toHaveProperty("recovery");
+            expect(createWalletParams.config).not.toHaveProperty("recoveryMethods");
         });
 
         it("derives an address for every server signer in the list", async () => {

--- a/packages/wallets/src/wallets/wallet-factory.test.ts
+++ b/packages/wallets/src/wallets/wallet-factory.test.ts
@@ -1108,7 +1108,7 @@ describe("WalletFactory - recovery signer lists", () => {
             expect(mockApiClient.createWallet).toHaveBeenCalledWith(
                 expect.objectContaining({
                     config: expect.objectContaining({
-                        recovery: [
+                        recoveryMethods: [
                             { type: "server", address: firstAddress },
                             { type: "server", address: secondAddress },
                         ],
@@ -1141,7 +1141,7 @@ describe("WalletFactory - recovery signer lists", () => {
             expect(mockApiClient.createWallet).toHaveBeenCalledWith(
                 expect.objectContaining({
                     config: expect.objectContaining({
-                        recovery: [
+                        recoveryMethods: [
                             expect.objectContaining({ type: "passkey", id: "credential-for-first", name: "first" }),
                             expect.objectContaining({ type: "passkey", id: "credential-for-second", name: "second" }),
                         ],

--- a/packages/wallets/src/wallets/wallet-factory.ts
+++ b/packages/wallets/src/wallets/wallet-factory.ts
@@ -40,9 +40,9 @@ const SIGNER_MISMATCH_ERROR =
     "When 'signers' is provided to a method that may fetch an existing wallet, each specified signer must exist in that wallet's configuration.";
 
 type SmartWalletConfig = {
-    /** @deprecated The API still returns the first admin signer here; `recovery` holds all of them. */
+    /** @deprecated The API still returns the first admin signer here; `recoveryMethods` holds all of them. */
     adminSigner: RecoverySignerConfig | PasskeySignerConfig;
-    recovery?: Array<RecoverySignerConfig | PasskeySignerConfig>;
+    recoveryMethods?: Array<RecoverySignerConfig | PasskeySignerConfig>;
     delegatedSigners?: SignerResponse[];
 };
 
@@ -51,10 +51,10 @@ type ResolvedRecoverySigner = RecoverySignerConfig | RegisterSignerPasskeyParams
 
 /**
  * The recovery half of a wallet-creation request. The API rejects requests carrying both fields
- * (`RECOVERY_ADMIN_SIGNER_CONFLICT`), so a list goes under `recovery` while a single signer keeps
+ * (`RECOVERY_ADMIN_SIGNER_CONFLICT`), so a list goes under `recoveryMethods` while a single signer keeps
  * using the deprecated `adminSigner` field.
  */
-type RecoveryRequestConfig = { adminSigner: ResolvedRecoverySigner } | { recovery: ResolvedRecoverySigner[] };
+type RecoveryRequestConfig = { adminSigner: ResolvedRecoverySigner } | { recoveryMethods: ResolvedRecoverySigner[] };
 
 export class WalletFactory {
     constructor(private readonly apiClient: ApiClient) {}
@@ -167,7 +167,7 @@ export class WalletFactory {
             resolvedRecoverySigners.push(await this.resolveRecoverySigner(recoverySigner, validatedArgs.chain));
         }
         const recoveryRequestConfig: RecoveryRequestConfig = Array.isArray(validatedArgs.recovery)
-            ? { recovery: resolvedRecoverySigners }
+            ? { recoveryMethods: resolvedRecoverySigners }
             : { adminSigner: resolvedRecoverySigners[0] };
 
         const walletResponse = await this.createSmartWallet(
@@ -306,9 +306,9 @@ export class WalletFactory {
         // signer details (e.g. passkey credential ID).
         const createArgs = args as WalletCreateArgs<C>;
         const walletConfig = walletResponse.config as SmartWalletConfig;
-        // `recovery` holds every admin signer; older responses (and wallets created with a single
+        // `recoveryMethods` holds every admin signer; older responses (and wallets created with a single
         // signer) only carry the deprecated singular `adminSigner`.
-        const apiRecoverySigners = (walletConfig.recovery ?? [walletConfig.adminSigner]) as Array<
+        const apiRecoverySigners = (walletConfig.recoveryMethods ?? [walletConfig.adminSigner]) as Array<
             RecoverySignerConfigForChain<C>
         >;
         const recoverySigners = this.mergeRecoverySigners(
@@ -516,7 +516,8 @@ export class WalletFactory {
         const createArgs = args as WalletCreateArgs<C>;
         if (createArgs.recovery != null || createArgs.signers != null) {
             const config = existingWallet.config as SmartWalletConfig;
-            const existingWalletSigners = config?.recovery ?? (config?.adminSigner != null ? [config.adminSigner] : []);
+            const existingWalletSigners =
+                config?.recoveryMethods ?? (config?.adminSigner != null ? [config.adminSigner] : []);
 
             const unmatchedExistingSigners = [...existingWalletSigners] as Array<RecoverySignerConfigForChain<C>>;
             for (const inputRecoverySigner of toRecoverySignerList<C>(createArgs.recovery)) {

--- a/packages/wallets/src/wallets/wallet.test.ts
+++ b/packages/wallets/src/wallets/wallet.test.ts
@@ -2349,7 +2349,7 @@ describe("Wallet - useSigner()", () => {
                 type: "smart",
                 address: "5FHwkrdxntdK24hgQU8qgBjn35Y1zwhz1GZwCkP2UJnM",
                 config: {
-                    recovery: [{ type: "external-wallet", address: "RecoveryWallet111" }, { type: "api-key" }],
+                    recoveryMethods: [{ type: "external-wallet", address: "RecoveryWallet111" }, { type: "api-key" }],
                     delegatedSigners: [],
                 },
                 createdAt: Date.now(),
@@ -2382,7 +2382,7 @@ describe("Wallet - useSigner()", () => {
                 type: "smart",
                 address: "5FHwkrdxntdK24hgQU8qgBjn35Y1zwhz1GZwCkP2UJnM",
                 config: {
-                    recovery: [{ type: "api-key" }, { type: "external-wallet", address: "SecondRecovery222" }],
+                    recoveryMethods: [{ type: "api-key" }, { type: "external-wallet", address: "SecondRecovery222" }],
                     delegatedSigners: [],
                 },
                 createdAt: Date.now(),
@@ -2433,7 +2433,7 @@ describe("Wallet - useSigner()", () => {
                 type: "smart",
                 address: "5FHwkrdxntdK24hgQU8qgBjn35Y1zwhz1GZwCkP2UJnM",
                 config: {
-                    recovery: [{ type: "api-key" }, { type: "server", address: "0xDerivedServerAddress" }],
+                    recoveryMethods: [{ type: "api-key" }, { type: "server", address: "0xDerivedServerAddress" }],
                     delegatedSigners: [],
                 },
                 createdAt: Date.now(),
@@ -2471,7 +2471,10 @@ describe("Wallet - useSigner()", () => {
                     type: "smart",
                     address: "5FHwkrdxntdK24hgQU8qgBjn35Y1zwhz1GZwCkP2UJnM",
                     config: {
-                        recovery: [{ type: "api-key" }, { type: "external-wallet", address: "SecondRecovery222" }],
+                        recoveryMethods: [
+                            { type: "api-key" },
+                            { type: "external-wallet", address: "SecondRecovery222" },
+                        ],
                         delegatedSigners: [],
                     },
                     createdAt: Date.now(),
@@ -2557,7 +2560,7 @@ describe("Wallet - useSigner()", () => {
                 type: "smart",
                 address: "5FHwkrdxntdK24hgQU8qgBjn35Y1zwhz1GZwCkP2UJnM",
                 config: {
-                    recovery: [{ type: "api-key" }, { type: "external-wallet", address: "SecondRecovery222" }],
+                    recoveryMethods: [{ type: "api-key" }, { type: "external-wallet", address: "SecondRecovery222" }],
                     delegatedSigners: [],
                 },
                 createdAt: Date.now(),
@@ -2598,7 +2601,7 @@ describe("Wallet - useSigner()", () => {
                 type: "smart",
                 address: "5FHwkrdxntdK24hgQU8qgBjn35Y1zwhz1GZwCkP2UJnM",
                 config: {
-                    recovery: [
+                    recoveryMethods: [
                         { type: "external-wallet", address: "PrimaryRecovery111" },
                         { type: "server", address: "SecondaryLegacyDerivation" },
                     ],


### PR DESCRIPTION
## Description

Update the wallets SDK transport boundary for the 2025 wallet API rename. Multi-method wallet creation now sends `config.recoveryMethods`, and wallet response/existing-wallet parsing reads `config.recoveryMethods`; the SDK-facing `recovery` input remains unchanged.

**Details**

* `WalletFactory` maps request lists and response lists to the renamed wire field while retaining the deprecated single `adminSigner` path.
* WalletFactory tests cover Solana/Stellar request payloads, server/passkey resolution, and multi-method response parsing.
* The checked-in OpenAPI source and generated build output now use `recoveryMethods`.

## Test plan

* `pnpm --filter @crossmint/wallets-sdk test:vitest` — 745 passed, 68 skipped.
* `pnpm --filter @crossmint/wallets-sdk build` — passed.
* Scoped Biome checks and `git diff --check` — passed.

## Package updates

* Added a patch changeset for `@crossmint/wallets-sdk`.

Link to Devin session: https://crossmint.devinenterprise.com/sessions/01b95a25702040ee86e2f3a5d1c14c13
Open in Devin Desktop: https://crossmint.devinenterprise.com/desktop/session/01b95a25702040ee86e2f3a5d1c14c13?variant=devin
Requested by: @daniil-dovgal